### PR TITLE
feat: delete worktree via Delete key when row is focused

### DIFF
--- a/src/renderer/components/Sidebar/WorktreeRow.tsx
+++ b/src/renderer/components/Sidebar/WorktreeRow.tsx
@@ -73,6 +73,14 @@ export function WorktreeRow({ worktree, dragOverId, draggingId, isNew }: Props) 
   else if (sessions.some((s) => s.status === 'error')) status = 'error'
   else if (sessions.some((s) => s.status === 'idle')) status = 'idle'
 
+  const requestDeleteWorktree = () => {
+    if (skipDeleteConfirm) {
+      removeWorktree(worktree.projectId, worktree.id)
+    } else {
+      rowDispatch({ type: 'SHOW_DELETE_CONFIRM' })
+    }
+  }
+
   const worktreeMenuItems: ContextMenuItem[] = [
     {
       label: isPinned ? t('contextMenuUnpin') : t('contextMenuPin'),
@@ -87,13 +95,7 @@ export function WorktreeRow({ worktree, dragOverId, draggingId, isNew }: Props) 
       label: t('contextMenuDeleteWorktree'),
       danger: true,
       disabled: worktree.isMain,
-      onClick: () => {
-        if (skipDeleteConfirm) {
-          removeWorktree(worktree.projectId, worktree.id)
-        } else {
-          rowDispatch({ type: 'SHOW_DELETE_CONFIRM' })
-        }
-      }
+      onClick: requestDeleteWorktree
     }
   ]
 
@@ -120,13 +122,9 @@ export function WorktreeRow({ worktree, dragOverId, draggingId, isNew }: Props) 
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault()
             selectWorktree(worktree.projectId, worktree.id)
-          } else if (e.key === 'Delete' && !worktree.isMain) {
+          } else if ((e.key === 'Delete' || (e.key === 'Backspace' && e.metaKey)) && !worktree.isMain && e.currentTarget === e.target) {
             e.preventDefault()
-            if (skipDeleteConfirm) {
-              removeWorktree(worktree.projectId, worktree.id)
-            } else {
-              rowDispatch({ type: 'SHOW_DELETE_CONFIRM' })
-            }
+            requestDeleteWorktree()
           }
         }}
         onContextMenu={(e) => {

--- a/src/renderer/components/Sidebar/WorktreeRow.tsx
+++ b/src/renderer/components/Sidebar/WorktreeRow.tsx
@@ -120,6 +120,13 @@ export function WorktreeRow({ worktree, dragOverId, draggingId, isNew }: Props) 
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault()
             selectWorktree(worktree.projectId, worktree.id)
+          } else if (e.key === 'Delete' && !worktree.isMain) {
+            e.preventDefault()
+            if (skipDeleteConfirm) {
+              removeWorktree(worktree.projectId, worktree.id)
+            } else {
+              rowDispatch({ type: 'SHOW_DELETE_CONFIRM' })
+            }
           }
         }}
         onContextMenu={(e) => {


### PR DESCRIPTION
## Summary

- Adds keyboard shortcut: pressing `Delete` on a focused worktree row triggers deletion
- Respects the existing "don't ask again" preference — skips confirmation dialog if set, otherwise shows it
- Main worktree is guarded (`!worktree.isMain`) — same behaviour as the context menu

## Test plan

- [x] Tab to or click a non-main worktree row to focus it
- [x] Press `Delete` — confirmation dialog should appear
- [x] Confirm deletion — worktree is removed
- [x] Enable "don't ask again" in the dialog, then press `Delete` on another worktree — should delete immediately without dialog
- [x] Press `Delete` on the main worktree — nothing should happen