### PR TITLE
fix: clone to ~/Braid/repos, compact warning UX, mission-control header

### DIFF
--- a/src/main/services/git/__tests__/worktrees.test.ts
+++ b/src/main/services/git/__tests__/worktrees.test.ts
@@ -268,7 +268,7 @@ describe('cloneRepo', () => {
     mockMkdirSync.mockReturnValue(undefined)
   })
 
-  it('clones to ~/Braid/worktrees/{repoName}/', async () => {
+  it('clones to ~/Braid/repos/{repoName}/', async () => {
     mockExistsSync.mockReturnValue(false)
     mockClone.mockResolvedValue('')
 

--- a/src/main/services/git/worktrees.ts
+++ b/src/main/services/git/worktrees.ts
@@ -140,7 +140,7 @@ function classifyCloneError(err: unknown): CloneErrorCode {
 }
 
 /**
- * Clones a remote git URL into ~/${DATA_DIR_NAME}/worktrees/{repoName}/.
+ * Clones a remote git URL into ~/${DATA_DIR_NAME}/repos/{repoName}/.
  * Returns the local path of the cloned repository.
  */
 export async function cloneRepo(url: string, storagePath?: string): Promise<string> {

--- a/src/main/services/git/worktrees.ts
+++ b/src/main/services/git/worktrees.ts
@@ -145,9 +145,11 @@ function classifyCloneError(err: unknown): CloneErrorCode {
  */
 export async function cloneRepo(url: string, storagePath?: string): Promise<string> {
   const repoName = parseRepoName(url)
+  // Clone into ~/Braid/repos/ (not ~/Braid/worktrees/) so the cloned repo
+  // doesn't collide with worktrees created at ~/Braid/worktrees/{project}/{branch}/
   const baseDir = storagePath
     ? storagePath.replace(/^~/, homedir())
-    : join(homedir(), DATA_DIR_NAME, 'worktrees')
+    : join(homedir(), DATA_DIR_NAME, 'repos')
   const targetPath = join(baseDir, repoName)
 
   mkdirSync(dirname(targetPath), { recursive: true })


### PR DESCRIPTION
## Summary

- Clone repos to `~/Braid/repos/` instead of `~/Braid/worktrees/` to avoid path collisions with worktrees
- Hide the compact-warning nudge when `/compact` is already queued, typed, or a compaction just occurred
- Fix Mission Control header layout for macOS traffic light clearance (height + padding approach)

## Layers touched

- [x] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Sidebar / Center / Right panel:**
- `ChatInput.tsx`: Added `isCompactPending` memo that suppresses the context-warning nudge when `/compact` is already in flight or compaction just completed

**Services** (`git.ts` / `claude.ts` / `github.ts` / `pty.ts`):
- `worktrees.ts`: Changed default clone destination from `~/Braid/worktrees` → `~/Braid/repos` so bare repos don't collide with worktree directories

**Styles:**
- `mission-control.css`: Replaced the `::before` spacer hack with explicit `padding-left: var(--space-40)` and `height: 52px` on the header; added `background: var(--bg-secondary)` for consistency

## How to test

1. `yarn dev`
2. Add a new project — confirm it clones to `~/Braid/repos/<name>` not `~/Braid/worktrees/<name>`
3. Open a chat near context limit — verify the yellow/red compact warning hides once you type `/compact` or after a compaction runs
4. Open Mission Control — verify header aligns correctly under macOS traffic lights with no overlap

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store