### PR TITLE
fix(TabbedTerminal): reattach terminal after container recreation

### DIFF
--- a/src/renderer/components/Right/TabbedTerminal.tsx
+++ b/src/renderer/components/Right/TabbedTerminal.tsx
@@ -350,6 +350,11 @@ export function TabbedTerminal({ worktreePath, projectId, projectPath, hidden, c
                   containerRefs.current.set(tab.id, el)
                   const pending = pendingAttach.current.get(tab.id)
                   if (pending) { pendingAttach.current.delete(tab.id); attachTerm(pending, el); setupResizeObserver(pending, el); spawnTab(pending) }
+                  else if (tab.term.element && !el.contains(tab.term.element)) {
+                    // Container was recreated (e.g. after collapse/uncollapse) — re-attach and re-observe
+                    attachTerm(tab, el)
+                    setupResizeObserver(tab, el)
+                  }
                 }
               }}
               className="terminal-container"

--- a/src/renderer/components/Right/TabbedTerminal.tsx
+++ b/src/renderer/components/Right/TabbedTerminal.tsx
@@ -351,8 +351,8 @@ export function TabbedTerminal({ worktreePath, projectId, projectPath, hidden, c
                   const pending = pendingAttach.current.get(tab.id)
                   if (pending) { pendingAttach.current.delete(tab.id); attachTerm(pending, el); setupResizeObserver(pending, el); spawnTab(pending) }
                   else if (tab.term.element && !el.contains(tab.term.element)) {
-                    // Container was recreated (e.g. after collapse/uncollapse) — re-attach and re-observe
-                    attachTerm(tab, el)
+                    // Container was recreated (e.g. after collapse/uncollapse) — move the existing terminal element and re-observe
+                    el.appendChild(tab.term.element)
                     setupResizeObserver(tab, el)
                   }
                 }


### PR DESCRIPTION
## Summary

- Fix terminal not resizing to fill after collapse/uncollapse. The ResizeObserver was lost when container divs were unmounted, so subsequent panel resizes never triggered `fitAddon.fit()`.

Closes #45

## Layers touched

- [x] **Renderer** (`src/renderer/`) — components, stores, lib

## Changes

**Right panel:**
- `TabbedTerminal.tsx`: When the container ref callback fires on a new DOM element, check if the existing terminal's element is no longer a child of the new container. If so, re-attach the terminal and re-establish the `ResizeObserver`. The `!el.contains(tab.term.element)` guard prevents unnecessary work on normal re-renders.

## How to test

1. `yarn dev`
2. Open a worktree with a terminal tab active
3. Resize the terminal panel (drag vertical handle) - confirm it works
4. Collapse the terminal, then uncollapse it
5. Resize the terminal panel again - **terminal grid should reflow correctly**
6. Test with multiple terminal tabs
7. Test right panel width resize after collapse/uncollapse

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store