### PR TITLE
feat: add chat compact mode for denser CLI-like display

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -120,6 +120,22 @@ export default function App() {
     return unsub
   }, [])
 
+  // Apply chat density mode on mount and subscribe to changes
+  useEffect(() => {
+    const applyDensity = (compact: boolean) => {
+      document.documentElement.setAttribute('data-density', compact ? 'compact' : 'default')
+    }
+    applyDensity(useUIStore.getState().chatCompactMode)
+    let prev = useUIStore.getState().chatCompactMode
+    const unsub = useUIStore.subscribe((state) => {
+      if (state.chatCompactMode !== prev) {
+        prev = state.chatCompactMode
+        applyDensity(state.chatCompactMode)
+      }
+    })
+    return unsub
+  }, [])
+
   // Apply UI zoom on mount
   useEffect(() => {
     try { appWindow.setZoomFactor(useUIStore.getState().uiZoom) } catch {}

--- a/src/renderer/components/Settings/SettingsAppearance.tsx
+++ b/src/renderer/components/Settings/SettingsAppearance.tsx
@@ -66,6 +66,8 @@ export function SettingsAppearance() {
   const setActivityIndicatorStyle = useUIStore((s) => s.setActivityIndicatorStyle)
   const streamingAnimation = useUIStore((s) => s.streamingAnimation)
   const setStreamingAnimation = useUIStore((s) => s.setStreamingAnimation)
+  const chatCompactMode = useUIStore((s) => s.chatCompactMode)
+  const setChatCompactMode = useUIStore((s) => s.setChatCompactMode)
 
   const handleSelect = (theme: ThemePalette) => {
     setTheme(theme.id)
@@ -134,6 +136,14 @@ export function SettingsAppearance() {
         horizontal
       >
         <Toggle checked={streamingAnimation} onChange={setStreamingAnimation} />
+      </FormField>
+
+      <FormField
+        label={t('appearance.chatCompactMode')}
+        hint={t('appearance.chatCompactModeHint')}
+        horizontal
+      >
+        <Toggle checked={chatCompactMode} onChange={setChatCompactMode} />
       </FormField>
 
       {groupBuiltinThemes().map(({ group, themes }) => (

--- a/src/renderer/lib/storageKeys.ts
+++ b/src/renderer/lib/storageKeys.ts
@@ -80,6 +80,7 @@ export const SK = {
   streamingAnimation:         `${prefix}:streamingAnimation`,
   skipDeleteWorktreeConfirm:  `${prefix}:skipDeleteWorktreeConfirm`,
   tabDisplayMode:             `${prefix}:tabDisplayMode`,
+  chatCompactMode:            `${prefix}:chatCompactMode`,
 
   // ── i18n ───────────────────────────────────────────────────────────────
   language:                   `${prefix}:language`,

--- a/src/renderer/locales/en/settings.json
+++ b/src/renderer/locales/en/settings.json
@@ -60,7 +60,9 @@
     "indicatorDots": "Dots",
     "indicatorWaveform": "Waveform",
     "streamingAnimation": "Streaming Animation",
-    "streamingAnimationHint": "Animate words as they stream in"
+    "streamingAnimationHint": "Animate words as they stream in",
+    "chatCompactMode": "Chat Compact Mode",
+    "chatCompactModeHint": "Reduce spacing and font sizes for a denser, CLI-like chat display"
   },
   "ai": {
     "defaultModel": "Default Model",

--- a/src/renderer/locales/id/settings.json
+++ b/src/renderer/locales/id/settings.json
@@ -60,7 +60,9 @@
     "indicatorDots": "Titik",
     "indicatorWaveform": "Gelombang",
     "streamingAnimation": "Animasi Streaming",
-    "streamingAnimationHint": "Animasikan kata saat streaming masuk"
+    "streamingAnimationHint": "Animasikan kata saat streaming masuk",
+    "chatCompactMode": "Mode Kompak Chat",
+    "chatCompactModeHint": "Kurangi jarak dan ukuran font untuk tampilan chat yang lebih padat seperti CLI"
   },
   "ai": {
     "defaultModel": "Model Default",

--- a/src/renderer/locales/ja/settings.json
+++ b/src/renderer/locales/ja/settings.json
@@ -60,7 +60,9 @@
     "indicatorDots": "ドット",
     "indicatorWaveform": "ウェーブフォーム",
     "streamingAnimation": "ストリーミングアニメーション",
-    "streamingAnimationHint": "ストリーミング時にワードごとにアニメーション表示する"
+    "streamingAnimationHint": "ストリーミング時にワードごとにアニメーション表示する",
+    "chatCompactMode": "チャットコンパクトモード",
+    "chatCompactModeHint": "間隔とフォントサイズを縮小し、CLIのようなチャット表示にする"
   },
   "ai": {
     "defaultModel": "デフォルトモデル",

--- a/src/renderer/store/ui/settings.ts
+++ b/src/renderer/store/ui/settings.ts
@@ -69,6 +69,7 @@ export interface SettingsSlice {
   // UI preferences
   streamingAnimation: boolean
   tabDisplayMode: TabDisplayMode
+  chatCompactMode: boolean
 
   // Experimental
   experimentalCapture: boolean
@@ -114,6 +115,7 @@ export interface SettingsSlice {
   setToastDuration: (duration: ToastDuration) => void
   setStreamingAnimation: (v: boolean) => void
   setTabDisplayMode: (mode: TabDisplayMode) => void
+  setChatCompactMode: (v: boolean) => void
   setExperimentalCapture: (v: boolean) => void
   setBottomTerminalEnabled: (v: boolean) => void
   setExperimentalNoVirtualization: (v: boolean) => void
@@ -171,6 +173,8 @@ export const createSettingsSlice: StateCreator<UIState, [], [], SettingsSlice> =
     const v = loadStr(SK.tabDisplayMode, 'icons')
     return (v === 'icons' || v === 'labels' || v === 'both') ? v as TabDisplayMode : 'icons'
   })(),
+
+  chatCompactMode: loadBool(SK.chatCompactMode, false),
 
   experimentalCapture: loadBool(SK.experimentalCapture, false),
   bottomTerminalEnabled: loadBool(SK.bottomTerminalEnabled, false),
@@ -259,6 +263,7 @@ export const createSettingsSlice: StateCreator<UIState, [], [], SettingsSlice> =
   setToastDuration: (duration) => { localStorage.setItem(SK.toastDuration, String(duration)); set({ toastDuration: duration }) },
   setStreamingAnimation: (v) => { localStorage.setItem(SK.streamingAnimation, String(v)); set({ streamingAnimation: v }) },
   setTabDisplayMode: (mode) => { localStorage.setItem(SK.tabDisplayMode, mode); set({ tabDisplayMode: mode }) },
+  setChatCompactMode: (v) => { localStorage.setItem(SK.chatCompactMode, String(v)); set({ chatCompactMode: v }) },
   setExperimentalCapture: (v) => { localStorage.setItem(SK.experimentalCapture, String(v)); set({ experimentalCapture: v }) },
   setBottomTerminalEnabled: (v) => { localStorage.setItem(SK.bottomTerminalEnabled, String(v)); set({ bottomTerminalEnabled: v }) },
   setExperimentalNoVirtualization: (v) => { localStorage.setItem(SK.noVirtualization, String(v)); set({ experimentalNoVirtualization: v }) },

--- a/src/renderer/styles/compact-mode.css
+++ b/src/renderer/styles/compact-mode.css
@@ -1,0 +1,323 @@
+/* ── Chat Compact Mode ──────────────────────────────────────────────────
+ *
+ * When data-density="compact" is set on <html>, these overrides reduce
+ * spacing, padding, font sizes, and line heights in the chat area to
+ * create a denser, CLI-like display.
+ *
+ * Only chat-related selectors are targeted - sidebar, settings, and
+ * other UI areas are not affected.
+ */
+
+/* ── Chat container / wrapper ──────────────────────────────────────── */
+[data-density="compact"] .chat-container {
+  padding: var(--space-10) var(--space-16);
+  font-size: var(--text-md);
+  line-height: 1.4;
+}
+
+[data-density="compact"] .chat-virtuoso-wrapper {
+  font-size: var(--text-md);
+  line-height: 1.4;
+}
+
+/* ── Per-item horizontal padding ───────────────────────────────────── */
+[data-density="compact"] .chat-virtuoso-item,
+[data-density="compact"] .chat-plain-item {
+  padding: 0 var(--space-16);
+}
+
+/* ── Message gap ───────────────────────────────────────────────────── */
+[data-density="compact"] .chat-msg {
+  margin-bottom: var(--space-12);
+}
+
+[data-density="compact"] .chat-msg-assistant:has(.tcg) {
+  margin-bottom: var(--space-6);
+}
+
+/* ── User bubble ───────────────────────────────────────────────────── */
+[data-density="compact"] .chat-msg-user-bubble {
+  padding: var(--space-7) var(--space-12);
+  font-size: var(--text-md);
+  line-height: 1.4;
+}
+
+/* ── Assistant content ─────────────────────────────────────────────── */
+[data-density="compact"] .chat-msg-assistant-content {
+  font-size: var(--text-md);
+  line-height: 1.4;
+}
+
+[data-density="compact"] .chat-msg-assistant-content p {
+  margin: 0 0 var(--space-6) 0;
+}
+
+[data-density="compact"] .chat-msg-assistant-content ul,
+[data-density="compact"] .chat-msg-assistant-content ol {
+  margin: 0 0 var(--space-6) 0;
+  padding-left: var(--space-16);
+}
+
+[data-density="compact"] .chat-msg-assistant-content li {
+  margin-bottom: var(--space-2);
+}
+
+[data-density="compact"] .chat-msg-assistant-content code {
+  font-size: var(--text-base);
+  padding: var(--space-1) var(--space-4);
+}
+
+[data-density="compact"] .chat-msg-assistant-content pre {
+  padding: var(--space-8) var(--space-10);
+  margin: var(--space-6) 0;
+  font-size: var(--text-md);
+  line-height: 1.4;
+}
+
+[data-density="compact"] .chat-msg-assistant-content blockquote {
+  margin: var(--space-6) 0;
+  padding: var(--space-2) 0 var(--space-2) var(--space-10);
+}
+
+[data-density="compact"] .chat-msg-assistant-content h1,
+[data-density="compact"] .chat-msg-assistant-content h2,
+[data-density="compact"] .chat-msg-assistant-content h3 {
+  margin: var(--space-10) 0 var(--space-4) 0;
+}
+
+[data-density="compact"] .chat-msg-assistant-content h1 { font-size: var(--text-3xl); }
+[data-density="compact"] .chat-msg-assistant-content h2 { font-size: var(--text-2xl); }
+[data-density="compact"] .chat-msg-assistant-content h3 { font-size: var(--text-xl); }
+[data-density="compact"] .chat-msg-assistant-content h4 { font-size: var(--text-lg); }
+
+[data-density="compact"] .chat-msg-assistant-content hr {
+  margin: var(--space-10) 0;
+}
+
+[data-density="compact"] .chat-msg-assistant-content table {
+  font-size: var(--text-md);
+  margin: var(--space-8) 0;
+}
+
+[data-density="compact"] .chat-msg-assistant-content th,
+[data-density="compact"] .chat-msg-assistant-content td {
+  padding: var(--space-4) var(--space-8);
+}
+
+/* ── Tool call groups ──────────────────────────────────────────────── */
+[data-density="compact"] .tcg {
+  margin: var(--space-1) 0;
+}
+
+[data-density="compact"] .tcg-header {
+  padding: var(--space-3) 0;
+  gap: var(--space-6);
+  font-size: var(--text-md);
+}
+
+[data-density="compact"] .tcg-label {
+  font-size: var(--text-md);
+}
+
+[data-density="compact"] .tcg-body {
+  padding: var(--space-2) 0 var(--space-2) var(--space-6);
+}
+
+[data-density="compact"] .tcg-row {
+  margin-bottom: var(--space-1);
+}
+
+[data-density="compact"] .tcg-row-open {
+  margin-bottom: var(--space-2);
+}
+
+[data-density="compact"] .tcg-row-main {
+  padding: var(--space-3) var(--space-6);
+  font-size: var(--text-md);
+  gap: var(--space-4);
+}
+
+[data-density="compact"] .tcg-row-name {
+  font-size: var(--text-md);
+}
+
+[data-density="compact"] .tcg-row-detail {
+  padding: 0 var(--space-4) var(--space-4) var(--space-24);
+}
+
+[data-density="compact"] .tcg-row-code {
+  padding: var(--space-6) var(--space-8);
+  font-size: var(--text-base);
+  line-height: 1.4;
+}
+
+[data-density="compact"] .tcg-summary {
+  font-size: var(--text-base);
+}
+
+[data-density="compact"] .tcg-diff {
+  font-size: var(--text-base);
+}
+
+[data-density="compact"] .tcg-file-badge {
+  padding: var(--space-1) var(--space-6);
+  font-size: var(--text-base);
+}
+
+/* ── Interleaved text inside tool groups ───────────────────────────── */
+[data-density="compact"] .tcg-text {
+  padding: var(--space-3) 0 var(--space-3) var(--space-16);
+  font-size: var(--text-md);
+  line-height: 1.4;
+}
+
+[data-density="compact"] .tcg-text p {
+  margin: 0 0 var(--space-3) 0;
+}
+
+[data-density="compact"] .tcg-text code {
+  font-size: var(--text-sm);
+}
+
+[data-density="compact"] .tcg-text pre {
+  padding: var(--space-6) var(--space-8);
+  margin: var(--space-6) 0;
+  font-size: var(--text-base);
+  line-height: 1.4;
+}
+
+[data-density="compact"] .tcg-text th,
+[data-density="compact"] .tcg-text td {
+  padding: var(--space-4) var(--space-8);
+}
+
+[data-density="compact"] .tcg-error {
+  padding: var(--space-2) 0 var(--space-2) var(--space-16);
+  font-size: var(--text-base);
+}
+
+/* ── Todo list ─────────────────────────────────────────────────────── */
+[data-density="compact"] .tcg-todo-list {
+  padding: var(--space-4) var(--space-6);
+}
+
+[data-density="compact"] .tcg-todo-item {
+  padding: var(--space-2) var(--space-1);
+  font-size: var(--text-base);
+  line-height: 1.35;
+}
+
+/* ── Inline diff ───────────────────────────────────────────────────── */
+[data-density="compact"] .tcg-inline-diff {
+  font-size: var(--text-base);
+  line-height: 1.4;
+}
+
+/* ── Grep results ──────────────────────────────────────────────────── */
+[data-density="compact"] .tcg-grep-results {
+  font-size: var(--text-base);
+  padding: var(--space-4) 0;
+}
+
+[data-density="compact"] .tcg-grep-line {
+  padding: var(--space-1) var(--space-6);
+}
+
+/* ── Glob results ──────────────────────────────────────────────────── */
+[data-density="compact"] .tcg-glob-results {
+  gap: var(--space-2);
+}
+
+/* ── Input area ────────────────────────────────────────────────────── */
+[data-density="compact"] .chat-input-float {
+  margin: 0 var(--space-8) var(--space-8);
+}
+
+[data-density="compact"] .chat-input-container {
+  padding: var(--space-8) var(--space-12) var(--space-6);
+}
+
+[data-density="compact"] .chat-input {
+  font-size: var(--text-md);
+  line-height: 1.4;
+  min-height: var(--space-20);
+}
+
+[data-density="compact"] .chat-input-backdrop {
+  font-size: var(--text-md);
+  line-height: 1.4;
+}
+
+[data-density="compact"] .chat-bottom-bar {
+  padding: var(--space-4) var(--space-10) var(--space-8);
+}
+
+/* ── System messages ───────────────────────────────────────────────── */
+[data-density="compact"] .chat-msg-system-content {
+  font-size: var(--text-md);
+  padding: var(--space-6) var(--space-10);
+}
+
+/* ── Compact boundary divider ──────────────────────────────────────── */
+[data-density="compact"] .chat-msg-compact-boundary {
+  padding: var(--space-4) var(--space-16);
+  margin: var(--space-2) 0;
+}
+
+/* ── Snippet and terminal cards ────────────────────────────────────── */
+[data-density="compact"] .chat-msg-snippet-card-content,
+[data-density="compact"] .chat-msg-terminal-card-content {
+  padding: var(--space-4) var(--space-6);
+}
+
+[data-density="compact"] .chat-msg-snippet-card-header,
+[data-density="compact"] .chat-msg-terminal-card-header {
+  padding: var(--space-3) var(--space-6);
+  min-height: var(--space-24);
+}
+
+/* ── Turn footer and actions ───────────────────────────────────────── */
+[data-density="compact"] .turn-footer {
+  padding: var(--space-3) 0;
+  margin-top: var(--space-2);
+  gap: var(--space-4);
+}
+
+[data-density="compact"] .turn-actions {
+  padding-top: var(--space-2);
+  gap: var(--space-4);
+}
+
+/* ── Empty state ───────────────────────────────────────────────────── */
+[data-density="compact"] .chat-empty-hint {
+  gap: var(--space-8);
+}
+
+/* ── Prompt panels (ask-user, plan, tool-permission) ───────────────── */
+[data-density="compact"] .ask-user-prompt {
+  padding: var(--space-8) var(--space-12) var(--space-6);
+  gap: var(--space-8);
+}
+
+[data-density="compact"] .ask-user-header {
+  gap: var(--space-5);
+}
+
+[data-density="compact"] .plan-prompt {
+  padding: var(--space-8) var(--space-12) var(--space-6);
+  gap: var(--space-6);
+}
+
+[data-density="compact"] .plan-prompt-actions {
+  gap: var(--space-6);
+}
+
+[data-density="compact"] .tool-permission-prompt {
+  padding: var(--space-8) var(--space-10) var(--space-8);
+  gap: var(--space-6);
+}
+
+/* ── Input footer (file mentions, snippets) ────────────────────────── */
+[data-density="compact"] .chat-input-footer {
+  padding: var(--space-3) var(--space-10) var(--space-5);
+}

--- a/src/renderer/styles/compact-mode.css
+++ b/src/renderer/styles/compact-mode.css
@@ -52,6 +52,10 @@
   margin: 0 0 var(--space-6) 0;
 }
 
+[data-density="compact"] .chat-msg-assistant-content p:last-child {
+  margin-bottom: 0;
+}
+
 [data-density="compact"] .chat-msg-assistant-content ul,
 [data-density="compact"] .chat-msg-assistant-content ol {
   margin: 0 0 var(--space-6) 0;
@@ -173,6 +177,10 @@
 
 [data-density="compact"] .tcg-text p {
   margin: 0 0 var(--space-3) 0;
+}
+
+[data-density="compact"] .tcg-text p:last-child {
+  margin-bottom: 0;
 }
 
 [data-density="compact"] .tcg-text code {

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -8,6 +8,7 @@
 @import './chat-messages.css';
 @import './tool-calls.css';
 @import './chat-input.css';
+@import './compact-mode.css';
 @import './chat-images.css';
 @import './chat-queue.css';
 @import './prompts.css';


### PR DESCRIPTION
## Summary

- Adds a "Chat Compact Mode" toggle to Settings > Appearance that reduces spacing, padding, font sizes, and line heights in the chat area for a denser, CLI-like display
- Only affects chat-related elements - sidebar, settings, and other UI areas remain unchanged

## Layers touched

- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Settings:**
- `SettingsAppearance.tsx`: Added `chatCompactMode` toggle using `FormField` + `Toggle`

**Stores** (`ui/settings.ts`):
- New `chatCompactMode` boolean state with `setChatCompactMode` action, persisted via `localStorage`
- Added `chatCompactMode` storage key to `storageKeys.ts`

**App root** (`App.tsx`):
- `useEffect` that sets `data-density="compact"|"default"` on `<html>` and subscribes to store changes

**Styles** (`compact-mode.css`):
- 323-line stylesheet with `[data-density="compact"]` overrides targeting chat messages, tool call groups, user bubbles, assistant content, input area, prompts, and related elements

**i18n** (`en/`, `ja/`, `id/` settings.json):
- Added `chatCompactMode` and `chatCompactModeHint` translations for all three locales

## How to test

1. `yarn dev`
2. Open Settings > Appearance
3. Toggle "Chat Compact Mode" on
4. Verify chat messages, tool calls, and input area become denser with reduced spacing
5. Verify sidebar and settings panels are unaffected
6. Toggle off and confirm everything reverts to default spacing
7. Reload the app and confirm the setting persists

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer) — N/A, renderer-only change
- [x] New state is added to the correct Zustand store