### PR TITLE
fix: overlap back button

### DIFF
--- a/src/renderer/styles/settings.css
+++ b/src/renderer/styles/settings.css
@@ -32,8 +32,9 @@
 
 .settings-title {
   position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
+  right: 0;
+  text-align: center;
   font-size: var(--text-xl);
   font-weight: var(--weight-semibold);
   color: var(--text-primary);


### PR DESCRIPTION
## Summary

- Fix the settings back button overlapping the centered title by replacing `left: 50%` + `translateX(-50%)` with `left: 0` / `right: 0` / `text-align: center` on `.settings-title`

## Layers touched

- [ ] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Styles** (`src/renderer/styles/settings.css`):
- Changed `.settings-title` positioning from `left: 50% + translateX(-50%)` to `left: 0 / right: 0 / text-align: center` so the title spans the full width and the back button no longer overlaps it

## How to test

1. `yarn dev`
2. Open Settings
3. Navigate to any sub-page that shows a back button — confirm the title is centered and the back button does not overlap it

## Screenshots

Before: 
<img width="194" height="54" alt="GENERAL" src="https://github.com/user-attachments/assets/77528e17-bb35-4240-9755-8cdc9aadf06a" />


After : 
<img width="172" height="49" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/e99d6355-720e-4008-89af-f85881302be8" />


## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store