### PR TITLE
fix: resolve CLI ENOENT errors when app launched from Finder

### DIFF
--- a/src/main/lib/enrichedEnv.ts
+++ b/src/main/lib/enrichedEnv.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns process.env with PATH enriched to include common Homebrew and local bin dirs.
+ *
+ * When Electron is launched from Finder/Dock (release builds), process.env.PATH is
+ * minimal (/usr/bin:/bin:/usr/sbin:/sbin) and CLIs installed via Homebrew (gh, acli)
+ * are not found (ENOENT). Prepending these dirs fixes the lookup.
+ *
+ * In dev mode (launched from terminal) the extra dirs are typically already in PATH,
+ * so prepending them is a harmless no-op.
+ */
+export function enrichedEnv(): NodeJS.ProcessEnv {
+  const envPath = ['/opt/homebrew/bin', '/usr/local/bin', process.env.PATH ?? ''].join(':')
+  return { ...process.env, PATH: envPath }
+}

--- a/src/main/services/git/branches.ts
+++ b/src/main/services/git/branches.ts
@@ -2,6 +2,7 @@ import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { getValidGit } from './core'
 import { ServiceCache } from '../../lib/serviceCache'
+import { enrichedEnv } from '../../lib/enrichedEnv'
 import { resolveNwo } from '../github'
 
 const execFileAsync = promisify(execFile)
@@ -30,10 +31,10 @@ async function _fetchRemoteBranches(worktreePath: string): Promise<{ branches: s
 
     // Parallelize: default branch + branch list (independent of each other)
     const [defaultBranch, branches] = await Promise.all([
-      execFileAsync('gh', ['repo', 'view', '--json', 'defaultBranchRef', '-q', '.defaultBranchRef.name'], { cwd: worktreePath, timeout: 15_000 })
+      execFileAsync('gh', ['repo', 'view', '--json', 'defaultBranchRef', '-q', '.defaultBranchRef.name'], { cwd: worktreePath, timeout: 15_000, env: enrichedEnv() })
         .then(({ stdout }) => stdout.trim() || undefined)
         .catch(() => undefined),
-      execFileAsync('gh', ['api', `repos/${repo}/branches`, '--paginate', '-q', '.[].name'], { cwd: worktreePath, timeout: 30_000 })
+      execFileAsync('gh', ['api', `repos/${repo}/branches`, '--paginate', '-q', '.[].name'], { cwd: worktreePath, timeout: 30_000, env: enrichedEnv() })
         .then(({ stdout }) => stdout.split('\n').map((b) => b.trim()).filter(Boolean).map((b) => `origin/${b}`)),
     ])
 
@@ -110,7 +111,7 @@ async function _checkProtected(repo: string, branch: string, cwd: string): Promi
     const { stdout } = await execFileAsync(
       'gh',
       ['api', `repos/${repo}/branches/${encodeURIComponent(branch)}`, '-q', '.protected'],
-      { cwd, timeout: 15_000 }
+      { cwd, timeout: 15_000, env: enrichedEnv() }
     )
     return stdout.trim() === 'true'
   } catch {

--- a/src/main/services/github.ts
+++ b/src/main/services/github.ts
@@ -2,6 +2,7 @@ import { execFile, spawn } from 'child_process'
 import { promisify } from 'util'
 import simpleGit from 'simple-git'
 import { ServiceCache } from '../lib/serviceCache'
+import { enrichedEnv } from '../lib/enrichedEnv'
 
 const exec = promisify(execFile)
 
@@ -16,7 +17,7 @@ export async function resolveNwo(cwd: string): Promise<string> {
   return nwoCache.get(cwd, async () => {
     const { stdout } = await exec(
       'gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'],
-      { cwd, timeout: 15_000 }
+      { cwd, timeout: 15_000, env: enrichedEnv() }
     )
     const nwo = stdout.trim()
     if (!nwo) throw new Error('Could not resolve repo nameWithOwner')
@@ -87,7 +88,7 @@ class GitHubService {
 
   private async gh(args: string[], cwd: string, throwOnError = false): Promise<string> {
     try {
-      const { stdout } = await exec('gh', args, { cwd, timeout: 15_000, maxBuffer: 10 * 1024 * 1024 })
+      const { stdout } = await exec('gh', args, { cwd, timeout: 15_000, maxBuffer: 10 * 1024 * 1024, env: enrichedEnv() })
       return stdout.trim()
     } catch (err) {
       if (throwOnError) {
@@ -282,7 +283,7 @@ class GitHubService {
   /** Spawn `gh` and stream stdout, keeping only the last `tailChars` characters. */
   private ghTail(args: string[], cwd: string, tailChars: number): Promise<string> {
     return new Promise((resolve, reject) => {
-      const proc = spawn('gh', args, { cwd, stdio: ['ignore', 'pipe', 'ignore'] })
+      const proc = spawn('gh', args, { cwd, stdio: ['ignore', 'pipe', 'ignore'], env: enrichedEnv() })
       let tail = ''
       const timer = setTimeout(() => { proc.kill(); reject(new Error('gh log fetch timed out')) }, 30_000)
 

--- a/src/main/services/jira.ts
+++ b/src/main/services/jira.ts
@@ -4,6 +4,7 @@ import { readFile } from 'fs/promises'
 import { homedir } from 'os'
 import { join } from 'path'
 import { ServiceCache } from '../lib/serviceCache'
+import { enrichedEnv } from '../lib/enrichedEnv'
 
 const exec = promisify(execFile)
 
@@ -38,7 +39,7 @@ class JiraService {
   async isAvailable(): Promise<boolean> {
     if (this._available !== null) return this._available
     try {
-      await exec('which', ['acli'], { timeout: 3_000 })
+      await exec('which', ['acli'], { timeout: 3_000, env: enrichedEnv() })
       this._available = true
     } catch {
       this._available = false
@@ -109,7 +110,8 @@ class JiraService {
     const data = await this.issueDataCache.get(key, async () => {
       try {
         const { stdout } = await exec('acli', ['jira', 'workitem', 'view', key, '--json'], {
-          timeout: 10_000
+          timeout: 10_000,
+          env: enrichedEnv()
         })
         return JSON.parse(stdout.trim()) as Record<string, unknown>
       } catch {


### PR DESCRIPTION
## Summary

- Fixes `ENOENT` errors for Homebrew-installed CLIs (`gh`, `acli`) when Electron is launched from Finder/Dock
- Adds `enrichedEnv()` utility that prepends `/opt/homebrew/bin` and `/usr/local/bin` to `PATH`
- Applies the enriched env to all `gh` and `acli` invocations in git, GitHub, and Jira services

## Layers touched

- [x] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [ ] **Renderer** (`src/renderer/`) — components, stores, lib
- [ ] **Styles** (`App.css`)

## Changes

**Services** (`git.ts` / `claude.ts` / `github.ts` / `pty.ts`):
- `src/main/lib/enrichedEnv.ts` — new utility that returns `process.env` with Homebrew paths prepended to `PATH`
- `src/main/services/github.ts` — pass `enrichedEnv()` to all `gh` `exec`/`spawn` calls (`resolveNwo`, `gh()`, `ghTail()`)
- `src/main/services/git/branches.ts` — pass `enrichedEnv()` to `gh` calls for fetching remote branches and checking branch protection
- `src/main/services/jira.ts` — pass `enrichedEnv()` to `acli` calls (`isAvailable`, `issueDataCache`)

## How to test

1. `yarn build && yarn package` to produce a release `.app`
2. Launch the `.app` from Finder (not from a terminal)
3. Open a project and verify remote branches load, PR checks fetch, and Jira integration resolves without ENOENT errors
4. Verify `yarn dev` (terminal launch) still works normally - the extra PATH entries are a harmless no-op when already present

## Screenshots

N/A - no UI changes

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store