### PR TITLE
feat(website): update site URL to getbraid.dev with root baseUrl

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -7,8 +7,8 @@ const config: Config = {
   tagline: 'Manage worktrees. Run AI agents. Ship from isolated branches.',
   favicon: 'img/favicon.ico',
 
-  url: 'https://gedeagas.github.io',
-  baseUrl: '/braid/',
+  url: 'https://getbraid.dev',
+  baseUrl: '/',
 
   organizationName: 'gedeagas',
   projectName: 'Braid',


### PR DESCRIPTION
## Summary

- Update Docusaurus site URL from `gedeagas.github.io/braid/` to `getbraid.dev` with root `/` baseUrl

## Layers touched

- [x] **Renderer** (`src/renderer/`) — components, stores, lib

> Note: This change is in `website/` (Docusaurus config), not the Electron app itself.

## Changes

**Website** (`website/docusaurus.config.ts`):
- Changed `url` from `https://gedeagas.github.io` to `https://getbraid.dev`
- Changed `baseUrl` from `/braid/` to `/`

## How to test

1. `cd website && yarn start`
2. Verify the site loads at `localhost:3000/` (root path, not `/braid/`)

## Checklist

- [x] Self-reviewed the diff
- [x] No console errors or warnings in DevTools