### PR TITLE
feat(settings): dedicated Jira settings page with acli status

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -204,6 +204,7 @@ export function registerIpcHandlers(): void {
 
   // Jira (optional — only available if acli is installed)
   ipcMain.handle('jira:isAvailable', () => jiraService.isAvailable())
+  ipcMain.handle('jira:recheckAvailability', () => jiraService.recheckAvailability())
   ipcMain.handle('jira:getIssuesForBranch', (_e, worktreePath: string, overrideBaseUrl?: string) =>
     jiraService.getIssuesForBranch(worktreePath, overrideBaseUrl)
   )

--- a/src/main/services/jira.ts
+++ b/src/main/services/jira.ts
@@ -24,7 +24,7 @@ export interface JiraResult {
 }
 
 class JiraService {
-  // Cached per app session — acli installation doesn't change at runtime
+  // Cached availability flag, reset by recheckAvailability() after install
   private _available: boolean | null = null
 
   // Base URL detection cache: undefined = not yet attempted

--- a/src/main/services/jira.ts
+++ b/src/main/services/jira.ts
@@ -47,6 +47,11 @@ class JiraService {
     return this._available
   }
 
+  async recheckAvailability(): Promise<boolean> {
+    this._available = null
+    return this.isAvailable()
+  }
+
   /**
    * Detect the Jira base URL from the jira-cli config file.
    * jira-cli (ankitpokhrel/jira-cli) stores `server: https://yoursite.atlassian.net`

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -204,6 +204,7 @@ const api = {
   // Jira (optional — only available when acli is installed)
   jira: {
     isAvailable: () => ipcRenderer.invoke('jira:isAvailable') as Promise<boolean>,
+    recheckAvailability: () => ipcRenderer.invoke('jira:recheckAvailability') as Promise<boolean>,
     getIssuesForBranch: (worktreePath: string, overrideBaseUrl?: string) =>
       ipcRenderer.invoke('jira:getIssuesForBranch', worktreePath, overrideBaseUrl),
     getIssueByKey: (key: string, overrideBaseUrl?: string) =>

--- a/src/renderer/components/Settings/SettingsApps.tsx
+++ b/src/renderer/components/Settings/SettingsApps.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useCallback, useMemo, useState } from 'react'
+import { useReducer, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useShallow } from 'zustand/react/shallow'
 import { useUIStore } from '@/store/ui'
@@ -61,8 +61,6 @@ export function SettingsApps() {
   const { t } = useTranslation('settings')
   const webAppsEnabled = useUIStore((s) => s.webAppsEnabled)
   const setWebAppsEnabled = useUIStore((s) => s.setWebAppsEnabled)
-  const jiraBaseUrl = useUIStore((s) => s.jiraBaseUrl)
-  const setJiraBaseUrl = useUIStore((s) => s.setJiraBaseUrl)
   const embeddedApps = useUIStore(useShallow((s) => s.embeddedApps))
   const addEmbeddedApp = useUIStore((s) => s.addEmbeddedApp)
   const removeEmbeddedApp = useUIStore((s) => s.removeEmbeddedApp)
@@ -73,8 +71,6 @@ export function SettingsApps() {
   const appIds = useMemo(() => embeddedApps.map((a) => a.id), [embeddedApps])
   const { dragKey, overKey, onDragStart, onDragOver, onDragLeave, onDrop, onDragEnd } =
     useTabReorder(appIds, reorderEmbeddedApps)
-
-  const [jiraDraft, setJiraDraft] = useState(jiraBaseUrl)
 
   const [form, dispatch] = useReducer(formReducer, {
     name: '', url: '', error: '', pendingPreset: null, workspace: '',
@@ -116,22 +112,6 @@ export function SettingsApps() {
         <Toggle checked={webAppsEnabled} onChange={setWebAppsEnabled} />
       </div>
       <span className="settings-hint">{t('apps.enableHint')}</span>
-
-      <div className="settings-divider" />
-
-      <div className="settings-field">
-        <label className="settings-label">{t('apps.jiraBaseUrl')}</label>
-        <input
-          type="text"
-          className="settings-input"
-          value={jiraDraft}
-          onChange={(e) => setJiraDraft(e.target.value)}
-          onBlur={() => setJiraBaseUrl(jiraDraft)}
-          placeholder="https://yourcompany.atlassian.net"
-          spellCheck={false}
-        />
-        <span className="settings-hint">{t('apps.jiraBaseUrlHint')}</span>
-      </div>
 
       <div className="settings-divider" />
 

--- a/src/renderer/components/Settings/SettingsJira.tsx
+++ b/src/renderer/components/Settings/SettingsJira.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useReducer, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useUIStore } from '@/store/ui'
 import { jira, shell } from '@/lib/ipc'
@@ -11,39 +11,66 @@ type SaveState = 'idle' | 'saved'
 
 const ACLI_DOCS_URL = 'https://developer.atlassian.com/cloud/acli/guides/install-acli/'
 
+interface State {
+  acliStatus: AcliStatus
+  draft: string
+  saveState: SaveState
+}
+
+type Action =
+  | { type: 'setAcli'; status: AcliStatus }
+  | { type: 'setDraft'; value: string }
+  | { type: 'saved' }
+  | { type: 'resetSave' }
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'setAcli': return { ...state, acliStatus: action.status }
+    case 'setDraft': return { ...state, draft: action.value, saveState: 'idle' }
+    case 'saved': return { ...state, saveState: 'saved' }
+    case 'resetSave': return { ...state, saveState: 'idle' }
+  }
+}
+
 export function SettingsJira() {
   const { t } = useTranslation('settings')
   const jiraBaseUrl = useUIStore((s) => s.jiraBaseUrl)
   const setJiraBaseUrl = useUIStore((s) => s.setJiraBaseUrl)
 
-  const [acliStatus, setAcliStatus] = useState<AcliStatus>('checking')
-  const [jiraDraft, setJiraDraft] = useState(jiraBaseUrl)
+  const [state, dispatch] = useReducer(reducer, {
+    acliStatus: 'checking',
+    draft: jiraBaseUrl,
+    saveState: 'idle',
+  })
 
   useEffect(() => {
-    jira.isAvailable().then((ok: boolean) => setAcliStatus(ok ? 'installed' : 'not_installed'))
+    jira.isAvailable().then((ok: boolean) => dispatch({ type: 'setAcli', status: ok ? 'installed' : 'not_installed' }))
   }, [])
 
   const handleInstall = useCallback(async () => {
-    setAcliStatus('installing')
+    dispatch({ type: 'setAcli', status: 'installing' })
     try { await shell.installTool('acli') } catch { /* still recheck below */ }
-    setAcliStatus('checking')
+    dispatch({ type: 'setAcli', status: 'checking' })
     const ok = await jira.recheckAvailability()
-    setAcliStatus(ok ? 'installed' : 'not_installed')
+    dispatch({ type: 'setAcli', status: ok ? 'installed' : 'not_installed' })
   }, [])
 
   // ── Base URL save with brief "Saved" flash ──────────────────────────
-  const [saveState, setSaveState] = useState<SaveState>('idle')
-  const dirty = jiraDraft.trim() !== jiraBaseUrl
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => () => { if (saveTimerRef.current) clearTimeout(saveTimerRef.current) }, [])
+
+  const dirty = state.draft.trim() !== jiraBaseUrl
 
   const handleSave = useCallback(() => {
-    setJiraBaseUrl(jiraDraft.trim())
-    setSaveState('saved')
-    setTimeout(() => setSaveState('idle'), 1500)
-  }, [jiraDraft, setJiraBaseUrl])
+    setJiraBaseUrl(state.draft.trim())
+    dispatch({ type: 'saved' })
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+    saveTimerRef.current = setTimeout(() => dispatch({ type: 'resetSave' }), 1500)
+  }, [state.draft, setJiraBaseUrl])
 
   const dotState =
-    acliStatus === 'installed' ? 'success' as const
-      : acliStatus === 'not_installed' ? 'failure' as const
+    state.acliStatus === 'installed' ? 'success' as const
+      : state.acliStatus === 'not_installed' ? 'failure' as const
       : 'pending' as const
 
   return (
@@ -57,13 +84,13 @@ export function SettingsJira() {
         <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-8)' }}>
           <StatusDot state={dotState} />
           <span className="settings-label">
-            {acliStatus === 'checking' && t('jira.statusChecking')}
-            {acliStatus === 'installed' && t('jira.statusInstalled')}
-            {acliStatus === 'not_installed' && t('jira.statusNotInstalled')}
-            {acliStatus === 'installing' && t('jira.statusInstalling')}
+            {state.acliStatus === 'checking' && t('jira.statusChecking')}
+            {state.acliStatus === 'installed' && t('jira.statusInstalled')}
+            {state.acliStatus === 'not_installed' && t('jira.statusNotInstalled')}
+            {state.acliStatus === 'installing' && t('jira.statusInstalling')}
           </span>
         </div>
-        {acliStatus === 'not_installed' && (
+        {state.acliStatus === 'not_installed' && (
           <div style={{ display: 'flex', gap: 'var(--space-8)' }}>
             <Button size="sm" variant="primary" onClick={handleInstall}>
               {t('jira.install')}
@@ -73,7 +100,7 @@ export function SettingsJira() {
             </Button>
           </div>
         )}
-        {acliStatus === 'installing' && (
+        {state.acliStatus === 'installing' && (
           <Button size="sm" variant="primary" disabled loading>
             {t('jira.installing')}
           </Button>
@@ -89,14 +116,14 @@ export function SettingsJira() {
             type="text"
             className="settings-input"
             style={{ flex: 1 }}
-            value={jiraDraft}
-            onChange={(e) => setJiraDraft(e.target.value)}
+            value={state.draft}
+            onChange={(e) => dispatch({ type: 'setDraft', value: e.target.value })}
             onKeyDown={(e) => { if (e.key === 'Enter' && dirty) handleSave() }}
             placeholder="https://yourcompany.atlassian.net"
             spellCheck={false}
           />
-          <Button size="sm" variant="primary" disabled={!dirty && saveState === 'idle'} onClick={handleSave}>
-            {saveState === 'saved' ? t('jira.saved') : t('jira.save')}
+          <Button size="sm" variant="primary" disabled={!dirty && state.saveState === 'idle'} onClick={handleSave}>
+            {state.saveState === 'saved' ? t('jira.saved') : t('jira.save')}
           </Button>
         </div>
         <span className="settings-hint">{t('jira.baseUrlHint')}</span>

--- a/src/renderer/components/Settings/SettingsJira.tsx
+++ b/src/renderer/components/Settings/SettingsJira.tsx
@@ -7,6 +7,7 @@ import { StatusDot } from '@/components/ui/StatusDot'
 import { IconExternalLink } from '@/components/shared/icons'
 
 type AcliStatus = 'checking' | 'installed' | 'not_installed' | 'installing'
+type SaveState = 'idle' | 'saved'
 
 const ACLI_DOCS_URL = 'https://developer.atlassian.com/cloud/acli/guides/install-acli/'
 
@@ -30,6 +31,21 @@ export function SettingsJira() {
     setAcliStatus(ok ? 'installed' : 'not_installed')
   }, [])
 
+  // ── Base URL save with brief "Saved" flash ──────────────────────────
+  const [saveState, setSaveState] = useState<SaveState>('idle')
+  const dirty = jiraDraft.trim() !== jiraBaseUrl
+
+  const handleSave = useCallback(() => {
+    setJiraBaseUrl(jiraDraft.trim())
+    setSaveState('saved')
+    setTimeout(() => setSaveState('idle'), 1500)
+  }, [jiraDraft, setJiraBaseUrl])
+
+  const dotState =
+    acliStatus === 'installed' ? 'success' as const
+      : acliStatus === 'not_installed' ? 'failure' as const
+      : 'pending' as const
+
   return (
     <div className="settings-section">
       <span className="settings-hint">{t('jira.description')}</span>
@@ -39,9 +55,7 @@ export function SettingsJira() {
       <h4 className="settings-section-subtitle">{t('jira.statusHeader')}</h4>
       <div className="settings-field settings-field--row">
         <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-8)' }}>
-          <StatusDot
-            state={acliStatus === 'installed' ? 'success' : acliStatus === 'checking' || acliStatus === 'installing' ? 'pending' : 'failure'}
-          />
+          <StatusDot state={dotState} />
           <span className="settings-label">
             {acliStatus === 'checking' && t('jira.statusChecking')}
             {acliStatus === 'installed' && t('jira.statusInstalled')}
@@ -70,15 +84,21 @@ export function SettingsJira() {
 
       <div className="settings-field">
         <label className="settings-label">{t('jira.baseUrl')}</label>
-        <input
-          type="text"
-          className="settings-input"
-          value={jiraDraft}
-          onChange={(e) => setJiraDraft(e.target.value)}
-          onBlur={() => setJiraBaseUrl(jiraDraft)}
-          placeholder="https://yourcompany.atlassian.net"
-          spellCheck={false}
-        />
+        <div style={{ display: 'flex', gap: 'var(--space-8)' }}>
+          <input
+            type="text"
+            className="settings-input"
+            style={{ flex: 1 }}
+            value={jiraDraft}
+            onChange={(e) => setJiraDraft(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter' && dirty) handleSave() }}
+            placeholder="https://yourcompany.atlassian.net"
+            spellCheck={false}
+          />
+          <Button size="sm" variant="primary" disabled={!dirty && saveState === 'idle'} onClick={handleSave}>
+            {saveState === 'saved' ? t('jira.saved') : t('jira.save')}
+          </Button>
+        </div>
         <span className="settings-hint">{t('jira.baseUrlHint')}</span>
       </div>
     </div>

--- a/src/renderer/components/Settings/SettingsJira.tsx
+++ b/src/renderer/components/Settings/SettingsJira.tsx
@@ -44,15 +44,22 @@ export function SettingsJira() {
   })
 
   useEffect(() => {
-    jira.isAvailable().then((ok: boolean) => dispatch({ type: 'setAcli', status: ok ? 'installed' : 'not_installed' }))
+    jira
+      .isAvailable()
+      .then((ok: boolean) => dispatch({ type: 'setAcli', status: ok ? 'installed' : 'not_installed' }))
+      .catch(() => dispatch({ type: 'setAcli', status: 'not_installed' }))
   }, [])
 
   const handleInstall = useCallback(async () => {
     dispatch({ type: 'setAcli', status: 'installing' })
     try { await shell.installTool('acli') } catch { /* still recheck below */ }
     dispatch({ type: 'setAcli', status: 'checking' })
-    const ok = await jira.recheckAvailability()
-    dispatch({ type: 'setAcli', status: ok ? 'installed' : 'not_installed' })
+    try {
+      const ok = await jira.recheckAvailability()
+      dispatch({ type: 'setAcli', status: ok ? 'installed' : 'not_installed' })
+    } catch {
+      dispatch({ type: 'setAcli', status: 'not_installed' })
+    }
   }, [])
 
   // ── Base URL save with brief "Saved" flash ──────────────────────────
@@ -62,7 +69,9 @@ export function SettingsJira() {
   const dirty = state.draft.trim() !== jiraBaseUrl
 
   const handleSave = useCallback(() => {
-    setJiraBaseUrl(state.draft.trim())
+    const trimmed = state.draft.trim()
+    setJiraBaseUrl(trimmed)
+    dispatch({ type: 'setDraft', value: trimmed })
     dispatch({ type: 'saved' })
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
     saveTimerRef.current = setTimeout(() => dispatch({ type: 'resetSave' }), 1500)

--- a/src/renderer/components/Settings/SettingsJira.tsx
+++ b/src/renderer/components/Settings/SettingsJira.tsx
@@ -1,0 +1,86 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useUIStore } from '@/store/ui'
+import { jira, shell } from '@/lib/ipc'
+import { Button } from '@/components/ui/Button'
+import { StatusDot } from '@/components/ui/StatusDot'
+import { IconExternalLink } from '@/components/shared/icons'
+
+type AcliStatus = 'checking' | 'installed' | 'not_installed' | 'installing'
+
+const ACLI_DOCS_URL = 'https://developer.atlassian.com/cloud/acli/guides/install-acli/'
+
+export function SettingsJira() {
+  const { t } = useTranslation('settings')
+  const jiraBaseUrl = useUIStore((s) => s.jiraBaseUrl)
+  const setJiraBaseUrl = useUIStore((s) => s.setJiraBaseUrl)
+
+  const [acliStatus, setAcliStatus] = useState<AcliStatus>('checking')
+  const [jiraDraft, setJiraDraft] = useState(jiraBaseUrl)
+
+  useEffect(() => {
+    jira.isAvailable().then((ok: boolean) => setAcliStatus(ok ? 'installed' : 'not_installed'))
+  }, [])
+
+  const handleInstall = useCallback(async () => {
+    setAcliStatus('installing')
+    try { await shell.installTool('acli') } catch { /* still recheck below */ }
+    setAcliStatus('checking')
+    const ok = await jira.recheckAvailability()
+    setAcliStatus(ok ? 'installed' : 'not_installed')
+  }, [])
+
+  return (
+    <div className="settings-section">
+      <span className="settings-hint">{t('jira.description')}</span>
+
+      <div className="settings-divider" />
+
+      <h4 className="settings-section-subtitle">{t('jira.statusHeader')}</h4>
+      <div className="settings-field settings-field--row">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-8)' }}>
+          <StatusDot
+            state={acliStatus === 'installed' ? 'success' : acliStatus === 'checking' || acliStatus === 'installing' ? 'pending' : 'failure'}
+          />
+          <span className="settings-label">
+            {acliStatus === 'checking' && t('jira.statusChecking')}
+            {acliStatus === 'installed' && t('jira.statusInstalled')}
+            {acliStatus === 'not_installed' && t('jira.statusNotInstalled')}
+            {acliStatus === 'installing' && t('jira.statusInstalling')}
+          </span>
+        </div>
+        {acliStatus === 'not_installed' && (
+          <div style={{ display: 'flex', gap: 'var(--space-8)' }}>
+            <Button size="sm" variant="primary" onClick={handleInstall}>
+              {t('jira.install')}
+            </Button>
+            <Button size="sm" onClick={() => shell.openExternal(ACLI_DOCS_URL)}>
+              {t('jira.docs')} <IconExternalLink size={10} />
+            </Button>
+          </div>
+        )}
+        {acliStatus === 'installing' && (
+          <Button size="sm" variant="primary" disabled loading>
+            {t('jira.installing')}
+          </Button>
+        )}
+      </div>
+
+      <div className="settings-divider" />
+
+      <div className="settings-field">
+        <label className="settings-label">{t('jira.baseUrl')}</label>
+        <input
+          type="text"
+          className="settings-input"
+          value={jiraDraft}
+          onChange={(e) => setJiraDraft(e.target.value)}
+          onBlur={() => setJiraBaseUrl(jiraDraft)}
+          placeholder="https://yourcompany.atlassian.net"
+          spellCheck={false}
+        />
+        <span className="settings-hint">{t('jira.baseUrlHint')}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Settings/SettingsNav.tsx
+++ b/src/renderer/components/Settings/SettingsNav.tsx
@@ -21,7 +21,7 @@ const NAV_GROUPS = [
   { header: 'general', items: ['general', 'editor', 'analytics', 'about'] },
   { header: 'claudeAgent', items: ['ai', 'claudePermissions', 'claudeHooks', 'claudeInstructions', 'claudePlugins', 'claudeMcp', 'claudeSkills'] },
   { header: 'appearance', items: ['appearance'] },
-  { header: 'integrations', items: ['apps', 'git', 'notifications'] },
+  { header: 'integrations', items: ['apps', 'git', 'jira', 'notifications'] },
 ]
 
 export function SettingsNav() {

--- a/src/renderer/components/Settings/SettingsOverlay.tsx
+++ b/src/renderer/components/Settings/SettingsOverlay.tsx
@@ -19,6 +19,7 @@ import { SettingsClaudePlugins } from './SettingsClaudePlugins'
 import { SettingsClaudeMcp } from './SettingsClaudeMcp'
 import { SettingsClaudeSkills } from './SettingsClaudeSkills'
 import { SettingsApps } from './SettingsApps'
+import { SettingsJira } from './SettingsJira'
 import { SettingsAnalytics } from './SettingsAnalytics'
 import { SettingsAbout } from './SettingsAbout'
 
@@ -47,6 +48,7 @@ const sectionMap: Record<string, React.ReactNode> = {
   claudeMcp: <SettingsClaudeMcp />,
   claudeSkills: <SettingsClaudeSkills />,
   apps: <SettingsApps />,
+  jira: <SettingsJira />,
   analytics: <SettingsAnalytics />,
   about: <SettingsAbout />,
 }

--- a/src/renderer/lib/ipc.ts
+++ b/src/renderer/lib/ipc.ts
@@ -284,6 +284,7 @@ export const notes = {
 
 export const jira = {
   isAvailable: () => api().jira.isAvailable(),
+  recheckAvailability: () => api().jira.recheckAvailability() as Promise<boolean>,
   getIssuesForBranch: (worktreePath: string, overrideBaseUrl?: string) =>
     api().jira.getIssuesForBranch(worktreePath, overrideBaseUrl) as Promise<import('@/types').JiraResult>,
   getIssueByKey: (key: string, overrideBaseUrl?: string) =>

--- a/src/renderer/locales/en/settings.json
+++ b/src/renderer/locales/en/settings.json
@@ -15,6 +15,7 @@
     "claudeMcp": "MCP Servers",
     "claudeSkills": "Skills",
     "apps": "Apps",
+    "jira": "Jira",
     "analytics": "Analytics",
     "about": "About"
   },
@@ -308,9 +309,20 @@
     "hide": "Hide",
     "invalidUrl": "URL must start with http:// or https://",
     "nameRequired": "Name is required",
-    "workspaceRequired": "Workspace name is required",
-    "jiraBaseUrl": "Jira Base URL",
-    "jiraBaseUrlHint": "Your Atlassian site URL (e.g. https://yourcompany.atlassian.net). Auto-detected from jira-cli config if left blank."
+    "workspaceRequired": "Workspace name is required"
+  },
+  "jira": {
+    "description": "Connect to Jira via the Atlassian CLI (acli). Shows linked issues from branch names and enables ticket lookup when creating worktrees.",
+    "statusHeader": "Atlassian CLI",
+    "statusChecking": "Checking...",
+    "statusInstalled": "Installed",
+    "statusNotInstalled": "Not installed",
+    "statusInstalling": "Installing...",
+    "install": "Install",
+    "installing": "Installing...",
+    "docs": "Docs",
+    "baseUrl": "Jira Base URL",
+    "baseUrlHint": "Your Atlassian site URL (e.g. https://yourcompany.atlassian.net). Auto-detected from jira-cli config if left blank."
   },
   "analytics": {
     "overview": "Overview",

--- a/src/renderer/locales/en/settings.json
+++ b/src/renderer/locales/en/settings.json
@@ -322,7 +322,9 @@
     "installing": "Installing...",
     "docs": "Docs",
     "baseUrl": "Jira Base URL",
-    "baseUrlHint": "Your Atlassian site URL (e.g. https://yourcompany.atlassian.net). Auto-detected from jira-cli config if left blank."
+    "baseUrlHint": "Your Atlassian site URL (e.g. https://yourcompany.atlassian.net). Auto-detected from jira-cli config if left blank.",
+    "save": "Save",
+    "saved": "Saved"
   },
   "analytics": {
     "overview": "Overview",

--- a/src/renderer/locales/id/settings.json
+++ b/src/renderer/locales/id/settings.json
@@ -322,7 +322,9 @@
     "installing": "Menginstal...",
     "docs": "Dokumentasi",
     "baseUrl": "URL Dasar Jira",
-    "baseUrlHint": "URL situs Atlassian Anda (mis. https://perusahaan.atlassian.net). Terdeteksi otomatis dari konfigurasi jira-cli jika dikosongkan."
+    "baseUrlHint": "URL situs Atlassian Anda (mis. https://perusahaan.atlassian.net). Terdeteksi otomatis dari konfigurasi jira-cli jika dikosongkan.",
+    "save": "Simpan",
+    "saved": "Tersimpan"
   },
   "analytics": {
     "overview": "Ikhtisar",

--- a/src/renderer/locales/id/settings.json
+++ b/src/renderer/locales/id/settings.json
@@ -15,6 +15,7 @@
     "claudeMcp": "Server MCP",
     "claudeSkills": "Keahlian",
     "apps": "Aplikasi",
+    "jira": "Jira",
     "analytics": "Analitik",
     "about": "Tentang"
   },
@@ -308,9 +309,20 @@
     "hide": "Sembunyikan",
     "invalidUrl": "URL harus diawali dengan http:// atau https://",
     "nameRequired": "Nama diperlukan",
-    "workspaceRequired": "Nama workspace diperlukan",
-    "jiraBaseUrl": "URL Dasar Jira",
-    "jiraBaseUrlHint": "URL situs Atlassian Anda (mis. https://perusahaan.atlassian.net). Terdeteksi otomatis dari konfigurasi jira-cli jika dikosongkan."
+    "workspaceRequired": "Nama workspace diperlukan"
+  },
+  "jira": {
+    "description": "Hubungkan ke Jira melalui Atlassian CLI (acli). Menampilkan tiket terkait dari nama branch dan memungkinkan pencarian tiket saat membuat worktree.",
+    "statusHeader": "Atlassian CLI",
+    "statusChecking": "Memeriksa...",
+    "statusInstalled": "Terinstal",
+    "statusNotInstalled": "Belum terinstal",
+    "statusInstalling": "Menginstal...",
+    "install": "Instal",
+    "installing": "Menginstal...",
+    "docs": "Dokumentasi",
+    "baseUrl": "URL Dasar Jira",
+    "baseUrlHint": "URL situs Atlassian Anda (mis. https://perusahaan.atlassian.net). Terdeteksi otomatis dari konfigurasi jira-cli jika dikosongkan."
   },
   "analytics": {
     "overview": "Ikhtisar",

--- a/src/renderer/locales/ja/settings.json
+++ b/src/renderer/locales/ja/settings.json
@@ -322,7 +322,9 @@
     "installing": "インストール中...",
     "docs": "ドキュメント",
     "baseUrl": "Jira ベースURL",
-    "baseUrlHint": "AtlassianサイトのURL（例: https://yourcompany.atlassian.net）。空白の場合はjira-cli設定から自動検出されます。"
+    "baseUrlHint": "AtlassianサイトのURL（例: https://yourcompany.atlassian.net）。空白の場合はjira-cli設定から自動検出されます。",
+    "save": "保存",
+    "saved": "保存済み"
   },
   "analytics": {
     "overview": "概要",

--- a/src/renderer/locales/ja/settings.json
+++ b/src/renderer/locales/ja/settings.json
@@ -15,6 +15,7 @@
     "claudeMcp": "MCPサーバー",
     "claudeSkills": "スキル",
     "apps": "アプリ",
+    "jira": "Jira",
     "analytics": "アナリティクス",
     "about": "このアプリについて"
   },
@@ -308,9 +309,20 @@
     "hide": "非表示",
     "invalidUrl": "URLは http:// または https:// で始まる必要があります",
     "nameRequired": "名前は必須です",
-    "workspaceRequired": "ワークスペース名は必須です",
-    "jiraBaseUrl": "Jira ベースURL",
-    "jiraBaseUrlHint": "AtlassianサイトのURL（例: https://yourcompany.atlassian.net）。空白の場合はjira-cli設定から自動検出されます。"
+    "workspaceRequired": "ワークスペース名は必須です"
+  },
+  "jira": {
+    "description": "Atlassian CLI (acli) を使用して Jira に接続します。ブランチ名から関連チケットを表示し、ワークツリー作成時にチケット検索を有効にします。",
+    "statusHeader": "Atlassian CLI",
+    "statusChecking": "確認中...",
+    "statusInstalled": "インストール済み",
+    "statusNotInstalled": "未インストール",
+    "statusInstalling": "インストール中...",
+    "install": "インストール",
+    "installing": "インストール中...",
+    "docs": "ドキュメント",
+    "baseUrl": "Jira ベースURL",
+    "baseUrlHint": "AtlassianサイトのURL（例: https://yourcompany.atlassian.net）。空白の場合はjira-cli設定から自動検出されます。"
   },
   "analytics": {
     "overview": "概要",


### PR DESCRIPTION
## Summary

- Move Jira configuration out of the Apps settings page into a dedicated **Jira** settings page with acli availability detection, install button, and base URL input with explicit save
- Thread new `jira:recheckAvailability` IPC through all three layers so the settings page can re-probe acli after install
- Add i18n translations for all new Jira settings strings in en, ja, and id locales

## Layers touched

- [x] **Main process** (`src/main/`) - services, IPC handlers
- [x] **Preload** (`src/preload/`) - context bridge API
- [x] **Renderer** (`src/renderer/`) - components, stores, lib

## Changes

**Settings components:**
- New `SettingsJira.tsx` - dedicated page with acli status indicator (StatusDot), install/docs buttons, base URL input with explicit Save button and "Saved" confirmation flash
- `SettingsApps.tsx` - removed Jira base URL field (moved to dedicated page)
- `SettingsNav.tsx` - added `jira` to integrations group
- `SettingsOverlay.tsx` - registered `SettingsJira` in sectionMap

**Services** (`jira.ts`):
- Added `recheckAvailability()` - resets cached availability and re-probes

**IPC** (`main/ipc.ts` -> `preload/index.ts` -> `lib/ipc.ts`):
- New `jira:recheckAvailability` handler threaded through all 3 layers

**i18n** (`locales/{en,ja,id}/settings.json`):
- New `jira` namespace with 13 keys (description, status states, buttons, base URL)
- Added `jira` nav label to all locales
- Removed old `apps.jiraBaseUrl` / `apps.jiraBaseUrlHint` keys

## How to test

1. `yarn dev`
2. Open Settings -> Jira (under Integrations)
3. Verify acli status shows correctly (installed/not installed)
4. If not installed, verify Install button triggers installation and rechecks
5. Enter a base URL, verify Save button enables, click Save, see "Saved" flash
6. Verify the old Jira field is gone from Settings -> Apps

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass - `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [x] IPC changes are threaded through all 3 layers (main -> preload -> renderer)
- [x] New state is added to the correct Zustand store