### PR TITLE
fix: suppress spurious error dialog after OTA restart

### DIFF
--- a/src/main/services/autoUpdate.ts
+++ b/src/main/services/autoUpdate.ts
@@ -20,6 +20,7 @@ const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000 // 4 hours
 let checkTimer: ReturnType<typeof setTimeout> | null = null
 let checkInterval: ReturnType<typeof setInterval> | null = null
 let isDownloading = false
+let isInstallingUpdate = false
 let activeWindow: BrowserWindow | null = null
 
 /** Safe IPC send - guards against destroyed window. */
@@ -76,6 +77,9 @@ export function initAutoUpdater(mainWindow: BrowserWindow): void {
 
   autoUpdater.on('error', (err: Error) => {
     isDownloading = false
+    // Suppress errors that fire during quit-and-install — the app is
+    // relaunching and the error is an artifact of the process teardown.
+    if (isInstallingUpdate) return
     logger.error('Auto-updater error', err)
     sendToRenderer(mainWindow, 'updater:error', {
       message: err.message,
@@ -148,6 +152,7 @@ export function downloadUpdate(): void {
 
 /** Quit and install the downloaded update. Called via IPC from renderer. */
 export function installUpdate(): void {
+  isInstallingUpdate = true
   // isSilent=false (show installer), isForceRunAfter=true (relaunch after)
   autoUpdater.quitAndInstall(false, true)
 }

--- a/src/main/services/autoUpdate.ts
+++ b/src/main/services/autoUpdate.ts
@@ -153,6 +153,14 @@ export function downloadUpdate(): void {
 /** Quit and install the downloaded update. Called via IPC from renderer. */
 export function installUpdate(): void {
   isInstallingUpdate = true
-  // isSilent=false (show installer), isForceRunAfter=true (relaunch after)
-  autoUpdater.quitAndInstall(false, true)
+  try {
+    // isSilent=false (show installer), isForceRunAfter=true (relaunch after)
+    autoUpdater.quitAndInstall(false, true)
+  } catch (err) {
+    isInstallingUpdate = false
+    throw err
+  }
+  // Safety net: if the process hasn't exited within 5s (e.g. dev mode or a
+  // failed quit), clear the flag so real errors aren't silently swallowed.
+  setTimeout(() => { isInstallingUpdate = false }, 5_000)
 }


### PR DESCRIPTION
When quitAndInstall() is called, electron-updater emits an error event as an artifact of process teardown. This error was reaching the renderer before the window closed, causing a false error dialog to flash on screen even though the restart succeeded. Guard the error handler with an isInstallingUpdate flag set just before quitAndInstall() is invoked.

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-

## Layers touched

<!-- Check which layers this PR modifies. Helps reviewers know what to look at. -->

- [ ] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [ ] **Renderer** (`src/renderer/`) — components, stores, lib
- [ ] **Styles** (`App.css`)

## Changes

<!-- Key files changed and why. Group by area if helpful. -->

**Sidebar / Center / Right panel:**
-

**Stores** (`projects.ts` / `sessions.ts` / `ui.ts`):
-

**Services** (`git.ts` / `claude.ts` / `github.ts` / `pty.ts`):
-

**IPC** (`main/ipc.ts` → `preload/index.ts` → `lib/ipc.ts`):
-

<!-- Remove sections above that don't apply. -->

## How to test

<!-- Steps to verify. Include which panel/area to look at. -->

1. `yarn dev`
2.

## Screenshots

<!-- Before/after if UI changed. Remove if not applicable. -->

## Checklist

- [ ] Self-reviewed the diff
- [ ] Tested locally with `yarn dev`
- [ ] Types pass — `yarn typecheck`
- [ ] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store
