### PR TITLE
fix: snippet card overflow and visual polish

### DIFF
--- a/src/renderer/styles/chat-messages.css
+++ b/src/renderer/styles/chat-messages.css
@@ -133,7 +133,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-  max-width: 75%;
+  max-width: 60%;
   min-width: 0;
 }
 
@@ -183,7 +183,7 @@
   white-space: nowrap;
   flex-shrink: 0;
   padding: var(--space-1) var(--space-6);
-  background: var(--overlay-5);
+  background: var(--overlay-6);
   border-radius: var(--radius-pill);
 }
 
@@ -207,6 +207,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+  max-width: 100%;
+  min-width: 0;
 }
 
 .chat-msg-terminal-card {
@@ -253,7 +255,9 @@
   color: var(--text-muted);
   white-space: nowrap;
   flex-shrink: 0;
-  opacity: 0.8;
+  padding: var(--space-1) var(--space-6);
+  background: var(--overlay-6);
+  border-radius: var(--radius-pill);
 }
 
 .chat-msg-terminal-card-content {

--- a/src/renderer/styles/chat-messages.css
+++ b/src/renderer/styles/chat-messages.css
@@ -133,12 +133,15 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+  max-width: 75%;
+  min-width: 0;
 }
 
 .chat-msg-snippet-card {
   border-radius: var(--radius);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
+  border-left: 2px solid var(--accent-tint-40);
   overflow: hidden;
   min-width: 0;
 }
@@ -147,9 +150,9 @@
   display: flex;
   align-items: center;
   gap: var(--space-6);
-  padding: var(--space-5) var(--space-8);
+  padding: var(--space-6) var(--space-10);
   font-size: var(--text-base);
-  min-height: 28px;
+  min-height: 30px;
   width: 100%;
   border: none;
   background: transparent;
@@ -179,7 +182,9 @@
   color: var(--text-muted);
   white-space: nowrap;
   flex-shrink: 0;
-  opacity: 0.8;
+  padding: var(--space-1) var(--space-6);
+  background: var(--overlay-5);
+  border-radius: var(--radius-pill);
 }
 
 .chat-msg-snippet-card-content {

--- a/src/renderer/styles/snippet-chips.css
+++ b/src/renderer/styles/snippet-chips.css
@@ -64,7 +64,7 @@
   white-space: nowrap;
   flex-shrink: 0;
   padding: var(--space-1) var(--space-6);
-  background: var(--overlay-5);
+  background: var(--overlay-6);
   border-radius: var(--radius-pill);
 }
 

--- a/src/renderer/styles/snippet-chips.css
+++ b/src/renderer/styles/snippet-chips.css
@@ -5,12 +5,14 @@
   flex-direction: column;
   gap: var(--space-6);
   padding: var(--space-8) var(--space-12) 0;
+  min-width: 0;
 }
 
 .snippet-chip {
   border-radius: var(--radius);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
+  border-left: 2px solid var(--accent-tint-40);
   overflow: hidden;
   min-width: 0;
 }
@@ -61,7 +63,9 @@
   color: var(--text-muted);
   white-space: nowrap;
   flex-shrink: 0;
-  opacity: 0.8;
+  padding: var(--space-1) var(--space-6);
+  background: var(--overlay-5);
+  border-radius: var(--radius-pill);
 }
 
 .snippet-chip-remove {


### PR DESCRIPTION
## Summary

- Fix snippet and terminal cards overflowing to the left when the window is narrow
- Polish snippet card visuals with accent border and pill-styled badges

## Changes

**`chat-messages.css`:**
- Add `max-width: 60%` + `min-width: 0` to `.chat-msg-snippets` - prevents wide `<pre>` content from overflowing past the parent under `align-items: flex-end`
- Add `max-width: 100%` + `min-width: 0` to `.chat-msg-terminal-blocks` - same containment fix
- Add `border-left: 2px solid var(--accent-tint-40)` to snippet cards for visual distinction
- Replace `opacity: 0.8` badges with pill-styled badges (`--overlay-6` background + `border-radius: pill`)
- Slightly increase snippet header padding for better breathing room

**`snippet-chips.css`:**
- Add `min-width: 0` to `.snippet-chips` container for flex shrink safety
- Add `border-left: 2px solid var(--accent-tint-40)` to input area chips (consistent with sent cards)
- Same pill badge treatment for line/char count

## How to test

1. `yarn dev`
2. Paste a long code snippet (10+ lines with long lines) into the chat input
3. Send the message - verify the snippet card stays contained, doesn't overflow left
4. Resize the window smaller - verify card shrinks and `<pre>` scrolls horizontally
5. Verify accent left border and pill badges render on both input chips and sent cards