### PR TITLE
ci: enable corepack before installing dependencies in docs deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           node-version: 20
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION
## Summary

- Fix docs deployment workflow by enabling Corepack before `yarn install`, which is required for Yarn 4 (Berry) to be available in CI

## Layers touched

- [x] **CI** (`.github/workflows/`)

## Changes

**CI** (`deploy-docs.yml`):
- Added `corepack enable` step before the `yarn install --immutable` step in the GitHub Pages deployment workflow. Without this, the CI runner uses the system Yarn (v1) instead of the project's Yarn 4, causing `yarn install --immutable` to fail.

## How to test

1. Merge this PR and observe the `deploy-docs` workflow succeeds on the next push to `main`
2. Alternatively, check the workflow run triggered by this branch

## Checklist

- [x] Self-reviewed the diff
- [x] No console errors or warnings in DevTools