### PR TITLE
feat(update): render release notes as markdown with styled formatting

### DIFF
--- a/scripts/package.js
+++ b/scripts/package.js
@@ -459,6 +459,21 @@ async function packageArch(arch) {
 
   const appPath = path.join(outputDir, `${APP_NAME}.app`)
 
+  // Inject app-update.yml so electron-updater doesn't throw ENOENT.
+  // setFeedURL() in autoUpdate.ts overrides the provider config for checking,
+  // but getOrCreateDownloadHelper() still reads this file at download time to
+  // get updaterCacheDirName for the disk cache directory.
+  const appUpdateYml = [
+    'provider: github',
+    'owner: gedeagas',
+    'repo: braid',
+    `updaterCacheDirName: ${APP_PKG.name}-updater`,
+    '',
+  ].join('\n')
+  const resourcesDir = path.join(appPath, 'Contents/Resources')
+  fs.writeFileSync(path.join(resourcesDir, 'app-update.yml'), appUpdateYml)
+  log('Injected app-update.yml into Resources/')
+
   // Fix native binary permissions (ASAR unpack strips +x from Mach-O helpers)
   fixNativePermissions(appPath)
 

--- a/src/renderer/components/shared/UpdateDialog.tsx
+++ b/src/renderer/components/shared/UpdateDialog.tsx
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import { useTranslation } from 'react-i18next'
+import ReactMarkdown from 'react-markdown'
 import { Dialog, Button } from '@/components/ui'
 import type { UpdateState } from '@/hooks/useAutoUpdate'
 
@@ -50,7 +51,9 @@ export function UpdateDialog({ state, onDownload, onInstall, onDismiss, onRetry 
         {state.releaseNotes && (
           <>
             <p className="update-dialog__notes-label">{t('update.available.whatsNew')}</p>
-            <div className="update-dialog__notes">{state.releaseNotes}</div>
+            <div className="update-dialog__notes">
+              <ReactMarkdown>{state.releaseNotes}</ReactMarkdown>
+            </div>
           </>
         )}
       </Dialog>

--- a/src/renderer/styles/update-dialog.css
+++ b/src/renderer/styles/update-dialog.css
@@ -20,14 +20,44 @@
   font-size: var(--text-base);
   color: var(--text-secondary);
   line-height: 1.6;
-  max-height: 160px;
+  max-height: 200px;
   overflow-y: auto;
   padding: var(--space-10);
   background: var(--bg-tertiary);
   border-radius: var(--radius);
   border: 1px solid var(--border);
-  white-space: pre-wrap;
   word-break: break-word;
+}
+
+.update-dialog__notes p {
+  margin: 0 0 var(--space-6);
+}
+
+.update-dialog__notes p:last-child {
+  margin-bottom: 0;
+}
+
+.update-dialog__notes ul {
+  margin: 0 0 var(--space-6);
+  padding-left: var(--space-16);
+}
+
+.update-dialog__notes li {
+  margin-bottom: var(--space-2);
+}
+
+.update-dialog__notes a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.update-dialog__notes a:hover {
+  text-decoration: underline;
+}
+
+.update-dialog__notes strong {
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
 }
 
 /* ── Progress bar ────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Render release notes in the update dialog as styled markdown using `ReactMarkdown` instead of raw text
- Inject `app-update.yml` into the packaged `.app` bundle so `electron-updater` doesn't throw ENOENT at download time
- Remove unused `DownloadDialog` component and its CSS from the website, replacing the hero button with a direct link to the install docs

## Layers touched

- [x] **Renderer** (`src/renderer/`) - components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Sidebar / Center / Right panel:**
- `UpdateDialog.tsx` - swapped raw text rendering of `state.releaseNotes` for `<ReactMarkdown>` component
- `update-dialog.css` - added styles for markdown elements (paragraphs, lists, links, bold) inside the notes area, bumped max-height from 160px to 200px, removed `white-space: pre-wrap`

**Build / Packaging:**
- `scripts/package.js` - inject `app-update.yml` into `Contents/Resources/` during packaging so `electron-updater`'s `getOrCreateDownloadHelper()` can resolve the updater cache directory
- `package.json` - version bump to 26.0.2

**Website:**
- Removed `DownloadDialog.tsx` and all associated CSS (~580 lines)
- Changed hero "Download for macOS" button from a dialog trigger to a `<Link>` to `/docs/getting-started/installation`

## How to test

1. `yarn dev`
2. Trigger the update dialog (Settings > Check for Updates, or mock an update event)
3. Verify release notes render with proper markdown formatting - headings, lists, links, bold text
4. Confirm no visual regressions in the update dialog's progress and error states

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [ ] Types pass - `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main -> preload -> renderer)
- [ ] New state is added to the correct Zustand store