### PR TITLE
fix: hide compact warning when /compact is already queued or typed

### DIFF
--- a/src/renderer/components/Center/ChatInput.tsx
+++ b/src/renderer/components/Center/ChatInput.tsx
@@ -277,6 +277,15 @@ export function ChatInput({
     return activeSession.contextTokens / CONTEXT_WINDOW
   }, [activeSession.contextTokens])
 
+  // Hide the compact warning if /compact is already queued or already typed,
+  // or if the last message is a compact-boundary (compaction just happened with no new user turn yet)
+  const isCompactPending = useMemo(() => {
+    if (queuedMessage?.text?.trim() === '/compact') return true
+    if (input.trim() === '/compact') return true
+    const lastMsg = activeSession.messages.at(-1)
+    return lastMsg?.tag === 'compact-boundary'
+  }, [queuedMessage, input, activeSession.messages])
+
   const placeholder = useMemo(() => {
     if (isWaitingInput) return t('placeholderWaitingInput')
     if (isRunning) return queuedMessage !== null ? t('placeholderQueued') : t('placeholderQueueNext')
@@ -391,7 +400,7 @@ export function ChatInput({
         <LinkedWorktreeChips sessionId={activeSession.id} worktreeId={activeSession.worktreeId} />
       )}
 
-      {variant === 'default' && contextPercent >= CONTEXT_WARN_THRESHOLD && (
+      {variant === 'default' && contextPercent >= CONTEXT_WARN_THRESHOLD && !isCompactPending && (
         <button
           className={`context-warning-nudge${contextPercent >= CONTEXT_CRITICAL_THRESHOLD ? ' context-warning-nudge--critical' : ''}`}
           onClick={handleCompactClick}


### PR DESCRIPTION
## Summary

- Hides the context-warning nudge when the user has already typed or queued `/compact`, preventing a redundant prompt to compact when compaction is already in progress or queued
- Also hides the warning immediately after a compact-boundary message (compaction just happened, no new user turn yet)

## Layers touched

- [ ] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [ ] **Styles** (`App.css`)

## Changes

**Sidebar / Center / Right panel:**
- `ChatInput.tsx`: Added `isCompactPending` memo that checks if `/compact` is already queued, already typed in the input, or if the last message is a `compact-boundary`. The context-warning nudge is now hidden when any of these conditions are true.

## How to test

1. `yarn dev`
2. Fill up context to near the warning threshold
3. Click the compact nudge button (or type `/compact`) — verify the warning disappears immediately instead of staying visible
4. Queue a `/compact` message while running — verify the warning is hidden while it's queued

## Screenshots

<!-- Before/after if UI changed. Remove if not applicable. -->

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [ ] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store