### PR TITLE
fix(notifications): fire toast/sound for AskUserQuestion and always bounce dock on waiting_input

### DIFF
--- a/src/main/services/agent.ts
+++ b/src/main/services/agent.ts
@@ -180,7 +180,7 @@ class AgentCoordinator {
         // maybeNotify) because the user may be looking at a different session
         // or have Braid focused behind another app.
         this.maybeNotify(event.sessionId, 'waiting_input', undefined,
-          event.reason === 'tool_permission' || event.reason === 'elicitation' ? undefined : event.reason as 'question' | 'plan_approval' | undefined)
+          event.reason === 'question' || event.reason === 'plan_approval' ? event.reason : undefined)
         break
       case 'elicitation_complete':
         this.sendEvent(event.sessionId, { type: 'elicitation_complete', serverName: event.serverName })
@@ -443,7 +443,7 @@ class AgentCoordinator {
       ? `${projectPrefix}${rawName} — ${branch}`
       : `${projectPrefix}${sessionName}`
 
-    const waitingTitle = reason === 'plan_approval' ? 'Plan ready for review' : 'Agent has a question'
+    const waitingTitle = reason === 'plan_approval' ? 'Plan ready for review' : reason === 'question' ? 'Agent has a question' : 'Agent needs input'
     const waitingBody = reason === 'plan_approval'
       ? `${label} — review and approve the plan`
       : `${label} — reply to continue`

--- a/src/main/services/agent.ts
+++ b/src/main/services/agent.ts
@@ -175,8 +175,12 @@ class AgentCoordinator {
         } else {
           this.sendEvent(event.sessionId, { type: 'waiting_input', reason: event.reason })
         }
+        // Fire desktop notification directly from the main process. For
+        // waiting_input we intentionally bypass the isFocused guard (see
+        // maybeNotify) because the user may be looking at a different session
+        // or have Braid focused behind another app.
         this.maybeNotify(event.sessionId, 'waiting_input', undefined,
-          event.reason === 'tool_permission' || event.reason === 'elicitation' ? undefined : event.reason)
+          event.reason === 'tool_permission' || event.reason === 'elicitation' ? undefined : event.reason as 'question' | 'plan_approval' | undefined)
         break
       case 'elicitation_complete':
         this.sendEvent(event.sessionId, { type: 'elicitation_complete', serverName: event.serverName })
@@ -411,7 +415,10 @@ class AgentCoordinator {
     if (type === 'waiting_input' && !mainSettings.notifyOnWaitingInput) return
 
     const win = this.getWindow()
-    if (win && !win.isDestroyed() && win.isFocused()) return
+    // For waiting_input (AI asking a question), always notify regardless of focus —
+    // the user may be looking at a different session or worktree.
+    const skipWhenFocused = type !== 'waiting_input'
+    if (skipWhenFocused && win && !win.isDestroyed() && win.isFocused()) return
 
     if (process.platform === 'darwin' && app.dock) {
       app.dock.bounce(type === 'waiting_input' ? 'critical' : 'informational')

--- a/src/renderer/store/sessions/__tests__/handleWaiting.test.ts
+++ b/src/renderer/store/sessions/__tests__/handleWaiting.test.ts
@@ -134,11 +134,26 @@ describe('handleWaitingInput (question/plan_approval)', () => {
     expect(s.pendingQuestion?.toolUseId).toBe('tc-1')
   })
 
-  it('is idempotent when status is already waiting_input', () => {
+  it('is idempotent when status is already waiting_input (skips state update)', () => {
     const store = makeStore({ status: 'waiting_input' })
     handleWaitingInput(makeCtx(store), { reason: 'question' })
-    // persistSession should not be called (early return)
+    // State is already correct — no persist needed
     expect(persistSession).not.toHaveBeenCalled()
+  })
+
+  it('still fires maybeShowToast when status is already waiting_input', () => {
+    // Regression: handleAssistant pre-sets status='waiting_input' via resolvePendingState
+    // before the waiting_input event arrives.  The old code returned early and skipped
+    // maybeShowToast entirely, so the in-app toast and sound were never triggered.
+    const store = makeStore({ status: 'waiting_input' })
+    handleWaitingInput(makeCtx(store), { reason: 'question' })
+    expect(maybeShowToast).toHaveBeenCalledWith('sess-1', 'waiting_input', expect.anything(), 'question')
+  })
+
+  it('fires maybeShowToast before the status guard so both running and waiting sessions notify', () => {
+    const storeFresh = makeStore({ status: 'running' })
+    handleWaitingInput(makeCtx(storeFresh), { reason: 'question' })
+    expect(vi.mocked(maybeShowToast)).toHaveBeenCalledWith('sess-1', 'waiting_input', expect.anything(), 'question')
   })
 })
 

--- a/src/renderer/store/sessions/handlers/handleWaiting.ts
+++ b/src/renderer/store/sessions/handlers/handleWaiting.ts
@@ -17,6 +17,10 @@ import { maybeShowToast, createNotificationDeps } from './notifications'
  * - `reason === 'tool_permission'`: direct tool permission prompt (data in event)
  * - `reason === 'elicitation'`: MCP server auth/input request (data in event)
  * - Otherwise: AskUserQuestion / ExitPlanMode (resolved from message history)
+ *
+ * Desktop notifications are fired from the main process (agent.ts maybeNotify)
+ * so they fire even when the window is focused on a different session.
+ * The renderer only handles in-app toasts here.
  */
 export function handleWaitingInput(ctx: HandlerContext, ev: Record<string, unknown>): void {
   const { store, sessionId } = ctx
@@ -59,7 +63,22 @@ export function handleWaitingInput(ctx: HandlerContext, ev: Record<string, unkno
 
   // AskUserQuestion / ExitPlanMode: resolve pending state from message history
   const session = store.getState().sessions[sessionId]
-  if (!session || session.status === 'waiting_input') return
+  if (!session) return
+
+  // Always fire the in-app toast — addToast deduplicates by sessionId+type so
+  // this is safe even if handleAssistant already pre-set status to 'waiting_input'
+  // by calling resolvePendingState on the tool-call block.  Without this call the
+  // toast (and its accompanying sound) would never fire for AskUserQuestion /
+  // ExitPlanMode because the status guard below returns early.
+  maybeShowToast(
+    sessionId,
+    'waiting_input',
+    createNotificationDeps(),
+    reason as 'question' | 'plan_approval' | undefined
+  )
+
+  // State is already correct when handleAssistant pre-set it — skip the redundant update.
+  if (session.status === 'waiting_input') return
 
   const lastAssistant = findLastAssistantWithTools(session.messages)
   const pending = lastAssistant?.toolCalls
@@ -72,12 +91,6 @@ export function handleWaitingInput(ctx: HandlerContext, ev: Record<string, unkno
     ...pending
   }))
   persistSession(sessionId)
-  maybeShowToast(
-    sessionId,
-    'waiting_input',
-    createNotificationDeps(),
-    reason as 'question' | 'plan_approval' | undefined
-  )
 }
 
 /**

--- a/src/renderer/store/sessions/handlers/handleWaiting.ts
+++ b/src/renderer/store/sessions/handlers/handleWaiting.ts
@@ -65,20 +65,18 @@ export function handleWaitingInput(ctx: HandlerContext, ev: Record<string, unkno
   const session = store.getState().sessions[sessionId]
   if (!session) return
 
+  const alreadyWaiting = session.status === 'waiting_input'
+  const typedReason = reason === 'question' || reason === 'plan_approval' ? reason : undefined
+
   // Always fire the in-app toast — addToast deduplicates by sessionId+type so
   // this is safe even if handleAssistant already pre-set status to 'waiting_input'
   // by calling resolvePendingState on the tool-call block.  Without this call the
   // toast (and its accompanying sound) would never fire for AskUserQuestion /
   // ExitPlanMode because the status guard below returns early.
-  maybeShowToast(
-    sessionId,
-    'waiting_input',
-    createNotificationDeps(),
-    reason as 'question' | 'plan_approval' | undefined
-  )
+  maybeShowToast(sessionId, 'waiting_input', createNotificationDeps(), typedReason)
 
   // State is already correct when handleAssistant pre-set it — skip the redundant update.
-  if (session.status === 'waiting_input') return
+  if (alreadyWaiting) return
 
   const lastAssistant = findLastAssistantWithTools(session.messages)
   const pending = lastAssistant?.toolCalls

--- a/src/renderer/store/sessions/handlers/notifications.ts
+++ b/src/renderer/store/sessions/handlers/notifications.ts
@@ -73,7 +73,11 @@ export function fireDesktopNotification(
   deps: Pick<NotificationDeps, 'desktopNotify'>,
   reason?: 'question' | 'plan_approval'
 ): void {
-  deps.desktopNotify(sessionId, type, sessionName, undefined, reason)
+  if (reason !== undefined) {
+    deps.desktopNotify(sessionId, type, sessionName, undefined, reason)
+    return
+  }
+  deps.desktopNotify(sessionId, type, sessionName)
 }
 
 // ---------------------------------------------------------------------------
@@ -111,6 +115,6 @@ export function createNotificationDeps(): NotificationDeps {
     getProjectCount: () => useProjectsStore.getState().projects.length,
     addToast: (toast) => useToastsStore.getState().addToast(toast),
     desktopNotify: (sessionId, type, name, errorMessage, reason) =>
-      ipc.agent.notify(sessionId, type as 'done' | 'error' | 'waiting_input', name, errorMessage, reason)
+      ipc.agent.notify(sessionId, type, name, errorMessage, reason)
   }
 }

--- a/src/renderer/store/sessions/handlers/notifications.ts
+++ b/src/renderer/store/sessions/handlers/notifications.ts
@@ -37,9 +37,10 @@ export function maybeShowToast(
   if (type === 'error' && !ui.notifyOnError) return
   if (type === 'waiting_input' && !ui.notifyOnWaitingInput) return
 
-  // Skip if user is already viewing this session
+  // Skip if user is already viewing this session — but always notify for
+  // waiting_input: Claude is blocked and needs attention regardless of focus
   const cv = ui.activeCenterView
-  if (cv?.type === 'session' && cv.sessionId === sessionId) return
+  if (type !== 'waiting_input' && cv?.type === 'session' && cv.sessionId === sessionId) return
 
   const session = deps.getSessionInfo(sessionId)
   if (!session) return
@@ -69,9 +70,10 @@ export function fireDesktopNotification(
   sessionId: string,
   type: 'done' | 'error' | 'waiting_input',
   sessionName: string,
-  deps: Pick<NotificationDeps, 'desktopNotify'>
+  deps: Pick<NotificationDeps, 'desktopNotify'>,
+  reason?: 'question' | 'plan_approval'
 ): void {
-  deps.desktopNotify(sessionId, type, sessionName)
+  deps.desktopNotify(sessionId, type, sessionName, undefined, reason)
 }
 
 // ---------------------------------------------------------------------------
@@ -108,7 +110,7 @@ export function createNotificationDeps(): NotificationDeps {
     },
     getProjectCount: () => useProjectsStore.getState().projects.length,
     addToast: (toast) => useToastsStore.getState().addToast(toast),
-    desktopNotify: (sessionId, type, name) =>
-      ipc.agent.notify(sessionId, type as 'done' | 'error' | 'waiting_input', name)
+    desktopNotify: (sessionId, type, name, errorMessage, reason) =>
+      ipc.agent.notify(sessionId, type as 'done' | 'error' | 'waiting_input', name, errorMessage, reason)
   }
 }

--- a/src/renderer/store/sessions/handlers/types.ts
+++ b/src/renderer/store/sessions/handlers/types.ts
@@ -67,7 +67,7 @@ export interface NotificationDeps {
     projectName: string
     reason?: 'question' | 'plan_approval'
   }) => void
-  desktopNotify: (sessionId: string, type: string, name: string, errorMessage?: string, reason?: 'question' | 'plan_approval') => void
+  desktopNotify: (sessionId: string, type: 'done' | 'error' | 'waiting_input', name: string, errorMessage?: string, reason?: 'question' | 'plan_approval') => void
 }
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/store/sessions/handlers/types.ts
+++ b/src/renderer/store/sessions/handlers/types.ts
@@ -67,7 +67,7 @@ export interface NotificationDeps {
     projectName: string
     reason?: 'question' | 'plan_approval'
   }) => void
-  desktopNotify: (sessionId: string, type: string, name: string) => void
+  desktopNotify: (sessionId: string, type: string, name: string, errorMessage?: string, reason?: 'question' | 'plan_approval') => void
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Toasts and sounds were silently swallowed for every `AskUserQuestion` / `ExitPlanMode` event because `handleWaitingInput` returned early before calling `maybeShowToast`
- Dock bounce now fires even when the Braid window is focused for `waiting_input` events
- Desktop notifications now receive the correct reason (`question`/`plan_approval`)

## Layers touched

- [x] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [ ] **Styles** (`App.css`)

## Changes

**Stores** (`projects.ts` / `sessions.ts` / `ui.ts`):
- `handleWaiting.ts`: moved `maybeShowToast` call before the `session.status === 'waiting_input'` early return so it fires for pre-set status (AskUserQuestion path)
- `notifications.ts`: removed `skipWhenFocused` guard for `waiting_input`; `fireDesktopNotification` now accepts and forwards the `reason` field

**Services** (`git.ts` / `claude.ts` / `github.ts` / `pty.ts`):
- `agent.ts`: passes `reason` (question/plan_approval) when calling the waiting_input IPC event so desktop notification copy is correct

## How to test

1. `yarn dev`
2. Start a session and trigger an `AskUserQuestion` (e.g. use a skill that asks a question)
3. Verify a toast and sound fire — even if you are already viewing that session
4. Switch away from Braid and trigger `AskUserQuestion` again — verify dock bounces
5. Run `yarn test handleWaiting` — both new regression tests should pass

## Screenshots
<img width="1484" height="1406" alt="image" src="https://github.com/user-attachments/assets/a50c2ff6-4a24-4ae2-8bc5-b8e1f371c776" />


## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store