### PR TITLE
feat(chat): add turn stats tooltip and diff preview popover on file badges

### DIFF
--- a/src/renderer/components/Center/ChatMessage.tsx
+++ b/src/renderer/components/Center/ChatMessage.tsx
@@ -108,7 +108,9 @@ function TurnDuration({ durationMs, turnUsage }: { durationMs: number; turnUsage
     let top = r.top - tt.height - 6
     // If it would overflow the top of the viewport, flip below
     if (top < 4) top = r.bottom + 6
-    setCoords({ top, left: r.left })
+    // Clamp left to keep tooltip within viewport
+    const left = Math.max(4, Math.min(r.left, window.innerWidth - tt.width - 4))
+    setCoords({ top, left })
   }, [hovered])
 
   const modelName = turnUsage ? formatModelName(turnUsage.model) : null

--- a/src/renderer/components/Center/ChatMessage.tsx
+++ b/src/renderer/components/Center/ChatMessage.tsx
@@ -1,6 +1,7 @@
-import { memo, useState, useCallback, useRef, useEffect } from 'react'
+import { memo, useState, useCallback, useRef, useEffect, useLayoutEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
-import type { ContentBlock, Message } from '@/types'
+import type { ContentBlock, Message, TurnUsage } from '@/types'
 import { useUIStore } from '@/store/ui'
 import { ToolCallGroup } from './ToolCallGroup'
 import { StreamingMarkdown } from './StreamingMarkdown'
@@ -10,6 +11,7 @@ import { IconPrBranch, IconChevronRight, IconChevronDown, IconCodeBrackets, Icon
 import { TurnFooter } from './TurnFooter'
 import { parseDiffComments, parseSnippets, parseTerminalBlocks, stripAttachmentBlocks } from './diffCommentUtils'
 import type { ParsedDiffComment, ParsedSnippet, ParsedTerminalBlock } from './diffCommentUtils'
+import { formatTokens } from '@/lib/constants'
 
 /** Renders text with @mentions highlighted as accent-coloured spans */
 function renderWithMentions(text: string): React.ReactNode {
@@ -17,8 +19,7 @@ function renderWithMentions(text: string): React.ReactNode {
   return parts.length > 0 ? parts : text
 }
 
-function AssistantCopyButton({ text }: { text: string }) {
-  const { t } = useTranslation('common')
+function useCopyToClipboard(text: string) {
   const [copied, setCopied] = useState(false)
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
@@ -32,6 +33,13 @@ function AssistantCopyButton({ text }: { text: string }) {
     timerRef.current = setTimeout(() => setCopied(false), 2000)
   }, [text])
 
+  return { copied, handleCopy }
+}
+
+function AssistantCopyButton({ text }: { text: string }) {
+  const { t } = useTranslation('common')
+  const { copied, handleCopy } = useCopyToClipboard(text)
+
   return (
     <button
       className={`chat-msg-copy-btn${copied ? ' chat-msg-copy-btn--copied' : ''}`}
@@ -41,6 +49,128 @@ function AssistantCopyButton({ text }: { text: string }) {
       {copied ? <IconCheckmark size={14} /> : <IconCopy size={14} />}
     </button>
   )
+}
+
+interface TurnActionsProps {
+  text: string
+  durationMs?: number
+  turnUsage?: TurnUsage
+}
+
+function TurnActions({ text, durationMs, turnUsage }: TurnActionsProps) {
+  const { t } = useTranslation('common')
+  const { copied, handleCopy } = useCopyToClipboard(text)
+
+  return (
+    <div className="turn-actions">
+      {durationMs != null && durationMs > 0 && (
+        <TurnDuration durationMs={durationMs} turnUsage={turnUsage} />
+      )}
+      <button
+        className={`turn-actions-btn${copied ? ' turn-actions-btn--copied' : ''}`}
+        onClick={handleCopy}
+        title={copied ? t('copied') : t('copy')}
+      >
+        {copied ? <IconCheckmark size={14} /> : <IconCopy size={14} />}
+      </button>
+    </div>
+  )
+}
+
+const MODEL_LABELS: Record<string, string> = {
+  'claude-sonnet-4-6': 'Sonnet 4.6',
+  'claude-opus-4-6': 'Opus 4.6',
+  'claude-haiku-4-5': 'Haiku 4.5'
+}
+
+function formatModelName(raw?: string): string | null {
+  if (!raw) return null
+  if (MODEL_LABELS[raw]) return MODEL_LABELS[raw]
+  for (const [prefix, label] of Object.entries(MODEL_LABELS)) {
+    if (raw.startsWith(prefix)) return label
+  }
+  return raw
+}
+
+/** Duration text with a portal-based hover tooltip that escapes overflow:hidden ancestors. */
+function TurnDuration({ durationMs, turnUsage }: { durationMs: number; turnUsage?: TurnUsage }) {
+  const { t } = useTranslation('center')
+  const [hovered, setHovered] = useState(false)
+  const anchorRef = useRef<HTMLSpanElement>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
+  const [coords, setCoords] = useState<{ top: number; left: number }>({ top: 0, left: 0 })
+
+  useLayoutEffect(() => {
+    if (!hovered || !anchorRef.current || !tooltipRef.current) return
+    const r = anchorRef.current.getBoundingClientRect()
+    const tt = tooltipRef.current.getBoundingClientRect()
+    // Position above the anchor, left-aligned
+    let top = r.top - tt.height - 6
+    // If it would overflow the top of the viewport, flip below
+    if (top < 4) top = r.bottom + 6
+    setCoords({ top, left: r.left })
+  }, [hovered])
+
+  const modelName = turnUsage ? formatModelName(turnUsage.model) : null
+
+  return (
+    <span
+      ref={anchorRef}
+      className="turn-actions-duration"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {formatDuration(durationMs)}
+      {hovered && turnUsage && createPortal(
+        <div
+          ref={tooltipRef}
+          className="turn-usage-tooltip"
+          style={{ top: coords.top, left: coords.left }}
+        >
+          {modelName && (
+            <div className="turn-usage-tooltip-row">
+              <span className="turn-usage-tooltip-label">{t('turnStats.model')}</span>
+              <span className="turn-usage-tooltip-value">{modelName}</span>
+            </div>
+          )}
+          <div className="turn-usage-tooltip-row">
+            <span className="turn-usage-tooltip-label">{t('turnStats.duration')}</span>
+            <span className="turn-usage-tooltip-value">{formatDuration(durationMs)}</span>
+          </div>
+          <div className="turn-usage-tooltip-row">
+            <span className="turn-usage-tooltip-label">{t('turnStats.input')}</span>
+            <span className="turn-usage-tooltip-value">{formatTokens(turnUsage.inputTokens)}</span>
+          </div>
+          <div className="turn-usage-tooltip-row">
+            <span className="turn-usage-tooltip-label">{t('turnStats.output')}</span>
+            <span className="turn-usage-tooltip-value">{formatTokens(turnUsage.outputTokens)}</span>
+          </div>
+          {turnUsage.cacheReadTokens > 0 && (
+            <div className="turn-usage-tooltip-row">
+              <span className="turn-usage-tooltip-label">{t('turnStats.cacheRead')}</span>
+              <span className="turn-usage-tooltip-value">{formatTokens(turnUsage.cacheReadTokens)}</span>
+            </div>
+          )}
+          {turnUsage.cacheWriteTokens > 0 && (
+            <div className="turn-usage-tooltip-row">
+              <span className="turn-usage-tooltip-label">{t('turnStats.cacheWrite')}</span>
+              <span className="turn-usage-tooltip-value">{formatTokens(turnUsage.cacheWriteTokens)}</span>
+            </div>
+          )}
+        </div>,
+        document.body
+      )}
+    </span>
+  )
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  if (ms < 10000) return `${(ms / 1000).toFixed(1)}s`
+  if (ms < 60000) return `${Math.round(ms / 1000)}s`
+  const mins = Math.floor(ms / 60000)
+  const secs = Math.round((ms % 60000) / 1000)
+  return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`
 }
 
 interface Props {
@@ -122,10 +252,8 @@ export const ChatMessage = memo(function ChatMessage({ message }: Props) {
     const lastToolIdx = findLastToolIndex(blocks)
     const groupBlocks = blocks.slice(0, lastToolIdx + 1)
     const trailingBlocks = blocks.slice(lastToolIdx + 1)
-    const trailingText = trailingBlocks
-      .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
-      .map((b) => b.text)
-      .join('')
+    const trailingText = joinTextBlocks(trailingBlocks)
+    const allText = joinTextBlocks(blocks)
 
     return (
       <div className="chat-msg chat-msg-assistant">
@@ -137,6 +265,9 @@ export const ChatMessage = memo(function ChatMessage({ message }: Props) {
           </div>
         )}
         {!message.isPartial && <TurnFooter blocks={groupBlocks} />}
+        {!message.isPartial && allText && (
+          <TurnActions text={allText} durationMs={message.turnDurationMs} turnUsage={message.turnUsage} />
+        )}
       </div>
     )
   }
@@ -149,6 +280,9 @@ export const ChatMessage = memo(function ChatMessage({ message }: Props) {
           <StreamingMarkdown content={message.content} isStreaming={message.isPartial} enableAnimation={streamingAnimation} />
           {!message.isPartial && <AssistantCopyButton text={message.content} />}
         </div>
+      )}
+      {!message.isPartial && message.content && (
+        <TurnActions text={message.content} durationMs={message.turnDurationMs} turnUsage={message.turnUsage} />
       )}
     </div>
   )
@@ -308,4 +442,11 @@ function findLastToolIndex(blocks: ContentBlock[]): number {
     if (blocks[i].type === 'tool_use') return i
   }
   return -1
+}
+
+function joinTextBlocks(blocks: ContentBlock[]): string {
+  return blocks
+    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+    .map((b) => b.text)
+    .join('')
 }

--- a/src/renderer/components/Center/DiffPreviewPopover.tsx
+++ b/src/renderer/components/Center/DiffPreviewPopover.tsx
@@ -1,0 +1,232 @@
+import { useRef, useMemo, useState, useCallback, useEffect, memo } from 'react'
+import { createPortal } from 'react-dom'
+import { useAsyncHighlight } from '@/hooks/useAsyncHighlight'
+import { extToHljsLang } from './ToolCallGroup/toolMeta'
+
+export interface DiffChunk {
+  oldString: string
+  newString: string
+}
+
+interface Props {
+  filePath: string
+  chunks: DiffChunk[]
+  anchorRect: DOMRect
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+}
+
+const MAX_LINES = 20
+const POPOVER_WIDTH = 480
+
+/**
+ * Floating popover that shows a syntax-highlighted diff preview.
+ * Rendered as a portal, positioned relative to the anchor badge.
+ */
+export const DiffPreviewPopover = memo(function DiffPreviewPopover({
+  filePath,
+  chunks,
+  anchorRect,
+  onMouseEnter,
+  onMouseLeave,
+}: Props) {
+  // Build a flat list of diff lines from all chunks, truncating if needed.
+  const { lines, truncated } = useMemo(() => {
+    const result: Array<{ type: 'del' | 'add' | 'sep'; text: string }> = []
+    let count = 0
+
+    for (let ci = 0; ci < chunks.length; ci++) {
+      const chunk = chunks[ci]
+      if (ci > 0) {
+        result.push({ type: 'sep', text: '' })
+      }
+
+      const oldLines = chunk.oldString ? chunk.oldString.split('\n') : []
+      const newLines = chunk.newString ? chunk.newString.split('\n') : []
+
+      for (const line of oldLines) {
+        if (count >= MAX_LINES) return { lines: result, truncated: true }
+        result.push({ type: 'del', text: line })
+        count++
+      }
+      for (const line of newLines) {
+        if (count >= MAX_LINES) return { lines: result, truncated: true }
+        result.push({ type: 'add', text: line })
+        count++
+      }
+    }
+    return { lines: result, truncated: false }
+  }, [chunks])
+
+  // Concatenate del and add lines separately for syntax highlighting,
+  // and build index maps for O(1) lookup during render
+  const { delText, addText, delHtmlMap, addHtmlMap } = useMemo(() => {
+    const delParts: string[] = []
+    const addParts: string[] = []
+    const delIdx = new Map<number, number>() // line index -> position in delParts
+    const addIdx = new Map<number, number>()
+
+    for (let i = 0; i < lines.length; i++) {
+      const l = lines[i]
+      if (l.type === 'del') {
+        delIdx.set(i, delParts.length)
+        delParts.push(l.text)
+      } else if (l.type === 'add') {
+        addIdx.set(i, addParts.length)
+        addParts.push(l.text)
+      }
+    }
+    return {
+      delText: delParts.join('\n'),
+      addText: addParts.join('\n'),
+      delHtmlMap: delIdx,
+      addHtmlMap: addIdx,
+    }
+  }, [lines])
+
+  const lang = extToHljsLang(filePath)
+  const enabled = lang != null
+  const highlightedDel = useAsyncHighlight(delText || null, lang ?? 'plaintext', enabled)
+  const highlightedAdd = useAsyncHighlight(addText || null, lang ?? 'plaintext', enabled)
+
+  const delHtmlLines = useMemo(() => highlightedDel?.split('\n') ?? null, [highlightedDel])
+  const addHtmlLines = useMemo(() => highlightedAdd?.split('\n') ?? null, [highlightedAdd])
+
+  // O(1) lookup: line index -> highlighted HTML
+  const htmlForLine = useCallback((lineIdx: number, type: 'del' | 'add'): string | null => {
+    if (type === 'del' && delHtmlLines) {
+      const pos = delHtmlMap.get(lineIdx)
+      return pos != null ? (delHtmlLines[pos] ?? '') : null
+    }
+    if (type === 'add' && addHtmlLines) {
+      const pos = addHtmlMap.get(lineIdx)
+      return pos != null ? (addHtmlLines[pos] ?? '') : null
+    }
+    return null
+  }, [delHtmlLines, addHtmlLines, delHtmlMap, addHtmlMap])
+
+  // Position: above if anchor is in bottom half of viewport, below otherwise.
+  // Sets --slide-dir so CSS animation slides toward the anchor.
+  const { posStyle, opensAbove } = useMemo(() => {
+    const gap = 6
+    let left = anchorRect.left + anchorRect.width / 2 - POPOVER_WIDTH / 2
+    left = Math.max(8, Math.min(left, window.innerWidth - POPOVER_WIDTH - 8))
+
+    const anchorMid = anchorRect.top + anchorRect.height / 2
+    const above = anchorMid > window.innerHeight / 2
+    const pos = above
+      ? { bottom: window.innerHeight - anchorRect.top + gap, left, width: POPOVER_WIDTH }
+      : { top: anchorRect.bottom + gap, left, width: POPOVER_WIDTH }
+    return { posStyle: pos, opensAbove: above }
+  }, [anchorRect])
+
+  if (lines.length === 0) return null
+
+  return createPortal(
+    <div
+      className={`diff-preview-popover hljs ${opensAbove ? 'diff-preview-popover--above' : ''}`}
+      style={posStyle}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <div className="diff-preview-popover-scroll">
+        <div className="diff-preview-lines">
+          {lines.map((line, i) => {
+            if (line.type === 'sep') {
+              return <div key={`sep-${i}`} className="diff-preview-sep" />
+            }
+            const cls = line.type === 'del' ? 'diff-line diff-line-del' : 'diff-line diff-line-add'
+            const gutter = line.type === 'del' ? '-' : '+'
+            const html = htmlForLine(i, line.type)
+
+            return (
+              <div key={i} className={cls}>
+                <span className="diff-line-gutter">{gutter}</span>
+                <span
+                  className="diff-line-content"
+                  {...(html != null
+                    ? { dangerouslySetInnerHTML: { __html: html } }
+                    : { children: line.text }
+                  )}
+                />
+              </div>
+            )
+          })}
+          {truncated && (
+            <div className="diff-preview-truncated">...</div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+})
+
+/**
+ * Hook to manage hover state for a diff preview popover.
+ * Handles the badge <-> popover bridge (mouse can move between them without closing).
+ * Dismisses on scroll to avoid stale positioning.
+ */
+export function useDiffPreviewHover(delay = 250) {
+  const [visible, setVisible] = useState(false)
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const badgeRef = useRef<HTMLSpanElement>(null)
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  const dismiss = useCallback(() => {
+    clearTimer()
+    setVisible(false)
+  }, [clearTimer])
+
+  const onBadgeEnter = useCallback(() => {
+    clearTimer()
+    timerRef.current = setTimeout(() => {
+      if (!badgeRef.current) return
+      setAnchorRect(badgeRef.current.getBoundingClientRect())
+      setVisible(true)
+    }, delay)
+  }, [clearTimer, delay])
+
+  const onBadgeLeave = useCallback(() => {
+    clearTimer()
+    timerRef.current = setTimeout(() => setVisible(false), 120)
+  }, [clearTimer])
+
+  const onPopoverEnter = useCallback(() => {
+    clearTimer()
+  }, [clearTimer])
+
+  const onPopoverLeave = useCallback(() => {
+    clearTimer()
+    timerRef.current = setTimeout(() => setVisible(false), 80)
+  }, [clearTimer])
+
+  // Dismiss on scroll to prevent stale positioning
+  useEffect(() => {
+    if (!visible) return
+    // Find the nearest scrollable ancestor (Virtuoso scroller or plain scroller)
+    let el = badgeRef.current?.parentElement ?? null
+    while (el) {
+      const { overflowY } = getComputedStyle(el)
+      if (overflowY === 'auto' || overflowY === 'scroll') break
+      el = el.parentElement
+    }
+    if (!el) return
+    el.addEventListener('scroll', dismiss, { passive: true })
+    return () => el.removeEventListener('scroll', dismiss)
+  }, [visible, dismiss])
+
+  // Cleanup pending timers on unmount
+  useEffect(() => {
+    return () => { if (timerRef.current) clearTimeout(timerRef.current) }
+  }, [])
+
+  return { visible, anchorRect, badgeRef, onBadgeEnter, onBadgeLeave, onPopoverEnter, onPopoverLeave }
+}

--- a/src/renderer/components/Center/TurnFooter.tsx
+++ b/src/renderer/components/Center/TurnFooter.tsx
@@ -1,14 +1,27 @@
-import { memo, useMemo } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { ContentBlock } from '@/types'
 import { useUIStore } from '@/store/ui'
 import { IconFile } from '@/components/shared/icons'
+import { DiffPreviewPopover, useDiffPreviewHover, type DiffChunk } from './DiffPreviewPopover'
 
 interface TurnFileEdit {
   filePath: string
   filePathFull: string
   additions: number
   deletions: number
+  chunks: DiffChunk[]
+}
+
+/** Take the first N lines from a string without splitting the entire content. */
+function takeLines(text: string, n: number): string {
+  let end = 0
+  for (let i = 0; i < n; i++) {
+    const nl = text.indexOf('\n', end)
+    if (nl === -1) return text // fewer than n lines total
+    end = nl + 1
+  }
+  return text.slice(0, end > 0 ? end - 1 : 0)
 }
 
 function aggregateFileEdits(blocks: ContentBlock[]): TurnFileEdit[] {
@@ -17,18 +30,32 @@ function aggregateFileEdits(blocks: ContentBlock[]): TurnFileEdit[] {
     if (b.type !== 'tool_use') continue
     const tc = b.toolCall
     if (!tc.diffStats || !tc.filePathFull) continue
-    const existing = map.get(tc.filePathFull)
-    if (existing) {
-      existing.additions += tc.diffStats.additions
-      existing.deletions += tc.diffStats.deletions
-    } else {
-      map.set(tc.filePathFull, {
+
+    let existing = map.get(tc.filePathFull)
+    if (!existing) {
+      existing = {
         filePath: tc.filePath ?? tc.filePathFull.split('/').slice(-2).join('/'),
         filePathFull: tc.filePathFull,
-        additions: tc.diffStats.additions,
-        deletions: tc.diffStats.deletions,
-      })
+        additions: 0,
+        deletions: 0,
+        chunks: [],
+      }
+      map.set(tc.filePathFull, existing)
     }
+    existing.additions += tc.diffStats.additions
+    existing.deletions += tc.diffStats.deletions
+
+    // Extract diff content from Edit/Write tool inputs
+    if (typeof tc.input !== 'string') continue
+    try {
+      const p = JSON.parse(tc.input)
+      if (tc.name === 'Edit' && (p.old_string != null || p.new_string != null)) {
+        existing.chunks.push({ oldString: p.old_string ?? '', newString: p.new_string ?? '' })
+      } else if (tc.name === 'Write' && p.content) {
+        // For Write, show first ~15 lines as "all additions"
+        existing.chunks.push({ oldString: '', newString: takeLines(p.content, 15) })
+      }
+    } catch { /* skip unparseable inputs */ }
   }
   return Array.from(map.values())
 }
@@ -50,21 +77,51 @@ export const TurnFooter = memo(function TurnFooter({ blocks }: Props) {
       </span>
       <div className="turn-footer-badges">
         {edits.map((edit) => (
-          <span
-            key={edit.filePathFull}
-            className="tcg-file-badge tcg-file-badge--clickable"
-            title={edit.filePathFull}
-            onClick={() => useUIStore.getState().openFile(edit.filePathFull)}
-          >
-            <IconFile size={12} />
-            <span className="turn-footer-file-name">{edit.filePath}</span>
-            <span className="tcg-diff">
-              <span className="tcg-diff-add">+{edit.additions}</span>
-              <span className="tcg-diff-del">{'\u2212'}{edit.deletions}</span>
-            </span>
-          </span>
+          <TurnFooterBadge key={edit.filePathFull} edit={edit} />
         ))}
       </div>
     </div>
+  )
+})
+
+// ── Badge with hover popover ────────────────────────────────────────────────────
+
+const TurnFooterBadge = memo(function TurnFooterBadge({ edit }: { edit: TurnFileEdit }) {
+  const { visible, anchorRect, badgeRef, onBadgeEnter, onBadgeLeave, onPopoverEnter, onPopoverLeave } =
+    useDiffPreviewHover()
+
+  const hasChunks = edit.chunks.length > 0
+
+  const handleClick = useCallback(() => {
+    useUIStore.getState().openFile(edit.filePathFull)
+  }, [edit.filePathFull])
+
+  return (
+    <>
+      <span
+        ref={badgeRef}
+        className="tcg-file-badge tcg-file-badge--clickable"
+        title={hasChunks ? undefined : edit.filePathFull}
+        onClick={handleClick}
+        onMouseEnter={hasChunks ? onBadgeEnter : undefined}
+        onMouseLeave={hasChunks ? onBadgeLeave : undefined}
+      >
+        <IconFile size={12} />
+        <span className="turn-footer-file-name">{edit.filePath}</span>
+        <span className="tcg-diff">
+          <span className="tcg-diff-add">+{edit.additions}</span>
+          <span className="tcg-diff-del">{'\u2212'}{edit.deletions}</span>
+        </span>
+      </span>
+      {visible && anchorRect && hasChunks && (
+        <DiffPreviewPopover
+          filePath={edit.filePathFull}
+          chunks={edit.chunks}
+          anchorRect={anchorRect}
+          onMouseEnter={onPopoverEnter}
+          onMouseLeave={onPopoverLeave}
+        />
+      )}
+    </>
   )
 })

--- a/src/renderer/locales/en/center.json
+++ b/src/renderer/locales/en/center.json
@@ -312,5 +312,12 @@
   "toolSummary.todo_other": "{{count}} todos",
 
   "turnFooterFiles_one": "1 file changed",
-  "turnFooterFiles_other": "{{count}} files changed"
+  "turnFooterFiles_other": "{{count}} files changed",
+
+  "turnStats.model": "Model",
+  "turnStats.duration": "Duration",
+  "turnStats.input": "Input",
+  "turnStats.output": "Output",
+  "turnStats.cacheRead": "Cache read",
+  "turnStats.cacheWrite": "Cache write"
 }

--- a/src/renderer/locales/id/center.json
+++ b/src/renderer/locales/id/center.json
@@ -294,5 +294,12 @@
   "toolSummary.todo": "{{count}} tugas",
 
   "turnFooterFiles_one": "1 file diubah",
-  "turnFooterFiles_other": "{{count}} file diubah"
+  "turnFooterFiles_other": "{{count}} file diubah",
+
+  "turnStats.model": "Model",
+  "turnStats.duration": "Durasi",
+  "turnStats.input": "Input",
+  "turnStats.output": "Output",
+  "turnStats.cacheRead": "Cache baca",
+  "turnStats.cacheWrite": "Cache tulis"
 }

--- a/src/renderer/locales/ja/center.json
+++ b/src/renderer/locales/ja/center.json
@@ -295,5 +295,12 @@
   "toolSummary.todo": "{{count}} ToDo",
 
   "turnFooterFiles_one": "1 ファイル変更",
-  "turnFooterFiles_other": "{{count}} ファイル変更"
+  "turnFooterFiles_other": "{{count}} ファイル変更",
+
+  "turnStats.model": "モデル",
+  "turnStats.duration": "所要時間",
+  "turnStats.input": "入力",
+  "turnStats.output": "出力",
+  "turnStats.cacheRead": "キャッシュ読取",
+  "turnStats.cacheWrite": "キャッシュ書込"
 }

--- a/src/renderer/store/sessions/handlers/handleDone.ts
+++ b/src/renderer/store/sessions/handlers/handleDone.ts
@@ -7,6 +7,7 @@ import type { QueuedMessage } from '../store'
 import { updateSession } from '../stateUtils'
 import { persistSession } from '../persistence'
 import { stopPeriodicFlush, flushStreamingBuffer } from '../streaming'
+import { pendingTurnUsage } from './handleStreaming'
 import { sessionWorktreePaths } from '../storage'
 import { DOM_EVENT_FILES_CHANGED } from '@/lib/appBrand'
 import * as ipc from '@/lib/ipc'
@@ -38,18 +39,24 @@ export async function handleDone(
 
   stopPeriodicFlush(sessionId)
   flushStreamingBuffer(sessionId)
+  pendingTurnUsage.delete(sessionId)
 
   if (!updateSession(store, sessionId, (current) => {
     const keepWaiting = current.status === 'waiting_input'
-    const elapsed = current.runStartedAt ? Date.now() - current.runStartedAt : 0
+    const now = Date.now()
+    const elapsed = current.runStartedAt ? now - current.runStartedAt : 0
     return {
-      messages: current.messages.map((m) => (m.isPartial ? { ...m, isPartial: false } : m)),
+      messages: current.messages.map((m) =>
+        m.isPartial
+          ? { ...m, isPartial: false, turnDurationMs: elapsed > 0 ? elapsed : undefined }
+          : m
+      ),
       status: keepWaiting ? ('waiting_input' as const) : ('idle' as const),
       activity: keepWaiting ? current.activity : null,
       runStartedAt: null,
       // Only mark the run as completed if we're actually done — a session
       // still waiting for user input hasn't finished its run yet.
-      runCompletedAt: keepWaiting ? current.runCompletedAt : Date.now(),
+      runCompletedAt: keepWaiting ? current.runCompletedAt : now,
       totalRunDurationMs: (current.totalRunDurationMs ?? 0) + elapsed
     }
   })) return

--- a/src/renderer/store/sessions/handlers/handleDone.ts
+++ b/src/renderer/store/sessions/handlers/handleDone.ts
@@ -48,7 +48,7 @@ export async function handleDone(
     return {
       messages: current.messages.map((m) =>
         m.isPartial
-          ? { ...m, isPartial: false, turnDurationMs: elapsed > 0 ? elapsed : undefined }
+          ? { ...m, isPartial: false, turnDurationMs: elapsed > 0 ? elapsed : m.turnDurationMs }
           : m
       ),
       status: keepWaiting ? ('waiting_input' as const) : ('idle' as const),

--- a/src/renderer/store/sessions/handlers/handleStreaming.ts
+++ b/src/renderer/store/sessions/handlers/handleStreaming.ts
@@ -2,7 +2,7 @@
 // Streaming handlers — streamEvent, toolProgress, result
 // ---------------------------------------------------------------------------
 
-import type { ContentBlock, ToolCall } from '@/types'
+import type { ContentBlock, ToolCall, TurnUsage } from '@/types'
 import type { HandlerContext } from './types'
 import { accumulateTokens } from './tokenUtils'
 import { updateSession, msgId } from '../stateUtils'
@@ -19,6 +19,26 @@ import i18n from '@/lib/i18n'
  * double-counting in handleResult. Exported for test beforeEach cleanup.
  */
 export const sessionsWithStreamingTokens = new Set<string>()
+
+/**
+ * Stash per-turn usage from message_start until the partial assistant message
+ * shell is created (in content_block_start or content_block_delta).
+ * message_start always fires before any content blocks, so the message doesn't
+ * exist yet when usage arrives. Exported for test cleanup.
+ */
+export const pendingTurnUsage = new Map<string, TurnUsage>()
+
+/** Accumulate turn usage across multi-step tool use. Keeps the latest model. */
+function mergeTurnUsage(existing: TurnUsage | undefined, incoming: TurnUsage): TurnUsage {
+  if (!existing) return incoming
+  return {
+    model: incoming.model ?? existing.model,
+    inputTokens: existing.inputTokens + incoming.inputTokens,
+    outputTokens: existing.outputTokens + incoming.outputTokens,
+    cacheReadTokens: existing.cacheReadTokens + incoming.cacheReadTokens,
+    cacheWriteTokens: existing.cacheWriteTokens + incoming.cacheWriteTokens
+  }
+}
 
 // ---------------------------------------------------------------------------
 // handleStreamEvent
@@ -69,6 +89,17 @@ export function handleStreamEvent(ctx: HandlerContext, ev: Record<string, unknow
         const postTokens = totalContext
         const preTokens = preCompactTokens.get(sessionId)
 
+        // Stash per-turn usage - will be attached to the assistant message
+        // when its shell is created in content_block_start / content_block_delta.
+        const model = message?.model as string | undefined
+        pendingTurnUsage.set(sessionId, {
+          model,
+          inputTokens: usage.input_tokens ?? 0,
+          outputTokens: usage.output_tokens ?? 0,
+          cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+          cacheWriteTokens: usage.cache_creation_input_tokens ?? 0
+        })
+
         updateSession(store, sessionId, (current) => {
           const base = {
             tokenUsage: accumulateTokens(current.tokenUsage, usage),
@@ -110,9 +141,27 @@ export function handleStreamEvent(ctx: HandlerContext, ev: Record<string, unknow
       const usage = streamEvent.usage as { output_tokens?: number } | undefined
       if (usage) {
         sessionsWithStreamingTokens.add(sessionId)
-        updateSession(store, sessionId, (current) => ({
-          tokenUsage: accumulateTokens(current.tokenUsage, usage)
-        }))
+        updateSession(store, sessionId, (current) => {
+          const base = { tokenUsage: accumulateTokens(current.tokenUsage, usage) }
+          // Accumulate output tokens on the last partial assistant message's turnUsage
+          if (usage.output_tokens) {
+            const messages = [...current.messages]
+            for (let idx = messages.length - 1; idx >= 0; idx--) {
+              const m = messages[idx]
+              if (m.role === 'assistant' && m.isPartial && m.turnUsage) {
+                messages[idx] = {
+                  ...m,
+                  turnUsage: {
+                    ...m.turnUsage,
+                    outputTokens: m.turnUsage.outputTokens + usage.output_tokens
+                  }
+                }
+                return { ...base, messages }
+              }
+            }
+          }
+          return base
+        })
       }
       return
     }
@@ -147,23 +196,31 @@ export function handleContentBlockStart(
     updateSession(store, sessionId, (current) => {
       const messages = [...current.messages]
       const lastMsg = messages[messages.length - 1]
+      const stashedUsage = pendingTurnUsage.get(sessionId)
 
       if (lastMsg?.role === 'assistant' && lastMsg.isPartial) {
         const existingBlocks = lastMsg.blocks ?? []
         if (!existingBlocks.some((bl) => bl.type === 'tool_use' && bl.toolCall.id === toolId)) {
+          // Accumulate turnUsage across multi-step tool use (each API call fires message_start)
+          const mergedUsage = stashedUsage
+            ? mergeTurnUsage(lastMsg.turnUsage, stashedUsage)
+            : lastMsg.turnUsage
           messages[messages.length - 1] = {
             ...lastMsg,
             blocks: [...existingBlocks, placeholderBlock],
-            toolCalls: [...(lastMsg.toolCalls ?? []), placeholderToolCall]
+            toolCalls: [...(lastMsg.toolCalls ?? []), placeholderToolCall],
+            turnUsage: mergedUsage
           }
         }
       } else {
         messages.push({
           id: msgId(), role: 'assistant', content: '',
           blocks: [placeholderBlock], toolCalls: [placeholderToolCall],
-          isPartial: true, timestamp: Date.now()
+          isPartial: true, timestamp: Date.now(),
+          turnUsage: stashedUsage
         })
       }
+      if (stashedUsage) pendingTurnUsage.delete(sessionId)
       return { activity: toolActivity(toolName, 'calling'), messages }
     })
     return
@@ -194,11 +251,14 @@ export function handleContentBlockDelta(
   if (!updateSession(store, sessionId, (current) => {
     const lastMsg = current.messages[current.messages.length - 1]
     if (lastMsg?.role === 'assistant' && lastMsg.isPartial) return {}
+    const stashedUsage = pendingTurnUsage.get(sessionId)
+    if (stashedUsage) pendingTurnUsage.delete(sessionId)
     return {
       activity: 'Writing...',
       messages: [...current.messages, {
         id: msgId(), role: 'assistant' as const, content: '',
-        isPartial: true, timestamp: Date.now()
+        isPartial: true, timestamp: Date.now(),
+        turnUsage: stashedUsage
       }]
     }
   })) return
@@ -262,6 +322,7 @@ export function handleResult(ctx: HandlerContext, ev: Record<string, unknown>): 
   if (resultText && ev.subtype === 'success') {
     if (!updateSession(store, sessionId, (current) => {
       const elapsed = current.runStartedAt ? Date.now() - current.runStartedAt : 0
+      const turnDurationMs = elapsed > 0 ? elapsed : undefined
       const lastMsg = current.messages[current.messages.length - 1]
       const base = {
         status: 'idle' as const,
@@ -271,13 +332,28 @@ export function handleResult(ctx: HandlerContext, ev: Record<string, unknown>): 
         // preserves null rather than upgrading it to {0,0} with no data
         tokenUsage: usage != null ? accumulateTokens(current.tokenUsage, usage) : current.tokenUsage
       }
-      // De-duplicate: skip append if result already equals last message
-      if (lastMsg && lastMsg.content === resultText) return base
+      // De-duplicate: skip append if result already equals last message.
+      // Stamp turnDurationMs on the existing partial message (turnUsage was set during streaming).
+      if (lastMsg && lastMsg.content === resultText) {
+        if (turnDurationMs != null) {
+          const messages = [...current.messages]
+          messages[messages.length - 1] = { ...lastMsg, turnDurationMs }
+          return { ...base, messages }
+        }
+        return base
+      }
+      // Inherit turnUsage from the last partial assistant message, or from pending stash
+      const stashedUsage = pendingTurnUsage.get(sessionId)
+      if (stashedUsage) pendingTurnUsage.delete(sessionId)
+      const partialMsg = (lastMsg?.role === 'assistant' && lastMsg.isPartial) ? lastMsg : undefined
+      const turnUsage = partialMsg?.turnUsage ?? stashedUsage
       return {
         ...base,
         messages: [...current.messages, {
           id: msgId('result'), role: 'assistant' as const,
-          content: resultText, timestamp: Date.now()
+          content: resultText, timestamp: Date.now(),
+          turnDurationMs,
+          turnUsage
         }]
       }
     })) return

--- a/src/renderer/styles/chat-messages.css
+++ b/src/renderer/styles/chat-messages.css
@@ -690,3 +690,82 @@
   white-space: nowrap;
   max-width: 180px;
 }
+
+/* ============= Turn Actions (Bottom Copy Button) ============= */
+
+.turn-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  padding-top: var(--space-4);
+}
+
+.turn-actions-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color var(--duration-fast), background var(--duration-fast);
+}
+
+.turn-actions-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.turn-actions-btn--copied {
+  color: var(--green);
+}
+
+.turn-actions-btn--copied:hover {
+  color: var(--green);
+  background: none;
+}
+
+.turn-actions-duration {
+  font-size: var(--text-lg);
+  color: var(--text-muted);
+  cursor: default;
+}
+
+/* ---- Turn Usage Tooltip (portal, position: fixed) ---- */
+
+.turn-usage-tooltip {
+  position: fixed;
+  min-width: 180px;
+  padding: var(--space-6) var(--space-8);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-elevation-md);
+  z-index: var(--z-popover);
+  pointer-events: none;
+  animation: tooltip-fade-in 0.12s ease-out;
+}
+
+.turn-usage-tooltip-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-12);
+  padding: var(--space-2) 0;
+}
+
+.turn-usage-tooltip-label {
+  font-size: var(--text-md);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.turn-usage-tooltip-value {
+  font-size: var(--text-md);
+  color: var(--text-primary);
+  font-weight: var(--weight-medium);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}

--- a/src/renderer/styles/diff.css
+++ b/src/renderer/styles/diff.css
@@ -45,6 +45,7 @@
 .diff-line {
   display: flex;
   min-height: 20px;
+  min-width: fit-content;
 }
 
 .diff-line-add {
@@ -79,7 +80,6 @@
 .diff-line-content {
   flex: 1;
   white-space: pre;
-  overflow-x: auto;
   padding-right: var(--space-12);
   tab-size: 4;
 }

--- a/src/renderer/styles/tool-calls.css
+++ b/src/renderer/styles/tool-calls.css
@@ -684,13 +684,15 @@
 
 .diff-preview-popover-scroll::-webkit-scrollbar {
   width: 6px;
+  height: 6px;
 }
 .diff-preview-popover-scroll::-webkit-scrollbar-thumb {
   background: var(--text-muted);
   border-radius: var(--radius-pill);
 }
 .diff-preview-popover-scroll::-webkit-scrollbar-track {
-  background: transparent;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-pill);
 }
 
 .diff-preview-lines {

--- a/src/renderer/styles/tool-calls.css
+++ b/src/renderer/styles/tool-calls.css
@@ -527,6 +527,7 @@
   font-family: var(--font-mono);
   font-size: var(--text-md);
   line-height: 1.55;
+  background: var(--bg-secondary);
 }
 
 .tcg-inline-diff .diff-line-num {
@@ -536,6 +537,14 @@
 .tcg-inline-diff .diff-line {
   min-height: unset;
   padding: 0 var(--space-4);
+}
+
+.tcg-inline-diff .diff-line-add {
+  background: color-mix(in srgb, var(--green) 18%, var(--bg-secondary));
+}
+
+.tcg-inline-diff .diff-line-del {
+  background: color-mix(in srgb, var(--red) 16%, var(--bg-secondary));
 }
 
 .tcg-inline-diff .diff-line-content {
@@ -636,5 +645,89 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
+}
+
+/* ── Diff Preview Popover ─────────────────────────────────────────────────── */
+.diff-preview-popover {
+  position: fixed;
+  z-index: var(--z-popover);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-elevation-xl);
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  line-height: 1.5;
+  animation: diff-preview-in-below var(--duration-fast) ease-out;
+}
+
+.diff-preview-popover--above {
+  animation-name: diff-preview-in-above;
+}
+
+@keyframes diff-preview-in-below {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes diff-preview-in-above {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.diff-preview-popover-scroll {
+  max-height: 320px;
+  overflow: auto;
+  padding: var(--space-4) 0;
+}
+
+.diff-preview-popover-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+.diff-preview-popover-scroll::-webkit-scrollbar-thumb {
+  background: var(--text-muted);
+  border-radius: var(--radius-pill);
+}
+.diff-preview-popover-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.diff-preview-lines {
+  width: max-content;
+  min-width: 100%;
+}
+
+.diff-preview-popover .diff-line {
+  min-height: unset;
+  min-width: unset;
+  width: 100%;
+  padding: 0 var(--space-6) 0 0;
+}
+
+.diff-preview-popover .diff-line-add {
+  background: color-mix(in srgb, var(--green) 18%, var(--bg-secondary));
+}
+
+.diff-preview-popover .diff-line-del {
+  background: color-mix(in srgb, var(--red) 16%, var(--bg-secondary));
+}
+
+.diff-preview-popover .diff-line-content {
+  padding-right: var(--space-10);
+}
+
+.diff-preview-sep {
+  height: 1px;
+  background: var(--border);
+  margin: var(--space-4) 0;
+}
+
+.diff-preview-truncated {
+  text-align: center;
+  padding: var(--space-4) 0;
+  color: var(--text-muted);
+  font-size: var(--text-base);
+  font-family: var(--font-mono);
 }
 

--- a/src/renderer/types/session.ts
+++ b/src/renderer/types/session.ts
@@ -90,6 +90,14 @@ export type ContentBlock =
   | { type: 'text'; text: string }
   | { type: 'tool_use'; toolCall: ToolCall }
 
+export interface TurnUsage {
+  model?: string // raw model id from API (e.g. "claude-sonnet-4-6-20250514")
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+}
+
 export interface Message {
   id: string
   role: 'user' | 'assistant' | 'system'
@@ -100,6 +108,8 @@ export interface Message {
   isPartial?: boolean
   tag?: string // optional semantic tag (e.g. 'create-pr') for special renderers
   timestamp: number
+  turnDurationMs?: number // wall-clock duration for this assistant turn
+  turnUsage?: TurnUsage // per-turn token usage snapshot
 }
 
 export interface ToolCall {


### PR DESCRIPTION
## Summary

- Add per-turn duration display and token usage tooltip (model, input/output tokens, cache stats) to each assistant message
- Add a syntax-highlighted diff preview popover when hovering file badges in the turn footer
- Improve inline diff styling with proper background colors and scrollbar fixes

## Layers touched

- [x] **Renderer** (`src/renderer/`) - components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Center panel:**
- `ChatMessage.tsx` - Extract `useCopyToClipboard` hook, add `TurnActions` component with duration display and copy button, add `TurnDuration` portal tooltip showing model/token usage, add `formatDuration` and `formatModelName` helpers
- `DiffPreviewPopover.tsx` (new) - Floating portal-based popover with syntax-highlighted diff lines (add/del), truncation at 20 lines, scroll-dismiss, slide animation, `useDiffPreviewHover` hook for badge-popover bridge
- `TurnFooter.tsx` - Extract `TurnFooterBadge` component with hover popover support, collect Edit/Write diff chunks from tool inputs, add `takeLines` utility

**Stores** (`sessions/handlers/`):
- `handleStreaming.ts` - Track `TurnUsage` (model, input/output/cache tokens) from `message_start` events, accumulate across multi-step tool use, attach to partial assistant messages via `pendingTurnUsage` stash
- `handleDone.ts` - Stamp `turnDurationMs` on partial messages when a turn completes, clean up pending usage

**Types:**
- `session.ts` - Add `TurnUsage` interface and `turnDurationMs`/`turnUsage` fields to `Message`

**Styles:**
- `chat-messages.css` - Turn actions bar and usage tooltip styles
- `tool-calls.css` - Diff preview popover styles (positioning, animation, scrollbar, line colors), inline diff background colors
- `diff.css` - Fix horizontal scroll by using `min-width: fit-content` on diff lines

**i18n:**
- `en/center.json`, `ja/center.json`, `id/center.json` - Turn stats labels (model, duration, input, output, cache read/write)

## How to test

1. `yarn dev`
2. Start a session and let Claude make some edits
3. After a turn completes, verify:
   - Duration text appears below the message (e.g. "3.2s")
   - Hovering duration shows a tooltip with model name, token counts, and cache stats
   - File badges in the turn footer are hoverable - a diff preview popover appears after 250ms
   - Popover shows syntax-highlighted add/del lines
   - Popover dismisses on scroll and mouse leave
   - Copy button at the bottom of each turn copies the full text

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] No console errors or warnings in DevTools
- [x] New state is added to the correct Zustand store