### PR TITLE
fix: scrollable multiple choice from AI

### DIFF
--- a/src/renderer/components/Center/ChatInput.tsx
+++ b/src/renderer/components/Center/ChatInput.tsx
@@ -3,7 +3,7 @@
  *
  * Handles: drag-and-drop, paste, image previews, file mention chips,
  * snippet chips, context warning, textarea, slash/mention autocomplete,
- * queued-message banner, and prompt overlays (AskUserQuestion, ExitPlanMode, ToolPermission).
+ * queued-message banner, and prompt overlays (ExitPlanMode, ToolPermission).
  *
  * Extracted from ChatView.tsx to keep each file under the 450-line limit.
  */
@@ -14,7 +14,6 @@ import { MentionAutocomplete } from './MentionAutocomplete'
 import { InputHighlightBackdrop } from './mentionHighlight'
 import { SnippetChips } from './SnippetChips'
 import { LinkedWorktreeChips } from './LinkedWorktreeChips'
-import { AskUserQuestionPrompt } from './AskUserQuestionPrompt'
 import { ExitPlanModePrompt } from './ExitPlanModePrompt'
 import { ToolPermissionPrompt } from './ToolPermissionPrompt'
 import { AuthErrorPrompt } from './AuthErrorPrompt'
@@ -76,7 +75,6 @@ export function ChatInput({
   const setQueuedMessage = useSessionsStore((s) => s.setQueuedMessage)
   const setEditingQueue = useSessionsStore((s) => s.setEditingQueue)
   const drainDeferredQueue = useSessionsStore((s) => s.drainDeferredQueue)
-  const answerQuestion = useSessionsStore((s) => s.answerQuestion)
   const approvePlan = useSessionsStore((s) => s.approvePlan)
   const rejectPlan = useSessionsStore((s) => s.rejectPlan)
   const allowTool = useSessionsStore((s) => s.allowTool)
@@ -242,10 +240,6 @@ export function ChatInput({
 
   // ─── Prompts ───────────────────────────────────────────────────────────────
 
-  const handleAnswerSubmit = useCallback((answers: Record<string, string>) => {
-    answerQuestion(activeSession.id, answers)
-  }, [activeSession.id, answerQuestion])
-
   const handlePlanApprove = useCallback(() => approvePlan(activeSession.id), [activeSession.id, approvePlan])
   const handlePlanReject = useCallback((reason?: string) => rejectPlan(activeSession.id, reason), [activeSession.id, rejectPlan])
   const handleAllowTool = useCallback(() => allowTool(activeSession.id), [activeSession.id, allowTool])
@@ -297,9 +291,6 @@ export function ChatInput({
       onDrop={handleDrop}
     >
       {/* Prompt overlays - hidden in diff variant */}
-      {variant === 'default' && isWaitingInput && activeSession.pendingQuestion && (
-        <AskUserQuestionPrompt pendingQuestion={activeSession.pendingQuestion} onSubmit={handleAnswerSubmit} />
-      )}
       {variant === 'default' && isWaitingInput && activeSession.pendingPlanApproval && (
         <ExitPlanModePrompt
           onApprove={handlePlanApprove}

--- a/src/renderer/components/Center/ChatMessageList.tsx
+++ b/src/renderer/components/Center/ChatMessageList.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useRef, useLayoutEffect, memo } from 'react'
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
-import { useActiveSession } from '@/store/sessions'
+import { useActiveSession, useSessionsStore } from '@/store/sessions'
 import { useUIStore } from '@/store/ui'
 import { ChatMessage } from './ChatMessage'
 import { ActivityIndicator } from './ActivityIndicator'
+import { AskUserQuestionPrompt } from './AskUserQuestionPrompt'
 import type { Message } from '@/types'
 import { IconArrowDown } from '@/components/shared/icons'
 import { useTranslation } from 'react-i18next'
@@ -18,9 +19,16 @@ const VirtuosoHeader = () => <div style={{ height: 20 }} />
 
 const FooterContent = memo(function FooterContent({ itemClassName = 'chat-virtuoso-item' }: { itemClassName?: string }) {
   const session = useActiveSession()
+  const answerQuestion = useSessionsStore((s) => s.answerQuestion)
   const isRunning = session?.status === 'running'
   const isWaitingInput = session?.status === 'waiting_input'
   const showActivity = (isRunning || isWaitingInput) && session?.activity
+  const sessionId = session?.id
+
+  const handleAnswerSubmit = useCallback((answers: Record<string, string>) => {
+    if (sessionId) answerQuestion(sessionId, answers)
+  }, [sessionId, answerQuestion])
+
   return (
     // Fixed-height container prevents scroll bounce when activity toggles.
     <div style={{ minHeight: 68 }}>
@@ -33,6 +41,14 @@ const FooterContent = memo(function FooterContent({ itemClassName = 'chat-virtuo
           />
         </div>
       ) : null}
+      {isWaitingInput && session?.pendingQuestion && (
+        <div className={itemClassName}>
+          <AskUserQuestionPrompt
+            pendingQuestion={session.pendingQuestion}
+            onSubmit={handleAnswerSubmit}
+          />
+        </div>
+      )}
       <div style={{ height: 20 }} />
     </div>
   )

--- a/src/renderer/components/Center/ChatView.tsx
+++ b/src/renderer/components/Center/ChatView.tsx
@@ -157,6 +157,17 @@ export function ChatView({ worktreePath = '' }: ChatViewProps) {
 
   // ─── Effects ────────────────────────────────────────────────────────────────
 
+  // When Claude asks a question (waiting_input), re-engage auto-scroll so the
+  // user sees the prompt even if they scrolled away during streaming.
+  const prevWaitingRef = useRef(false)
+  useEffect(() => {
+    const wasWaiting = prevWaitingRef.current
+    prevWaitingRef.current = !!isWaitingInput
+    if (!wasWaiting && isWaitingInput) {
+      engageScroll()
+    }
+  }, [isWaitingInput, engageScroll])
+
   useEffect(() => {
     const handler = () => textareaRef.current?.focus()
     window.addEventListener('braid:focusChat', handler)

--- a/src/renderer/hooks/useChatScroll.ts
+++ b/src/renderer/hooks/useChatScroll.ts
@@ -29,12 +29,15 @@ interface UseChatScrollReturn {
  *     while idle sets `escapedFromLock = true`. Once escaped, the rAF loop
  *     stops forcing scroll and content growth can never silently re-engage it.
  *
- *   - **Re-engage** (explicit user intent only):
+ *   - **Re-engage** (explicit user intent or programmatic trigger):
  *     1. Scroll-to-bottom button click → `engageScroll()`
  *     2. User sends a message → `engageScroll()`
  *     3. Session switch → `engageScroll()`
  *     4. User manually scrolls to absolute bottom (≤ 2px) — tiny threshold to
  *        ensure it's deliberate, not content-growth drift.
+ *     5. `waiting_input` transition (Claude's `AskUserQuestion` fires) →
+ *        `engageScroll()` called programmatically from `ChatView` so the inline
+ *        prompt is scrolled into view automatically.
  *
  *   - **Streaming end**: When streaming stops and the user is within 150px of
  *     bottom, auto-re-engage so idle reading isn't stuck with the button showing.
@@ -174,8 +177,8 @@ export function useChatScroll({ isStreaming }: UseChatScrollOptions): UseChatScr
   }, [isStreaming])
 
   // Explicit re-engage: clears the escape latch and re-enables auto-scroll.
-  // Callers (scroll-to-bottom button, send message, session switch) must use
-  // this instead of poking wantsBottomRef directly.
+  // Callers (scroll-to-bottom button, send message, session switch,
+  // waiting_input transition) must use this instead of poking wantsBottomRef directly.
   const engageScroll = useCallback(() => {
     escapedRef.current = false
     wantsBottomRef.current = true


### PR DESCRIPTION
## Summary

- Move `AskUserQuestionPrompt` from `ChatInput` into the `ChatMessageList` footer so it renders inline in the message list, making it scrollable
- Add auto-scroll re-engagement in `ChatView` when Claude transitions to `waiting_input`, ensuring the user sees the prompt even if they had scrolled up during streaming

## Layers touched

- [x] **Renderer** (`src/renderer/`) — components, stores, lib

## Changes

**Center panel:**
- `ChatInput.tsx`: Removed `AskUserQuestionPrompt` import and rendering — it no longer lives in the input overlay area
- `ChatMessageList.tsx`: Added `AskUserQuestionPrompt` to `FooterContent` (rendered after the activity indicator, inside the virtualized list footer), so the question prompt scrolls naturally with the message list
- `ChatView.tsx`: Added effect that calls `engageScroll()` when `isWaitingInput` transitions to `true`, so the viewport scrolls to reveal the prompt

## How to test

1. `yarn dev`
2. Start a session and trigger a slash command or skill that calls `AskUserQuestion` (e.g. `/gsd-debug`)
3. Scroll up in the chat while Claude is streaming
4. Observe: when Claude pauses to ask a question, the view automatically scrolls down to reveal the prompt
5. Verify the multiple-choice/text prompt is scrollable and interactable inline in the message list

## Screenshots

Before : 
( no scroll bar on the side, user can't scroll ) 
<img width="821" height="841" alt="How do you want to work" src="https://github.com/user-attachments/assets/681f1d93-1bef-4225-8722-7022df478cbb" />

After : 
<img width="681" height="866" alt="image" src="https://github.com/user-attachments/assets/24920f6a-734e-4c32-8542-a06083e04c72" />



<!-- Before/after if UI changed. Remove if not applicable. -->

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools