### PR TITLE
feat(sidebar): add project avatars from GitHub org

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -171,6 +171,8 @@ export function registerIpcHandlers(): void {
     githubService.getChecks(worktreePath, forceRefresh))
   ipcMain.handle('github:getDeployments', (_e, worktreePath: string, forceRefresh?: boolean) =>
     githubService.getDeployments(worktreePath, forceRefresh))
+  ipcMain.handle('github:getOwnerAvatarUrl', (_e, cwd: string) =>
+    githubService.getOwnerAvatarUrl(cwd))
   ipcMain.handle('github:getGitSyncStatus', (_e, worktreePath: string, baseBranch: string, forceRefresh?: boolean) =>
     githubService.getGitSyncStatus(worktreePath, baseBranch, forceRefresh)
   )

--- a/src/main/services/github.ts
+++ b/src/main/services/github.ts
@@ -326,14 +326,21 @@ class GitHubService {
   private avatarCache = new ServiceCache<string>(Infinity)
 
   async getOwnerAvatarUrl(cwd: string): Promise<string> {
-    return this.avatarCache.get(cwd, async () => {
-      const nwo = await resolveNwo(cwd)
-      const raw = await this.gh(
-        ['api', `repos/${nwo}`, '--jq', '.owner.avatar_url'],
-        cwd
-      )
-      return raw || ''
-    })
+    const nwo = await resolveNwo(cwd)
+    try {
+      return await this.avatarCache.get(nwo, async () => {
+        const raw = await this.gh(
+          ['api', `repos/${nwo}`, '--jq', '.owner.avatar_url'],
+          cwd,
+          true
+        )
+        const url = raw.trim()
+        if (!url) throw new Error('Empty avatar URL')
+        return url
+      })
+    } catch {
+      return ''
+    }
   }
 
   async getGitSyncStatus(worktreePath: string, baseBranch: string, _forceRefresh?: boolean): Promise<GitSyncStatus> {

--- a/src/main/services/github.ts
+++ b/src/main/services/github.ts
@@ -323,6 +323,19 @@ class GitHubService {
     this.prCache.invalidate(worktreePath)
   }
 
+  private avatarCache = new ServiceCache<string>(Infinity)
+
+  async getOwnerAvatarUrl(cwd: string): Promise<string> {
+    return this.avatarCache.get(cwd, async () => {
+      const nwo = await resolveNwo(cwd)
+      const raw = await this.gh(
+        ['api', `repos/${nwo}`, '--jq', '.owner.avatar_url'],
+        cwd
+      )
+      return raw || ''
+    })
+  }
+
   async getGitSyncStatus(worktreePath: string, baseBranch: string, _forceRefresh?: boolean): Promise<GitSyncStatus> {
     const result: GitSyncStatus = {
       uncommittedChanges: 0,

--- a/src/main/services/storage.ts
+++ b/src/main/services/storage.ts
@@ -33,6 +33,7 @@ export interface StorageData {
     path: string
     createdAt: number
     settings?: StorageProjectSettings
+    avatarUrl?: string
   }>
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -177,6 +177,8 @@ const api = {
       ipcRenderer.invoke('github:getChecks', worktreePath, forceRefresh),
     getDeployments: (worktreePath: string, forceRefresh?: boolean) =>
       ipcRenderer.invoke('github:getDeployments', worktreePath, forceRefresh),
+    getOwnerAvatarUrl: (cwd: string) =>
+      ipcRenderer.invoke('github:getOwnerAvatarUrl', cwd) as Promise<string>,
     getGitSyncStatus: (worktreePath: string, baseBranch: string, forceRefresh?: boolean) =>
       ipcRenderer.invoke('github:getGitSyncStatus', worktreePath, baseBranch, forceRefresh),
     getCheckRunLog: (worktreePath: string, checkUrl: string) =>

--- a/src/renderer/components/Sidebar/ProjectList.tsx
+++ b/src/renderer/components/Sidebar/ProjectList.tsx
@@ -14,6 +14,38 @@ interface Props {
   onAddWorktree: (projectId: string) => void
 }
 
+// ─── ProjectAvatar ────────────────────────────────────────────────────────────
+
+function ProjectAvatar({ name, avatarUrl }: { name: string; avatarUrl?: string }) {
+  const [failed, setFailed] = useState(false)
+  const onError = useCallback(() => setFailed(true), [])
+
+  if (avatarUrl && !failed) {
+    return (
+      <img
+        src={avatarUrl}
+        width={18}
+        height={18}
+        alt={name}
+        onError={onError}
+        className="project-avatar"
+      />
+    )
+  }
+
+  // Letter avatar fallback - deterministic color from name
+  const letter = name.charAt(0).toUpperCase() || '?'
+  const hue = name.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0) % 360
+  return (
+    <div
+      className="project-avatar project-avatar--letter"
+      style={{ background: `hsl(${hue}, 55%, 40%)` }}
+    >
+      {letter}
+    </div>
+  )
+}
+
 // ─── ProjectGroupRow state ────────────────────────────────────────────────────
 
 type GroupRowState = { menu: { x: number; y: number } | null; wtDraggingId: string | null; wtDragOverId: string | null }
@@ -160,6 +192,7 @@ function ProjectGroupRow({
         }}
       >
         <span className={`project-chevron ${isExpanded ? 'expanded' : ''}`}>&#9654;</span>
+        <ProjectAvatar name={project.name} avatarUrl={project.avatarUrl} />
         <span className="project-name">{project.name}</span>
 
         {!isExpanded && notifyStatus && (

--- a/src/renderer/components/Sidebar/ProjectList.tsx
+++ b/src/renderer/components/Sidebar/ProjectList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useReducer } from 'react'
+import { useMemo, useState, useReducer, useCallback } from 'react'
 import { useProjectsStore } from '@/store/projects'
 import { useUIStore } from '@/store/ui'
 import { Tooltip } from '@/components/shared/Tooltip'

--- a/src/renderer/components/Sidebar/ProjectList.tsx
+++ b/src/renderer/components/Sidebar/ProjectList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useReducer, useCallback } from 'react'
+import { useMemo, useState, useReducer, useCallback, useEffect } from 'react'
 import { useProjectsStore } from '@/store/projects'
 import { useUIStore } from '@/store/ui'
 import { Tooltip } from '@/components/shared/Tooltip'
@@ -20,13 +20,17 @@ function ProjectAvatar({ name, avatarUrl }: { name: string; avatarUrl?: string }
   const [failed, setFailed] = useState(false)
   const onError = useCallback(() => setFailed(true), [])
 
+  // Reset failed state when avatarUrl changes (e.g. backfill arrives)
+  useEffect(() => { setFailed(false) }, [avatarUrl])
+
   if (avatarUrl && !failed) {
     return (
       <img
         src={avatarUrl}
         width={18}
         height={18}
-        alt={name}
+        alt=""
+        aria-hidden="true"
         onError={onError}
         className="project-avatar"
       />
@@ -39,6 +43,7 @@ function ProjectAvatar({ name, avatarUrl }: { name: string; avatarUrl?: string }
   return (
     <div
       className="project-avatar project-avatar--letter"
+      aria-hidden="true"
       style={{ background: `hsl(${hue}, 55%, 40%)` }}
     >
       {letter}

--- a/src/renderer/lib/ipc.ts
+++ b/src/renderer/lib/ipc.ts
@@ -157,6 +157,8 @@ export const github = {
     api().github.getChecks(worktreePath, forceRefresh),
   getDeployments: (worktreePath: string, forceRefresh?: boolean) =>
     api().github.getDeployments(worktreePath, forceRefresh),
+  getOwnerAvatarUrl: (cwd: string): Promise<string> =>
+    api().github.getOwnerAvatarUrl(cwd),
   getGitSyncStatus: (worktreePath: string, baseBranch: string, forceRefresh?: boolean) =>
     api().github.getGitSyncStatus(worktreePath, baseBranch, forceRefresh),
   getCheckRunLog: (worktreePath: string, checkUrl: string) =>

--- a/src/renderer/store/projects.ts
+++ b/src/renderer/store/projects.ts
@@ -152,6 +152,22 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
           ipc.git.getRemoteBranches(p.path).catch(() => {})
         }
       }, 500)
+
+      // Backfill GitHub org avatars for projects that don't have one yet.
+      // Non-blocking — updates trickle in after the initial paint.
+      for (const p of projects) {
+        if (!p.avatarUrl) {
+          ipc.github.getOwnerAvatarUrl(p.path).then((url) => {
+            if (!url) return
+            const current = get().projects
+            const updated = current.map((proj) =>
+              proj.id === p.id ? { ...proj, avatarUrl: url } : proj
+            )
+            set({ projects: updated })
+            ipc.storage.save({ projects: updated.map(serializeProject) })
+          }).catch(() => {})
+        }
+      }
     } catch {
       set({ loading: false })
     }
@@ -194,6 +210,17 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
     const projects = [...get().projects, project]
     set({ projects })
     await ipc.storage.save({ projects: projects.map(serializeProject) })
+
+    // Fetch GitHub org avatar in background
+    ipc.github.getOwnerAvatarUrl(path).then((url) => {
+      if (!url) return
+      const current = get().projects
+      const updated = current.map((p) =>
+        p.id === id ? { ...p, avatarUrl: url } : p
+      )
+      set({ projects: updated })
+      ipc.storage.save({ projects: updated.map(serializeProject) })
+    }).catch(() => {})
   },
 
   removeProject: async (id: string) => {

--- a/src/renderer/store/projects.ts
+++ b/src/renderer/store/projects.ts
@@ -155,18 +155,30 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
 
       // Backfill GitHub org avatars for projects that don't have one yet.
       // Non-blocking — updates trickle in after the initial paint.
-      for (const p of projects) {
-        if (!p.avatarUrl) {
-          ipc.github.getOwnerAvatarUrl(p.path).then((url) => {
-            if (!url) return
-            const current = get().projects
-            const updated = current.map((proj) =>
-              proj.id === p.id ? { ...proj, avatarUrl: url } : proj
-            )
-            set({ projects: updated })
-            ipc.storage.save({ projects: updated.map(serializeProject) })
-          }).catch(() => {})
-        }
+      // Fetches run concurrently; results are batched into a single state + save.
+      const needsAvatar = projects.filter((p) => !p.avatarUrl)
+      if (needsAvatar.length > 0) {
+        Promise.allSettled(
+          needsAvatar.map(async (p) => {
+            const url = await ipc.github.getOwnerAvatarUrl(p.path)
+            return url ? { id: p.id, url } : null
+          })
+        ).then((results) => {
+          const filled = results
+            .filter((r): r is PromiseFulfilledResult<{ id: string; url: string } | null> => r.status === 'fulfilled')
+            .map((r) => r.value)
+            .filter((v): v is { id: string; url: string } => v !== null)
+          if (filled.length === 0) return
+
+          const lookup = new Map(filled.map((f) => [f.id, f.url]))
+          const current = get().projects
+          const updated = current.map((proj) => {
+            const url = lookup.get(proj.id)
+            return url ? { ...proj, avatarUrl: url } : proj
+          })
+          set({ projects: updated })
+          void ipc.storage.save({ projects: updated.map(serializeProject) }).catch(() => {})
+        })
       }
     } catch {
       set({ loading: false })
@@ -219,7 +231,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
         p.id === id ? { ...p, avatarUrl: url } : p
       )
       set({ projects: updated })
-      ipc.storage.save({ projects: updated.map(serializeProject) })
+      void ipc.storage.save({ projects: updated.map(serializeProject) }).catch(() => {})
     }).catch(() => {})
   },
 

--- a/src/renderer/store/projects.ts
+++ b/src/renderer/store/projects.ts
@@ -30,7 +30,8 @@ function serializeProject(p: Project) {
     name: p.name,
     path: p.path,
     createdAt: p.createdAt,
-    settings: p.settings
+    settings: p.settings,
+    avatarUrl: p.avatarUrl
   }
 }
 

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -253,7 +253,7 @@
   align-items: center;
   justify-content: center;
   color: #fff;
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: var(--weight-semibold);
   user-select: none;
   line-height: 1;

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -241,6 +241,24 @@
 .badge--danger { background: var(--red-tint-15); color: var(--red); }
 .badge--muted { background: var(--overlay-6); color: var(--text-muted); }
 
+.project-avatar {
+  width: 18px;
+  height: 18px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.project-avatar--letter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 11px;
+  font-weight: var(--weight-semibold);
+  user-select: none;
+  line-height: 1;
+}
+
 .project-name {
   flex: 1;
   min-width: 0;

--- a/src/renderer/types/git.ts
+++ b/src/renderer/types/git.ts
@@ -39,6 +39,8 @@ export interface Project {
   worktrees: Worktree[]
   createdAt: number
   settings?: ProjectSettings
+  /** GitHub org/user avatar URL, fetched automatically */
+  avatarUrl?: string
   /** Detected platform — 'mobile' shows the Simulator tab */
   platform?: ProjectPlatform
   /** Detected mobile framework — enables framework-specific debug controls */


### PR DESCRIPTION
Closes #32

## Summary

- Add project avatars to the sidebar, sourced from the GitHub repository owner's avatar
- Show an image avatar when available, with a deterministic letter-color fallback
- Avatars are fetched in the background and persisted to storage so they only load once

## Layers touched

- [x] **Main process** (`src/main/`) — services, IPC handlers
- [x] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib

## Changes

**Sidebar / Center / Right panel:**
- New `ProjectAvatar` component in `ProjectList.tsx` - renders an `<img>` from the avatar URL with `onError` fallback to a colored letter avatar (hue derived deterministically from the project name)
- Avatar inserted next to the project name in the sidebar row

**Stores** (`projects.ts`):
- `loadProjects` backfills `avatarUrl` for existing projects that don't have one yet (non-blocking, updates trickle in after initial paint)
- `addProject` fetches the avatar in the background immediately after creation
- `serializeProject` persists `avatarUrl` to storage

**Services** (`github.ts`):
- New `getOwnerAvatarUrl(cwd)` method - calls `gh api repos/{nwo}` and extracts `.owner.avatar_url`
- Uses `ServiceCache` with `Infinity` TTL (avatar URLs are stable)

**IPC** (`main/ipc.ts` -> `preload/index.ts` -> `lib/ipc.ts`):
- New `github:getOwnerAvatarUrl` channel threaded through all 3 layers

**Types** (`types/git.ts`):
- Added optional `avatarUrl` field to `Project` interface

**Styles** (`sidebar.css`):
- `.project-avatar` base class (18x18, rounded corners)
- `.project-avatar--letter` variant (centered white text, HSL background)

## How to test

1. `yarn dev`
2. Check the sidebar - each project should show its GitHub org/user avatar next to the name
3. Add a new project from a GitHub repo - avatar should appear shortly after
4. For non-GitHub projects, a colored letter fallback should display
5. Restart the app - avatars should load instantly from cache (no re-fetch flicker)

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [x] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store