### PR TITLE
fix: syntax highlighting aliases, enriched subprocess env, and Atlassian docs link

### DIFF
--- a/src/main/services/agent.ts
+++ b/src/main/services/agent.ts
@@ -6,6 +6,7 @@ import { mainSettings } from '../ipc'
 import type { WorkerEvent, AgentSettings, SlashCommand } from './agentTypes'
 import type { WorkerCommand, WorkerResult } from './agentProcessTypes'
 import { ptyService } from './pty'
+import { enrichedEnv } from '../lib/enrichedEnv'
 
 /** Metadata cached in the coordinator (no cross-process call needed). */
 interface SessionMeta { sessionName: string; cwd: string; branch: string; projectName: string }
@@ -49,7 +50,8 @@ class AgentCoordinator {
 
   private spawnSessionProcess(sessionId: string): Electron.UtilityProcess {
     const child = utilityProcess.fork(ENTRY_PATH, [], {
-      serviceName: `claude-${sessionId.slice(-6)}`
+      serviceName: `claude-${sessionId.slice(-6)}`,
+      env: enrichedEnv(),
     })
 
     child.on('message', (msg: WorkerEvent) => {
@@ -84,7 +86,8 @@ class AgentCoordinator {
     return new Promise((resolve, reject) => {
       const { requestId } = cmd
       const child = utilityProcess.fork(ENTRY_PATH, [], {
-        serviceName: `claude-ephemeral`
+        serviceName: `claude-ephemeral`,
+        env: enrichedEnv(),
       })
 
       const timer = setTimeout(() => {

--- a/src/main/services/lsp/helpers.ts
+++ b/src/main/services/lsp/helpers.ts
@@ -2,28 +2,21 @@ import type { ChildProcess } from 'child_process'
 import { existsSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
+import { enrichedEnv } from '../../lib/enrichedEnv'
 
 // ─── PATH enrichment ──────────────────────────────────────────────────────────
 
+/**
+ * Build a PATH suitable for LSP server detection and spawning.
+ *
+ * Uses the login-shell-probed PATH from enrichedEnv() (which includes nvm,
+ * pyenv, rbenv, sdkman, etc.) and prepends the Braid-managed lsp-servers
+ * directory for downloaded binaries.
+ */
 export function buildEnrichedPath(): string {
-  const home = homedir()
-  const extras = [
-    join(home, 'Braid', 'lsp-servers'), // downloaded binaries
-    '/opt/homebrew/bin',
-    '/opt/homebrew/sbin',
-    '/usr/local/bin',
-    `${home}/.cargo/bin`,
-    `${home}/go/bin`,
-    `${home}/.local/bin`,
-    `${home}/.npm/bin`,
-    `${home}/.yarn/bin`,
-    '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin',
-    '/usr/bin',
-    '/bin',
-  ]
-  const systemPath = process.env.PATH ?? ''
-  const combined = [...extras, ...systemPath.split(':').filter(Boolean)]
-  // deduplicate while preserving order
+  const lspBinDir = join(homedir(), 'Braid', 'lsp-servers')
+  const basePath = enrichedEnv().PATH ?? process.env.PATH ?? ''
+  const combined = [lspBinDir, ...basePath.split(':').filter(Boolean)]
   return [...new Set(combined)].join(':')
 }
 

--- a/src/main/services/lsp/pool.ts
+++ b/src/main/services/lsp/pool.ts
@@ -5,6 +5,7 @@ import { join, basename } from 'path'
 import { buildEnrichedPath, findBinary, pathToFileUri, fileUriToPath, writeMessage, parseSeverity } from './helpers'
 import { resolveConfigs, detectServers, detectServersForFile } from './detect'
 import { installServer } from './download'
+import { waitForEnrichedEnv } from '../../lib/enrichedEnv'
 import * as ops from './operations'
 import type {
   LspServerStatus, LspServerConfig, LspDetectedServer,
@@ -15,6 +16,16 @@ import type {
 export class LspServerPool extends EventEmitter {
   private servers = new Map<string, ServerInstance>()
   private enrichedPath = buildEnrichedPath()
+
+  constructor() {
+    super()
+    // buildEnrichedPath() reads enrichedEnv() which may return a fallback PATH
+    // before the login-shell probe settles. Refresh once the probe is done so
+    // LSP detection/spawning sees nvm, pyenv, rbenv, etc.
+    waitForEnrichedEnv().then(() => {
+      this.enrichedPath = buildEnrichedPath()
+    })
+  }
 
   private serverKey(projectRoot: string, configId: string): string {
     return `${projectRoot}::${configId}`

--- a/src/renderer/components/Center/StreamingMarkdown.tsx
+++ b/src/renderer/components/Center/StreamingMarkdown.tsx
@@ -38,7 +38,15 @@ interface StreamingMarkdownProps {
 
 // Stable plugin arrays created once at module level
 const defaultRemarkPlugins: PluggableList = [remarkGfm]
-const defaultRehypePluginsWithHighlight: PluggableList = [rehypeHighlight]
+// highlight.js doesn't register tsx/jsx as built-in languages.
+// Alias them to their base languages so code blocks render highlighted.
+const highlightOptions = {
+  aliases: {
+    typescript: ['tsx', 'mts', 'cts'],
+    javascript: ['jsx', 'mjs', 'cjs'],
+  },
+}
+const defaultRehypePluginsWithHighlight: PluggableList = [[rehypeHighlight, highlightOptions]]
 const defaultRehypePluginsNoHighlight: PluggableList = []
 
 /**

--- a/src/renderer/components/Right/FileViewer.tsx
+++ b/src/renderer/components/Right/FileViewer.tsx
@@ -26,6 +26,7 @@ interface Props {
   onDirtyChange?: (filePath: string, isDirty: boolean) => void
 }
 
+// LSP-protocol language IDs (used for textDocument/didOpen).
 const EXT_TO_LANG: Record<string, string> = {
   ts: 'typescript', tsx: 'typescriptreact',
   js: 'javascript', jsx: 'javascriptreact',
@@ -38,11 +39,24 @@ const EXT_TO_LANG: Record<string, string> = {
   proto: 'protobuf', dockerfile: 'dockerfile',
 }
 
+// Monaco registers tsx/jsx under "typescript"/"javascript" - it does NOT
+// recognize VS Code-style "typescriptreact"/"javascriptreact" IDs.
+const LSP_TO_MONACO: Record<string, string> = {
+  typescriptreact: 'typescript',
+  javascriptreact: 'javascript',
+}
+
+/** LSP-protocol language ID for a file path. */
 function getLanguage(path: string): string {
   const ext = path.split('.').pop()?.toLowerCase() ?? ''
   const name = path.split('/').pop()?.toLowerCase() ?? ''
   if (name === 'dockerfile') return 'dockerfile'
   return EXT_TO_LANG[ext] ?? 'plaintext'
+}
+
+/** Map an LSP language ID to a Monaco-recognized language ID. */
+function toMonacoLanguage(lang: string): string {
+  return LSP_TO_MONACO[lang] ?? lang
 }
 
 // ─── Reducer ──────────────────────────────────────────────────────────────────
@@ -344,7 +358,7 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
         ) : (
           <Editor
             height="100%"
-            language={languageId}
+            language={toMonacoLanguage(languageId)}
             defaultValue={state.savedContent}
             theme={MONACO_THEME_NAME}
             onMount={handleEditorMount}


### PR DESCRIPTION
Closes #25

## Summary

- Fix tsx/jsx syntax highlighting in both Markdown code blocks (highlight.js) and the Monaco file editor by aliasing language IDs correctly
- Use login-shell-probed `enrichedEnv()` for agent subprocess spawning so tools like nvm, pyenv, and rbenv are available in Claude sessions
- Refresh `LspServerPool.enrichedPath` after the login-shell probe settles to avoid locking in the fallback PATH
- Redirect the Atlassian CLI install link from the old npmjs page to the official developer docs

## Layers touched

- [x] **Main process** (`src/main/`) - services, IPC handlers
- [ ] **Preload** (`src/preload/`) - context bridge API
- [x] **Renderer** (`src/renderer/`) - components, stores, lib
- [ ] **Styles** (`App.css`)

## Changes

**Center panel:**
- `StreamingMarkdown.tsx`: Added `aliases` config to `rehype-highlight` so `tsx`, `jsx`, `mts`, `cts`, `mjs`, `cjs` code blocks get proper syntax highlighting

**Right panel:**
- `FileViewer.tsx`: Added `LSP_TO_MONACO` mapping and `toMonacoLanguage()` helper to convert VS Code-style `typescriptreact`/`javascriptreact` IDs to Monaco-recognized `typescript`/`javascript`

**Services** (`agent.ts` / `lsp/helpers.ts` / `lsp/pool.ts`):
- `agent.ts`: Pass `enrichedEnv()` as the environment for both session and ephemeral agent utility processes, ensuring PATH includes nvm/pyenv/rbenv/sdkman paths
- `lsp/helpers.ts`: Replaced hardcoded PATH list with `enrichedEnv().PATH`, keeping only the Braid `lsp-servers` directory as a prepended entry
- `lsp/pool.ts`: Added constructor that refreshes `enrichedPath` after `waitForEnrichedEnv()` settles, fixing the race where the pool locks in the fallback PATH at import time

**Onboarding:**
- `OnboardingOverlay.tsx`: Updated Atlassian CLI install URL to point to the official developer docs

## How to test

1. `yarn dev`
2. **Syntax highlighting**: Ask Claude to write a tsx code block - it should render with TypeScript highlighting instead of plain text
3. **File viewer**: Open a `.tsx` or `.jsx` file in the right panel editor - syntax highlighting should work correctly
4. **Subprocess env**: Start a Claude session and verify tools can find binaries managed by nvm/pyenv (e.g., run a tool that uses node)
5. **Atlassian link**: Open the onboarding overlay doctor checks and verify the Atlassian CLI "install" link goes to `developer.atlassian.com`

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass - `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main -> preload -> renderer)
- [ ] New state is added to the correct Zustand store