### PR TITLE
feat: add client-side image compression for LLM context conservation

### DIFF
--- a/src/renderer/components/Center/ChatInput.tsx
+++ b/src/renderer/components/Center/ChatInput.tsx
@@ -41,16 +41,6 @@ const CONTEXT_WARN_THRESHOLD = 0.75
 const CONTEXT_CRITICAL_THRESHOLD = 0.90
 export const MAX_IMAGES = 5
 
-/** Read a File as a base64 data URI */
-export function fileToDataUri(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => resolve(reader.result as string)
-    reader.onerror = reject
-    reader.readAsDataURL(file)
-  })
-}
-
 // ─── Props ─────────────────────────────────────────────────────────────────────
 
 export type ChatInputVariant = 'default' | 'diff'

--- a/src/renderer/components/Center/ChatInput.tsx
+++ b/src/renderer/components/Center/ChatInput.tsx
@@ -30,8 +30,8 @@ import { QueuedMessageBanner } from './QueuedMessageBanner'
 import { CONTEXT_WINDOW } from '@/lib/constants'
 
 // ─── Constants ─────────────────────────────────────────────────────────────────
-const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
-const MAX_IMAGE_SIZE = 2 * 1024 * 1024
+export const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
+export const MAX_IMAGE_SIZE = 2 * 1024 * 1024
 const MAX_SNIPPET_SIZE = 100_000
 const MAX_SNIPPETS = 5
 const SNIPPET_LINE_THRESHOLD = 10

--- a/src/renderer/components/Center/ChatView.tsx
+++ b/src/renderer/components/Center/ChatView.tsx
@@ -16,7 +16,7 @@ import { useShallow } from 'zustand/shallow'
 import { useSessionsStore, useActiveSession } from '@/store/sessions'
 import { useUIStore, selectSelectedDiffFile, selectActiveCenterView } from '@/store/ui'
 import { ChatMessageList } from './ChatMessageList'
-import { ChatInput, MAX_IMAGES } from './ChatInput'
+import { ChatInput, MAX_IMAGES, ACCEPTED_IMAGE_TYPES, MAX_IMAGE_SIZE } from './ChatInput'
 import { compressImage } from '@/lib/imageCompression'
 import { ChatHeader } from './ChatHeader'
 import { buildDiffCommentBlocks } from './diffCommentUtils'
@@ -195,10 +195,10 @@ export function ChatView({ worktreePath = '' }: ChatViewProps) {
   // ─── Image management ──────────────────────────────────────────────────────
 
   const addImages = useCallback(async (files: File[]) => {
-    const imageFiles = files.filter((f) => ['image/png', 'image/jpeg', 'image/gif', 'image/webp'].includes(f.type))
+    const imageFiles = files.filter((f) => ACCEPTED_IMAGE_TYPES.includes(f.type))
     if (imageFiles.length === 0) return
     const valid = imageFiles.filter((f) => {
-      if (f.size > 2 * 1024 * 1024) { flash('warning', t('imageTooLarge')); return false }
+      if (f.size > MAX_IMAGE_SIZE) { flash('warning', t('imageTooLarge')); return false }
       return true
     })
     if (valid.length === 0) return
@@ -207,6 +207,8 @@ export function ChatView({ worktreePath = '' }: ChatViewProps) {
     const toAdd = valid.slice(0, remaining)
     if (toAdd.length < valid.length) flash('warning', t('imageLimitReached'))
     const results = await Promise.allSettled(toAdd.map(compressImage))
+    const failed = results.filter((r) => r.status === 'rejected').length
+    if (failed > 0) flash('warning', t('imageLoadFailed', { count: failed }))
     const uris = results
       .filter((r): r is PromiseFulfilledResult<string> => r.status === 'fulfilled')
       .map((r) => r.value)

--- a/src/renderer/components/Center/ChatView.tsx
+++ b/src/renderer/components/Center/ChatView.tsx
@@ -16,7 +16,8 @@ import { useShallow } from 'zustand/shallow'
 import { useSessionsStore, useActiveSession } from '@/store/sessions'
 import { useUIStore, selectSelectedDiffFile, selectActiveCenterView } from '@/store/ui'
 import { ChatMessageList } from './ChatMessageList'
-import { ChatInput, MAX_IMAGES, fileToDataUri } from './ChatInput'
+import { ChatInput, MAX_IMAGES } from './ChatInput'
+import { compressImage } from '@/lib/imageCompression'
 import { ChatHeader } from './ChatHeader'
 import { buildDiffCommentBlocks } from './diffCommentUtils'
 import type { Message, SlashCommand, SnippetAttachment, DiffComment } from '@/types'
@@ -205,7 +206,11 @@ export function ChatView({ worktreePath = '' }: ChatViewProps) {
     if (remaining <= 0) { flash('warning', t('imageLimitReached')); return }
     const toAdd = valid.slice(0, remaining)
     if (toAdd.length < valid.length) flash('warning', t('imageLimitReached'))
-    const uris = await Promise.all(toAdd.map(fileToDataUri))
+    const results = await Promise.allSettled(toAdd.map(compressImage))
+    const uris = results
+      .filter((r): r is PromiseFulfilledResult<string> => r.status === 'fulfilled')
+      .map((r) => r.value)
+    if (uris.length === 0) return
     dispatch({ type: 'APPEND_IMAGES', uris })
   }, [attachedImages.length, dispatch, t])
 

--- a/src/renderer/components/Sidebar/AddProjectDialog/index.tsx
+++ b/src/renderer/components/Sidebar/AddProjectDialog/index.tsx
@@ -62,9 +62,9 @@ export function AddProjectDialog() {
   // ── Tab config ─────────────────────────────────────────────────────────────
 
   const tabs: { id: Tab; icon: React.ReactNode; label: string }[] = [
-    { id: 'quickstart', icon: <IconSparkle />, label: t('quickStartTab') },
     { id: 'local', icon: <IconGridFill />, label: t('localPathTab') },
     { id: 'github', icon: <IconGitHub />, label: t('githubUrlTab') },
+    { id: 'quickstart', icon: <IconSparkle />, label: t('quickStartTab') },
   ]
 
   // ── Render ─────────────────────────────────────────────────────────────────

--- a/src/renderer/components/Sidebar/AddProjectDialog/types.ts
+++ b/src/renderer/components/Sidebar/AddProjectDialog/types.ts
@@ -46,7 +46,7 @@ export type Action =
   | { type: 'doneCreating' }
 
 export const initialState: State = {
-  tab: 'quickstart',
+  tab: 'local',
   localPath: '',
   githubUrl: '',
   phase: { kind: 'idle' },

--- a/src/renderer/lib/__tests__/imageCompression.test.ts
+++ b/src/renderer/lib/__tests__/imageCompression.test.ts
@@ -73,6 +73,8 @@ describe('compressImage', () => {
 
     const result = await compressImage(file)
 
+    // 2048x1536 scaled to fit 1024 -> 1024x768
+    expect(drawImageSpy).toHaveBeenCalledWith(expect.anything(), 0, 0, 1024, 768)
     expect(toDataURLSpy).toHaveBeenCalledWith('image/jpeg', 0.65)
     expect(result).toBe('data:image/jpeg;base64,compressed')
   })
@@ -107,7 +109,8 @@ describe('compressImage', () => {
     const file = new File(['fake'], 'small.png', { type: 'image/png' })
     const result = await compressImage(file)
 
-    // Should still JPEG-encode but at original dimensions (no resize)
+    // Should still JPEG-encode but at original dimensions (400x300, no resize)
+    expect(drawImageSpy).toHaveBeenCalledWith(expect.anything(), 0, 0, 400, 300)
     expect(toDataURLSpy).toHaveBeenCalledWith('image/jpeg', 0.65)
     expect(result).toBe('data:image/jpeg;base64,compressed')
   })

--- a/src/renderer/lib/__tests__/imageCompression.test.ts
+++ b/src/renderer/lib/__tests__/imageCompression.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { compressImage } from '../imageCompression'
+
+// ─── Mock browser APIs ──────────────────────────────────────────────────────
+
+let drawImageSpy: ReturnType<typeof vi.fn>
+let toDataURLSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+
+  drawImageSpy = vi.fn()
+  toDataURLSpy = vi.fn().mockReturnValue('data:image/jpeg;base64,compressed')
+
+  // Mock document.createElement for canvas
+  const origCreate = document.createElement.bind(document)
+  vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    if (tag === 'canvas') {
+      return {
+        width: 0,
+        height: 0,
+        getContext: () => ({ drawImage: drawImageSpy }),
+        toDataURL: toDataURLSpy,
+      } as unknown as HTMLCanvasElement
+    }
+    return origCreate(tag)
+  })
+
+  // Mock URL.createObjectURL / revokeObjectURL (preserve constructor)
+  globalThis.URL.createObjectURL = vi.fn().mockReturnValue('blob:mock')
+  globalThis.URL.revokeObjectURL = vi.fn()
+
+  // Mock Image constructor
+  vi.stubGlobal(
+    'Image',
+    class MockImage {
+      width = 2048
+      height = 1536
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      private _src = ''
+      get src() {
+        return this._src
+      }
+      set src(url: string) {
+        this._src = url
+        setTimeout(() => this.onload?.(), 0)
+      }
+    },
+  )
+
+  // Mock FileReader - returns data URI matching the file's MIME type
+  vi.stubGlobal(
+    'FileReader',
+    class MockFileReader {
+      result: string | null = null
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      readAsDataURL(file: File) {
+        const mime = file.type || 'application/octet-stream'
+        this.result = `data:${mime};base64,` + 'A'.repeat(10000)
+        setTimeout(() => this.onload?.(), 0)
+      }
+    },
+  )
+})
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('compressImage', () => {
+  it('compresses a large PNG to JPEG and resizes to fit 1024px', async () => {
+    const file = new File(['fake'], 'screenshot.png', { type: 'image/png' })
+
+    const result = await compressImage(file)
+
+    expect(toDataURLSpy).toHaveBeenCalledWith('image/jpeg', 0.65)
+    expect(result).toBe('data:image/jpeg;base64,compressed')
+  })
+
+  it('compresses GIF to JPEG (Claude only sees first frame)', async () => {
+    const file = new File(['fake'], 'animation.gif', { type: 'image/gif' })
+
+    const result = await compressImage(file)
+
+    expect(toDataURLSpy).toHaveBeenCalledWith('image/jpeg', 0.65)
+    expect(result).toBe('data:image/jpeg;base64,compressed')
+  })
+
+  it('re-encodes small images without resizing', async () => {
+    // Override Image mock to simulate a small image
+    vi.stubGlobal(
+      'Image',
+      class SmallImage {
+        width = 400
+        height = 300
+        onload: (() => void) | null = null
+        onerror: (() => void) | null = null
+        private _src = ''
+        get src() { return this._src }
+        set src(url: string) {
+          this._src = url
+          setTimeout(() => this.onload?.(), 0)
+        }
+      },
+    )
+
+    const file = new File(['fake'], 'small.png', { type: 'image/png' })
+    const result = await compressImage(file)
+
+    // Should still JPEG-encode but at original dimensions (no resize)
+    expect(toDataURLSpy).toHaveBeenCalledWith('image/jpeg', 0.65)
+    expect(result).toBe('data:image/jpeg;base64,compressed')
+  })
+
+  it('keeps original when compressed is larger', async () => {
+    // File content is 4 bytes, estimated data URI ~36 chars.
+    // Make compressed result much larger than that estimate.
+    toDataURLSpy.mockReturnValue('data:image/jpeg;base64,' + 'B'.repeat(200))
+
+    const file = new File(['fake'], 'tiny.png', { type: 'image/png' })
+    const result = await compressImage(file)
+
+    // Should fall back to original FileReader result
+    expect(result).toContain('data:image/png;base64,AAAA')
+  })
+})

--- a/src/renderer/lib/imageCompression.ts
+++ b/src/renderer/lib/imageCompression.ts
@@ -1,0 +1,81 @@
+/**
+ * Client-side image compression for LLM context conservation.
+ *
+ * Resizes images to fit within MAX_DIMENSION and re-encodes as JPEG
+ * at reduced quality. All formats (PNG, JPEG, GIF, WebP) are compressed
+ * - Claude only sees the first frame of GIFs anyway.
+ */
+
+const MAX_DIMENSION = 1024
+const JPEG_QUALITY = 0.65
+
+/** Load a File into an HTMLImageElement. */
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file)
+    const img = new Image()
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+      resolve(img)
+    }
+    img.onerror = () => {
+      URL.revokeObjectURL(url)
+      reject(new Error('Failed to load image'))
+    }
+    img.src = url
+  })
+}
+
+/**
+ * Compress an image file for sending to the LLM.
+ *
+ * - All formats are resized to fit within 1024x1024 and encoded as JPEG at 0.65 quality.
+ * - GIFs are flattened to first frame (Claude ignores animation frames anyway).
+ * - If the compressed result is larger than the original, the original is returned.
+ *
+ * Returns a base64 data URI string.
+ */
+export async function compressImage(file: File): Promise<string> {
+  const img = await loadImage(file)
+  const { width, height } = img
+
+  // Calculate scaled dimensions
+  let targetW = width
+  let targetH = height
+  if (width > MAX_DIMENSION || height > MAX_DIMENSION) {
+    const scale = MAX_DIMENSION / Math.max(width, height)
+    targetW = Math.round(width * scale)
+    targetH = Math.round(height * scale)
+  }
+
+  // Draw onto canvas and export as JPEG
+  const canvas = document.createElement('canvas')
+  canvas.width = targetW
+  canvas.height = targetH
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return readAsDataUri(file)
+  ctx.drawImage(img, 0, 0, targetW, targetH)
+
+  const compressed = canvas.toDataURL('image/jpeg', JPEG_QUALITY)
+
+  // Estimate original data URI length without reading the file again.
+  // Base64 expands by ~4/3, plus the "data:<mime>;base64," prefix (~25 chars).
+  const estimatedOriginalLen = Math.ceil(file.size / 3) * 4 + 30
+
+  // If compressed is larger (e.g. tiny image where JPEG overhead dominates), keep original
+  if (compressed.length >= estimatedOriginalLen) {
+    return readAsDataUri(file)
+  }
+
+  return compressed
+}
+
+/** Read a File as a base64 data URI (no compression). */
+function readAsDataUri(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = reject
+    reader.readAsDataURL(file)
+  })
+}

--- a/src/renderer/locales/en/center.json
+++ b/src/renderer/locales/en/center.json
@@ -152,6 +152,8 @@
   "snippetAttached_other": "{{count}} snippets attached ({{lines}} lines)",
   "imageLimitReached": "Maximum 5 images — remove one to add more",
   "imageTooLarge": "Image too large (max 2MB)",
+  "imageLoadFailed_one": "{{count}} image failed to load",
+  "imageLoadFailed_other": "{{count}} images failed to load",
   "draftInputTooLarge": "Input too long — use a snippet for large text",
   "linkWorktree": "Link Worktree",
   "unlinkWorktree": "Unlink",

--- a/src/renderer/locales/id/center.json
+++ b/src/renderer/locales/id/center.json
@@ -152,6 +152,8 @@
   "snippetAttached_other": "{{count}} cuplikan terlampir ({{lines}} baris)",
   "imageLimitReached": "Maksimal 5 gambar — hapus satu untuk menambah lagi",
   "imageTooLarge": "Gambar terlalu besar (maks 2MB)",
+  "imageLoadFailed_one": "{{count}} gambar gagal dimuat",
+  "imageLoadFailed_other": "{{count}} gambar gagal dimuat",
   "draftInputTooLarge": "Input terlalu panjang — gunakan cuplikan untuk teks besar",
   "linkWorktree": "Tautkan Worktree",
   "unlinkWorktree": "Lepas Tautan",

--- a/src/renderer/locales/ja/center.json
+++ b/src/renderer/locales/ja/center.json
@@ -153,6 +153,8 @@
   "snippetAttached_other": "{{count}}件のスニペット添付（{{lines}}行）",
   "imageLimitReached": "画像は最大5枚までです — 追加するには1枚削除してください",
   "imageTooLarge": "画像が大きすぎます（最大2MB）",
+  "imageLoadFailed_one": "{{count}}枚の画像の読み込みに失敗しました",
+  "imageLoadFailed_other": "{{count}}枚の画像の読み込みに失敗しました",
   "draftInputTooLarge": "入力が長すぎます — 大きなテキストにはスニペットを使用してください",
   "linkWorktree": "ワークツリーをリンク",
   "unlinkWorktree": "リンク解除",


### PR DESCRIPTION
## Summary

- Add client-side image compression that resizes images to 1024px max and re-encodes as JPEG at 0.65 quality before sending to the LLM, conserving context window tokens
- Gracefully handle failed image compressions with user-visible warnings instead of silently dropping images
- Move AddProjectDialog default tab from quickstart to local path

## Layers touched

- [x] **Renderer** (`src/renderer/`) — components, stores, lib

## Changes

**Center:**
- `ChatView.tsx`: Replace `fileToDataUri` with `compressImage`, use `Promise.allSettled` for error resilience, flash warning on failed images
- `ChatInput.tsx`: Export `ACCEPTED_IMAGE_TYPES` and `MAX_IMAGE_SIZE` constants, remove `fileToDataUri` (moved to compression module)

**Lib:**
- `imageCompression.ts`: New module - resizes images to fit 1024x1024, encodes as JPEG at 0.65 quality, falls back to original if compressed is larger
- `__tests__/imageCompression.test.ts`: Unit tests covering resize, GIF flattening, small image passthrough, and fallback behavior

**Sidebar:**
- `AddProjectDialog/index.tsx`: Reorder tabs to show local path first
- `AddProjectDialog/types.ts`: Change default tab from `quickstart` to `local`

**i18n:**
- Added `imageLoadFailed` plural keys to en, ja, id center translations

## How to test

1. `yarn dev`
2. Open a chat session
3. Drag and drop a large PNG/JPEG (>1024px) into the chat input
4. Verify the image is attached (it should be compressed - compare data URI size in devtools)
5. Try dragging a corrupt or invalid image file - verify a warning flash appears
6. Open "Add Project" dialog - verify "Local Path" tab is selected by default

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store