### PR TITLE
feat(sidebar): worktree name display, right-click context menu, and enriched PATH

### DIFF
--- a/src/renderer/components/Center/LinkedWorktreeChips.tsx
+++ b/src/renderer/components/Center/LinkedWorktreeChips.tsx
@@ -121,7 +121,7 @@ export function LinkedWorktreeChips({ sessionId, worktreeId }: Props) {
         <div key={lw.worktreeId} className="linked-worktree-chip">
           <IconLink size={11} />
           <span className="linked-worktree-chip-label">
-            {lw.projectName}/{lw.branch}
+            {lw.projectName}/{lw.path.split('/').pop() ?? lw.branch}
           </span>
           <button
             className="linked-worktree-chip-remove"
@@ -201,7 +201,7 @@ export function LinkedWorktreeChips({ sessionId, worktreeId }: Props) {
                           }}
                         >
                           <div className="lwt-card-header">
-                            <div className="lwt-card-branch">{wt.branch}</div>
+                            <div className="lwt-card-branch">{wt.path.split('/').pop() ?? wt.branch}</div>
                             {isLinked && (
                               <span className="lwt-card-badge">
                                 <IconCheckmark size={10} />
@@ -265,7 +265,8 @@ function buildAvailableWorktrees(
     const wts: WorktreeOption[] = []
     for (const wt of project.worktrees) {
       if (wt.id === currentWorktreeId) continue
-      if (lowerFilter && !wt.branch.toLowerCase().includes(lowerFilter) && !project.name.toLowerCase().includes(lowerFilter)) continue
+      const wtName = wt.path.split('/').pop() ?? ''
+      if (lowerFilter && !wt.branch.toLowerCase().includes(lowerFilter) && !project.name.toLowerCase().includes(lowerFilter) && !wtName.toLowerCase().includes(lowerFilter)) continue
       wts.push({ worktreeId: wt.id, branch: wt.branch, path: wt.path, upstream: wt.upstream })
     }
     if (wts.length > 0) {

--- a/src/renderer/components/Center/LinkedWorktreeChips.tsx
+++ b/src/renderer/components/Center/LinkedWorktreeChips.tsx
@@ -6,9 +6,10 @@ import { useReducer, useCallback, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSessionsStore, useLinkedWorktrees } from '@/store/sessions'
 import { useProjectsStore } from '@/store/projects'
-import { IconLink, IconPlus, IconClose, IconCheckmark } from '@/components/shared/icons'
+import { IconLink, IconPlus, IconClose, IconCheckmark, IconGitBranch } from '@/components/shared/icons'
 import type { LinkedWorktree, Project } from '@/types'
 import { SK } from '@/lib/storageKeys'
+import { worktreeName } from '@/lib/branchValidation'
 
 interface Props {
   sessionId: string
@@ -121,7 +122,7 @@ export function LinkedWorktreeChips({ sessionId, worktreeId }: Props) {
         <div key={lw.worktreeId} className="linked-worktree-chip">
           <IconLink size={11} />
           <span className="linked-worktree-chip-label">
-            {lw.projectName}/{lw.path.split('/').pop() ?? lw.branch}
+            {lw.projectName}/{worktreeName(lw.path, lw.branch)}
           </span>
           <button
             className="linked-worktree-chip-remove"
@@ -201,7 +202,7 @@ export function LinkedWorktreeChips({ sessionId, worktreeId }: Props) {
                           }}
                         >
                           <div className="lwt-card-header">
-                            <div className="lwt-card-branch">{wt.path.split('/').pop() ?? wt.branch}</div>
+                            <div className="lwt-card-branch">{worktreeName(wt.path, wt.branch)}</div>
                             {isLinked && (
                               <span className="lwt-card-badge">
                                 <IconCheckmark size={10} />
@@ -210,6 +211,10 @@ export function LinkedWorktreeChips({ sessionId, worktreeId }: Props) {
                             )}
                           </div>
                           <div className="lwt-card-details">
+                            <span className="lwt-card-branch-row">
+                              <IconGitBranch size={9} />
+                              <span>{wt.branch}</span>
+                            </span>
                             {wt.upstream && (
                               <span className="lwt-card-upstream">&uarr; {wt.upstream}</span>
                             )}
@@ -265,7 +270,7 @@ function buildAvailableWorktrees(
     const wts: WorktreeOption[] = []
     for (const wt of project.worktrees) {
       if (wt.id === currentWorktreeId) continue
-      const wtName = wt.path.split('/').pop() ?? ''
+      const wtName = worktreeName(wt.path, wt.branch)
       if (lowerFilter && !wt.branch.toLowerCase().includes(lowerFilter) && !project.name.toLowerCase().includes(lowerFilter) && !wtName.toLowerCase().includes(lowerFilter)) continue
       wts.push({ worktreeId: wt.id, branch: wt.branch, path: wt.path, upstream: wt.upstream })
     }

--- a/src/renderer/components/Sidebar/SidebarView.tsx
+++ b/src/renderer/components/Sidebar/SidebarView.tsx
@@ -6,6 +6,7 @@ import { useUIStore } from '@/store/ui'
 import { useProjectsStore } from '@/store/projects'
 import { useTranslation } from 'react-i18next'
 import { OverviewBanner } from '@/components/MissionControl/OverviewBanner'
+import { ContextMenu } from '@/components/shared/ContextMenu'
 
 export const SidebarView = memo(function SidebarView() {
   const showAddProject = useUIStore((s) => s.showAddProject)
@@ -17,6 +18,8 @@ export const SidebarView = memo(function SidebarView() {
   const addWorktreeProject = addWorktreeProjectId
     ? projects.find((p) => p.id === addWorktreeProjectId) ?? null
     : null
+
+  const [sidebarMenu, setSidebarMenu] = useState<{ x: number; y: number } | null>(null)
 
   return (
     <>
@@ -36,9 +39,22 @@ export const SidebarView = memo(function SidebarView() {
       <div
         className="sidebar-content"
         data-tour="sidebar"
+        onContextMenu={(e) => {
+          e.preventDefault()
+          setSidebarMenu({ x: e.clientX, y: e.clientY })
+        }}
       >
         <ProjectList onAddWorktree={(id) => setAddWorktreeProjectId(id)} />
       </div>
+
+      {sidebarMenu && (
+        <ContextMenu
+          x={sidebarMenu.x}
+          y={sidebarMenu.y}
+          items={[{ label: t('addProject'), onClick: () => setShowAddProject(true) }]}
+          onClose={() => setSidebarMenu(null)}
+        />
+      )}
 
       {showAddProject && <AddProjectDialog />}
       {addWorktreeProject && (

--- a/src/renderer/components/Sidebar/WorktreeRow.tsx
+++ b/src/renderer/components/Sidebar/WorktreeRow.tsx
@@ -10,6 +10,7 @@ import { ContextMenu, type ContextMenuItem } from '@/components/shared/ContextMe
 import { useSessionsForWorktree } from '@/store/sessions'
 import { useTranslation } from 'react-i18next'
 import { IconGitBranch } from '@/components/shared/icons'
+import { worktreeName } from '@/lib/branchValidation'
 
 interface Props {
   worktree: Worktree
@@ -145,7 +146,7 @@ export function WorktreeRow({ worktree, dragOverId, draggingId, isNew }: Props) 
         </Tooltip>
         <div className="worktree-name-stack">
           <span className="worktree-branch-name">
-            {worktree.path.split('/').pop() ?? worktree.branch}
+            {worktreeName(worktree.path, worktree.branch)}
           </span>
           <span className="worktree-branch-secondary">
             <IconGitBranch size={9} />

--- a/src/renderer/components/Sidebar/WorktreeRow.tsx
+++ b/src/renderer/components/Sidebar/WorktreeRow.tsx
@@ -9,6 +9,7 @@ import { Checkbox } from '@/components/ui'
 import { ContextMenu, type ContextMenuItem } from '@/components/shared/ContextMenu'
 import { useSessionsForWorktree } from '@/store/sessions'
 import { useTranslation } from 'react-i18next'
+import { IconGitBranch } from '@/components/shared/icons'
 
 interface Props {
   worktree: Worktree
@@ -142,9 +143,15 @@ export function WorktreeRow({ worktree, dragOverId, draggingId, isNew }: Props) 
         >
           <StatusDot status={status} count={sessions.length} />
         </Tooltip>
-        <span className="worktree-branch-name">
-          {worktree.branch}
-        </span>
+        <div className="worktree-name-stack">
+          <span className="worktree-branch-name">
+            {worktree.path.split('/').pop() ?? worktree.branch}
+          </span>
+          <span className="worktree-branch-secondary">
+            <IconGitBranch size={9} />
+            <span>{worktree.branch}</span>
+          </span>
+        </div>
         <div className="worktree-row-actions">
           <PrIcon worktreePath={worktree.path} />
           {worktree.isMain && (

--- a/src/renderer/lib/__tests__/branchValidation.test.ts
+++ b/src/renderer/lib/__tests__/branchValidation.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect } from 'vitest'
-import { validateBranchName, extractJiraKey, deriveBranchFromJira } from '../branchValidation'
+import { worktreeName, validateBranchName, extractJiraKey, deriveBranchFromJira } from '../branchValidation'
+
+describe('worktreeName', () => {
+  it('returns the last path segment', () => {
+    expect(worktreeName('/Users/agas/Braid/worktrees/proj/my-branch', 'fallback')).toBe('my-branch')
+  })
+
+  it('returns fallback for empty path', () => {
+    expect(worktreeName('', 'fallback')).toBe('fallback')
+  })
+
+  it('returns fallback for trailing slash (malformed path)', () => {
+    expect(worktreeName('/Users/agas/Braid/worktrees/proj/my-branch/', 'fallback')).toBe('fallback')
+  })
+
+  it('returns the name itself when path has no slashes', () => {
+    expect(worktreeName('my-branch', 'fallback')).toBe('my-branch')
+  })
+})
 
 describe('validateBranchName', () => {
   // ── valid names ────────────────────────────────────────────────────────────

--- a/src/renderer/lib/branchValidation.ts
+++ b/src/renderer/lib/branchValidation.ts
@@ -1,4 +1,12 @@
 /**
+ * Returns the display name for a worktree — the last segment of its path.
+ * Falls back to the branch name if the path is empty or malformed.
+ */
+export function worktreeName(path: string, fallback: string): string {
+  return path.split('/').pop() || fallback
+}
+
+/**
  * Validates a git branch name according to git-check-ref-format rules.
  * Returns an error message string if invalid, or null if valid.
  */

--- a/src/renderer/styles/linked-worktrees.css
+++ b/src/renderer/styles/linked-worktrees.css
@@ -269,7 +269,8 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  flex-shrink: 0;
+  flex-shrink: 1;
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/renderer/styles/linked-worktrees.css
+++ b/src/renderer/styles/linked-worktrees.css
@@ -265,6 +265,21 @@
   overflow: hidden;
 }
 
+.lwt-card-branch-row {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.lwt-card-branch-row svg {
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
 .lwt-card-upstream {
   flex-shrink: 0;
   white-space: nowrap;

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -460,11 +460,44 @@
    Extracted inline styles
    ══════════════════════════════════════════════════════════════════ */
 
-.worktree-branch-name {
+.worktree-name-stack {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  gap: var(--space-1);
+}
+
+.worktree-branch-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.worktree-branch-secondary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  overflow: hidden;
+  white-space: nowrap;
+  opacity: 0.75;
+}
+
+.worktree-branch-secondary svg {
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.worktree-branch-secondary span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.worktree-row.selected .worktree-branch-secondary,
+.worktree-row:hover .worktree-branch-secondary {
+  opacity: 1;
 }
 
 .sidebar-empty-state {


### PR DESCRIPTION
## Summary

- Display worktree name (last path segment) instead of raw branch name in the sidebar, with the branch name shown as secondary info
- Add right-click context menu on the sidebar background to quickly add a project
- Pass enriched PATH to child processes (git, github, jira services)

## Layers touched

- [x] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Sidebar / Center / Right panel:**
- `WorktreeRow.tsx`: replace single branch name span with a stacked layout showing worktree name (bold) + branch name with git icon (secondary/muted)
- `SidebarView.tsx`: add `onContextMenu` handler to the sidebar content area; renders a `ContextMenu` with an "Add Project" item at the cursor position
- `LinkedWorktreeChips.tsx`: use `worktreeName()` helper for chip labels

**Stores** (`projects.ts` / `sessions.ts` / `ui.ts`):
- No store changes

**Services** (`git.ts` / `claude.ts` / `github.ts` / `pty.ts`):
- `git/branches.ts`, `github.ts`, `jira.ts`: use `enrichedEnv()` so spawned processes inherit the full PATH (fixes missing CLI tools like `gh`, `acli`, `git` in restricted environments)
- `enrichedEnv.ts`: new utility that builds an enriched `env` object for child process spawning

**IPC** (`main/ipc.ts` → `preload/index.ts` → `lib/ipc.ts`):
- No IPC changes

## How to test

1. `yarn dev`
2. Right-click on an empty area of the sidebar - a context menu should appear with "Add Project"
3. Select "Add Project" - the Add Project dialog should open
4. Check a worktree row - it should show the worktree folder name prominently, with the branch name in smaller text below it with a git branch icon

## Screenshots

<!-- Before/after if UI changed. Remove if not applicable. -->

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store