### PR TITLE
fix: redirect Atlassian CLI docs link to official developer docs

### DIFF
--- a/src/renderer/components/Onboarding/OnboardingOverlay.tsx
+++ b/src/renderer/components/Onboarding/OnboardingOverlay.tsx
@@ -114,7 +114,7 @@ const CHECK_META: Record<CheckKey, CheckMeta> = {
   acli: {
     label: 'Atlassian CLI',
     required: false,
-    installUrl: 'https://www.npmjs.com/package/@atlassian/acli',
+    installUrl: 'https://developer.atlassian.com/cloud/acli/guides/install-acli/',
     autoInstall: { progressKey: 'onboarding.doctor.progressAcli' },
   },
 }


### PR DESCRIPTION
## Summary

- Replaces the broken `npmjs.com` link for Atlassian CLI with the official Atlassian developer documentation URL
- Old URL: `https://www.npmjs.com/package/@atlassian/acli` (requires NPM login)
- New URL: `https://developer.atlassian.com/cloud/acli/guides/install-acli/`

## Test plan

- [ ] Open Onboarding overlay
- [ ] Verify "Open Docs" button for Atlassian CLI navigates to `https://developer.atlassian.com/cloud/acli/guides/install-acli/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)