### PR TITLE
fix: centralize SimpleGit initialization with enriched environment

### DIFF
--- a/src/main/services/files.ts
+++ b/src/main/services/files.ts
@@ -1,5 +1,5 @@
 import { logger } from '../lib/logger'
-import simpleGit from 'simple-git'
+import { getGit } from './git/core'
 import { existsSync, statSync, copyFileSync, mkdirSync, readdirSync, readFileSync } from 'fs'
 import { join, dirname, relative } from 'path'
 import { ServiceCache } from '../lib/serviceCache'
@@ -131,7 +131,7 @@ class FilesService {
   private async _fetchIgnoredFiles(worktreePath: string, patterns?: string[]): Promise<IgnoredFile[]> {
     try {
       const globs = (patterns && patterns.length > 0 ? patterns : DEFAULT_PATTERNS).map(globToRegex)
-      const git = simpleGit(worktreePath)
+      const git = getGit(worktreePath)
       const raw = await git.raw(['ls-files', '--others', '--ignored', '--exclude-standard'])
       const files = raw
         .split('\n')

--- a/src/main/services/git/__tests__/branches.test.ts
+++ b/src/main/services/git/__tests__/branches.test.ts
@@ -3,10 +3,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // --- Mock simple-git ---
 const mockRaw = vi.fn()
 const mockBranchLocal = vi.fn()
-const mockGit = { raw: mockRaw, branchLocal: mockBranchLocal }
+const mockEnv = vi.fn()
+const mockGit = { raw: mockRaw, branchLocal: mockBranchLocal, env: mockEnv }
 
 vi.mock('simple-git', () => ({
   default: vi.fn(() => mockGit),
+}))
+
+vi.mock('../../../lib/enrichedEnv', () => ({
+  enrichedEnv: () => ({ ...process.env }),
 }))
 
 // --- Mock fs ---

--- a/src/main/services/git/__tests__/operations.test.ts
+++ b/src/main/services/git/__tests__/operations.test.ts
@@ -8,10 +8,15 @@ const mockAdd = vi.fn()
 const mockReset = vi.fn()
 const mockCheckout = vi.fn()
 const mockCommit = vi.fn()
-const mockGit = { raw: mockRaw, push: mockPush, pull: mockPull, add: mockAdd, reset: mockReset, checkout: mockCheckout, commit: mockCommit }
+const mockEnv = vi.fn()
+const mockGit = { raw: mockRaw, push: mockPush, pull: mockPull, add: mockAdd, reset: mockReset, checkout: mockCheckout, commit: mockCommit, env: mockEnv }
 
 vi.mock('simple-git', () => ({
   default: vi.fn(() => mockGit),
+}))
+
+vi.mock('../../../lib/enrichedEnv', () => ({
+  enrichedEnv: () => ({ ...process.env }),
 }))
 
 // --- Mock fs ---

--- a/src/main/services/git/__tests__/status.test.ts
+++ b/src/main/services/git/__tests__/status.test.ts
@@ -4,10 +4,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const mockRaw = vi.fn()
 const mockDiff = vi.fn()
 const mockStatus = vi.fn()
-const mockGit = { raw: mockRaw, diff: mockDiff, status: mockStatus }
+const mockEnv = vi.fn()
+const mockGit = { raw: mockRaw, diff: mockDiff, status: mockStatus, env: mockEnv }
 
 vi.mock('simple-git', () => ({
   default: vi.fn(() => mockGit),
+}))
+
+vi.mock('../../../lib/enrichedEnv', () => ({
+  enrichedEnv: () => ({ ...process.env }),
 }))
 
 // --- Mock fs ---

--- a/src/main/services/git/__tests__/worktrees.test.ts
+++ b/src/main/services/git/__tests__/worktrees.test.ts
@@ -4,7 +4,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const mockRaw = vi.fn()
 const mockBranchLocal = vi.fn()
 const mockClone = vi.fn()
-const mockGit = { raw: mockRaw, branchLocal: mockBranchLocal, clone: mockClone }
+const mockEnv = vi.fn()
+const mockGit = { raw: mockRaw, branchLocal: mockBranchLocal, clone: mockClone, env: mockEnv }
 
 vi.mock('simple-git', () => ({
   default: vi.fn(() => mockGit),
@@ -27,6 +28,11 @@ vi.mock('fs', async (importActual) => {
 
 // --- Mock appBrand ---
 vi.mock('../../appBrand', () => ({ DATA_DIR_NAME: 'Braid' }))
+
+// --- Mock enrichedEnv ---
+vi.mock('../../../lib/enrichedEnv', () => ({
+  enrichedEnv: () => ({ ...process.env }),
+}))
 
 // Import AFTER mocks are in place
 import { getWorktrees, addWorktree, removeWorktree, cloneRepo, parseRepoName, CloneError } from '../worktrees'

--- a/src/main/services/git/core.ts
+++ b/src/main/services/git/core.ts
@@ -1,5 +1,6 @@
 import simpleGit, { SimpleGit } from 'simple-git'
 import { existsSync } from 'fs'
+import { enrichedEnv } from '../../lib/enrichedEnv'
 
 export const NOISE_DIRS = new Set([
   'node_modules', '.git', 'dist', '.next', 'build', 'out',
@@ -7,7 +8,9 @@ export const NOISE_DIRS = new Set([
 ])
 
 export function getGit(repoPath: string): SimpleGit {
-  return simpleGit(repoPath)
+  const git = simpleGit(repoPath)
+  git.env(enrichedEnv())
+  return git
 }
 
 /** Returns a SimpleGit instance if path is a valid git repo, null otherwise */

--- a/src/main/services/git/operations.ts
+++ b/src/main/services/git/operations.ts
@@ -1,11 +1,10 @@
 import { unlinkSync, mkdirSync } from 'fs'
 import { join } from 'path'
-import simpleGit from 'simple-git'
-import { getValidGit } from './core'
+import { getGit, getValidGit } from './core'
 
 export async function initRepo(dirPath: string): Promise<void> {
   mkdirSync(dirPath, { recursive: true })
-  const git = simpleGit(dirPath)
+  const git = getGit(dirPath)
   await git.init(['-b', 'main'])
   await git.raw(['commit', '--allow-empty', '-m', 'Initial commit'])
 }

--- a/src/main/services/git/worktrees.ts
+++ b/src/main/services/git/worktrees.ts
@@ -1,10 +1,9 @@
 import { logger } from '../../lib/logger'
-import { getGit } from './core'
+import { getGit, getValidGit } from './core'
 import { mkdirSync, existsSync, rmSync } from 'fs'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
 import { DATA_DIR_NAME } from '../../appBrand'
-import { getValidGit } from './core'
 import type { WorktreeInfo } from './types'
 
 export async function getWorktrees(repoPath: string): Promise<WorktreeInfo[]> {

--- a/src/main/services/git/worktrees.ts
+++ b/src/main/services/git/worktrees.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../lib/logger'
-import simpleGit from 'simple-git'
+import { getGit } from './core'
 import { mkdirSync, existsSync, rmSync } from 'fs'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
@@ -162,7 +162,7 @@ export async function cloneRepo(url: string, storagePath?: string): Promise<stri
     finalPath = `${targetPath}-${i}`
   }
 
-  const git = simpleGit()
+  const git = getGit(process.cwd())
   try {
     await git.clone(url, finalPath)
   } catch (err) {

--- a/src/main/services/git/worktrees.ts
+++ b/src/main/services/git/worktrees.ts
@@ -162,7 +162,7 @@ export async function cloneRepo(url: string, storagePath?: string): Promise<stri
     finalPath = `${targetPath}-${i}`
   }
 
-  const git = getGit(process.cwd())
+  const git = getGit(dirname(finalPath))
   try {
     await git.clone(url, finalPath)
   } catch (err) {

--- a/src/main/services/github.ts
+++ b/src/main/services/github.ts
@@ -1,8 +1,8 @@
 import { execFile, spawn } from 'child_process'
 import { promisify } from 'util'
-import simpleGit from 'simple-git'
 import { ServiceCache } from '../lib/serviceCache'
 import { enrichedEnv } from '../lib/enrichedEnv'
+import { getGit } from './git/core'
 
 const exec = promisify(execFile)
 
@@ -35,7 +35,7 @@ async function fetchIfStale(worktreePath: string): Promise<void> {
   if (now - lastFetch < FETCH_COOLDOWN_MS) return
 
   fetchTimestamps.set(worktreePath, now)
-  const git = simpleGit(worktreePath)
+  const git = getGit(worktreePath)
   await git.fetch(['--no-tags', '--prune', 'origin'])
 }
 
@@ -199,7 +199,7 @@ class GitHubService {
     const nwoRaw = await resolveNwo(worktreePath)
 
     // Get branch name from git
-    const git = simpleGit(worktreePath)
+    const git = getGit(worktreePath)
     const branch = (await git.revparse(['--abbrev-ref', 'HEAD'])).trim()
     if (!branch) return []
 
@@ -351,7 +351,7 @@ class GitHubService {
       baseBranch
     }
     try {
-      const git = simpleGit(worktreePath)
+      const git = getGit(worktreePath)
       const status = await git.status()
       result.uncommittedChanges =
         status.modified.length +


### PR DESCRIPTION
## Summary

- Centralizes all `SimpleGit` initialization through `getGit()` in `core.ts`, which now injects `enrichedEnv()` automatically
- Replaces direct `simpleGit()` calls in `files.ts`, `operations.ts`, `worktrees.ts`, and `github.ts` with the centralized helper
- Fixes `cloneRepo` to use the target directory instead of `cwd` for git operations

## Layers touched

- [x] **Main process** (`src/main/`) — services, IPC handlers

## Changes

**Services** (`git.ts` / `github.ts` / `files.ts`):
- `core.ts`: `getGit()` now calls `git.env(enrichedEnv())` so every SimpleGit instance inherits the enriched environment (PATH, etc.)
- `files.ts`: replaced `simpleGit(worktreePath)` with `getGit(worktreePath)`
- `operations.ts`: replaced `simpleGit(dirPath)` with `getGit(dirPath)` in `initRepo`
- `worktrees.ts`: replaced `simpleGit()` with `getGit(dirname(finalPath))` in `cloneRepo` - also fixes a bug where clone ran against cwd instead of the target directory
- `github.ts`: replaced all 3 `simpleGit(worktreePath)` calls with `getGit(worktreePath)`

**Tests**:
- Updated `branches`, `operations`, `status`, and `worktrees` test suites to mock `enrichedEnv` and the new `.env()` method on the SimpleGit mock

## How to test

1. `yarn dev`
2. Clone a new repo via Braid - verify it clones successfully
3. Create a worktree - verify git operations (status, push, pull) work correctly
4. Verify `yarn typecheck` and `yarn test` pass

## Checklist

- [x] Self-reviewed the diff
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools