### PR TITLE
Add GitHub Pages deployment for docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,53 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build website
+        run: yarn build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -7,8 +7,8 @@ const config: Config = {
   tagline: 'Manage worktrees. Chat with Claude. Ship from isolated branches.',
   favicon: 'img/favicon.ico',
 
-  url: 'https://getbraid.dev',
-  baseUrl: '/',
+  url: 'https://gedeagas.github.io',
+  baseUrl: '/braid/',
 
   organizationName: 'gedeagas',
   projectName: 'Braid',


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to auto-deploy Docusaurus docs to GitHub Pages
- Triggers on push to `main` (when `website/` changes) and manual `workflow_dispatch`
- Update `docusaurus.config.ts` to use `https://gedeagas.github.io/braid/` as base URL

## After merge
1. Go to repo **Settings > Pages**
2. Set Source to **GitHub Actions**
3. Docs will be live at https://gedeagas.github.io/braid/