### PR TITLE
style(mission-control): fix header layout for traffic light clearance

### DIFF
--- a/src/renderer/styles/mission-control.css
+++ b/src/renderer/styles/mission-control.css
@@ -9,23 +9,16 @@
   min-width: 0;
 }
 
-/* Spacer to clear macOS traffic lights when sidebar panel is closed */
-.mission-control::before {
-  content: '';
-  height: 48px;
-  flex-shrink: 0;
-  -webkit-app-region: drag;
-}
-
 .mission-control-header {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
-  padding: 0 var(--space-16);
-  height: 40px;
+  padding: 0 var(--space-16) var(--space-8);
+  height: 52px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
   position: relative;
+  background: var(--bg-secondary);
 }
 
 .mission-control-header .drag-region {

--- a/src/renderer/styles/mission-control.css
+++ b/src/renderer/styles/mission-control.css
@@ -11,9 +11,9 @@
 
 .mission-control-header {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
-  padding: 0 var(--space-16) var(--space-8);
+  padding: 0 var(--space-16) 0 var(--space-40);
   height: 52px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;


### PR DESCRIPTION
Closes #40

## Summary

- Remove the `::before` pseudo-element spacer used to clear macOS traffic lights in Mission Control
- Replace with proper header height and left padding to align content below/beside the traffic lights
- Add `background: var(--bg-secondary)` to the header for visual consistency

## Layers touched

- [ ] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [ ] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Sidebar / Center / Right panel:**
- `src/renderer/styles/mission-control.css`: Removed `::before` spacer pseudo-element; updated `.mission-control-header` height from `40px` to `52px`, added `padding-left: var(--space-40)` to clear traffic lights, and added `background: var(--bg-secondary)`

## How to test

1. `yarn dev`
2. Open Mission Control (kanban view)
3. Verify the header does not overlap with macOS traffic light buttons
4. Verify header background matches the secondary background color

## Screenshots

<!-- Before/after if UI changed. Remove if not applicable. -->

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [ ] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store