### PR TITLE
feat(ui): add project avatar visibility toggle in settings

### DIFF
--- a/src/renderer/components/Settings/SettingsAppearance.tsx
+++ b/src/renderer/components/Settings/SettingsAppearance.tsx
@@ -68,6 +68,8 @@ export function SettingsAppearance() {
   const setStreamingAnimation = useUIStore((s) => s.setStreamingAnimation)
   const chatCompactMode = useUIStore((s) => s.chatCompactMode)
   const setChatCompactMode = useUIStore((s) => s.setChatCompactMode)
+  const projectAvatarVisible = useUIStore((s) => s.projectAvatarVisible)
+  const setProjectAvatarVisible = useUIStore((s) => s.setProjectAvatarVisible)
 
   const handleSelect = (theme: ThemePalette) => {
     setTheme(theme.id)
@@ -144,6 +146,14 @@ export function SettingsAppearance() {
         horizontal
       >
         <Toggle checked={chatCompactMode} onChange={setChatCompactMode} />
+      </FormField>
+
+      <FormField
+        label={t('appearance.projectAvatar')}
+        hint={t('appearance.projectAvatarHint')}
+        horizontal
+      >
+        <Toggle checked={projectAvatarVisible} onChange={setProjectAvatarVisible} />
       </FormField>
 
       {groupBuiltinThemes().map(({ group, themes }) => (

--- a/src/renderer/components/Sidebar/ProjectList.tsx
+++ b/src/renderer/components/Sidebar/ProjectList.tsx
@@ -100,6 +100,7 @@ function ProjectGroupRow({
 }: ProjectGroupRowProps) {
   const isExpanded = useUIStore((s) => s.expandedProjects.has(project.id))
   const toggleProject = useUIStore((s) => s.toggleProject)
+  const projectAvatarVisible = useUIStore((s) => s.projectAvatarVisible)
   const pinnedWorktrees = useUIStore((s) => s.pinnedWorktrees)
   const worktreeOrders = useUIStore((s) => s.worktreeOrders)
   const reorderWorktreesById = useUIStore((s) => s.reorderWorktreesById)
@@ -197,7 +198,7 @@ function ProjectGroupRow({
         }}
       >
         <span className={`project-chevron ${isExpanded ? 'expanded' : ''}`}>&#9654;</span>
-        <ProjectAvatar name={project.name} avatarUrl={project.avatarUrl} />
+        {projectAvatarVisible && <ProjectAvatar name={project.name} avatarUrl={project.avatarUrl} />}
         <span className="project-name">{project.name}</span>
 
         {!isExpanded && notifyStatus && (

--- a/src/renderer/lib/storageKeys.ts
+++ b/src/renderer/lib/storageKeys.ts
@@ -81,6 +81,7 @@ export const SK = {
   skipDeleteWorktreeConfirm:  `${prefix}:skipDeleteWorktreeConfirm`,
   tabDisplayMode:             `${prefix}:tabDisplayMode`,
   chatCompactMode:            `${prefix}:chatCompactMode`,
+  projectAvatarVisible:       `${prefix}:projectAvatarVisible`,
 
   // ── i18n ───────────────────────────────────────────────────────────────
   language:                   `${prefix}:language`,

--- a/src/renderer/locales/en/settings.json
+++ b/src/renderer/locales/en/settings.json
@@ -63,7 +63,9 @@
     "streamingAnimation": "Streaming Animation",
     "streamingAnimationHint": "Animate words as they stream in",
     "chatCompactMode": "Chat Compact Mode",
-    "chatCompactModeHint": "Reduce spacing and font sizes for a denser, CLI-like chat display"
+    "chatCompactModeHint": "Reduce spacing and font sizes for a denser, CLI-like chat display",
+    "projectAvatar": "Project Avatar",
+    "projectAvatarHint": "Show project icon next to each project name in the sidebar"
   },
   "ai": {
     "defaultModel": "Default Model",

--- a/src/renderer/locales/id/settings.json
+++ b/src/renderer/locales/id/settings.json
@@ -63,7 +63,9 @@
     "streamingAnimation": "Animasi Streaming",
     "streamingAnimationHint": "Animasikan kata saat streaming masuk",
     "chatCompactMode": "Mode Kompak Chat",
-    "chatCompactModeHint": "Kurangi jarak dan ukuran font untuk tampilan chat yang lebih padat seperti CLI"
+    "chatCompactModeHint": "Kurangi jarak dan ukuran font untuk tampilan chat yang lebih padat seperti CLI",
+    "projectAvatar": "Avatar Proyek",
+    "projectAvatarHint": "Tampilkan ikon proyek di samping nama proyek di sidebar"
   },
   "ai": {
     "defaultModel": "Model Default",

--- a/src/renderer/locales/ja/settings.json
+++ b/src/renderer/locales/ja/settings.json
@@ -63,7 +63,9 @@
     "streamingAnimation": "ストリーミングアニメーション",
     "streamingAnimationHint": "ストリーミング時にワードごとにアニメーション表示する",
     "chatCompactMode": "チャットコンパクトモード",
-    "chatCompactModeHint": "間隔とフォントサイズを縮小し、CLIのようなチャット表示にする"
+    "chatCompactModeHint": "間隔とフォントサイズを縮小し、CLIのようなチャット表示にする",
+    "projectAvatar": "プロジェクトアバター",
+    "projectAvatarHint": "サイドバーのプロジェクト名の横にアイコンを表示する"
   },
   "ai": {
     "defaultModel": "デフォルトモデル",

--- a/src/renderer/store/ui/layout.ts
+++ b/src/renderer/store/ui/layout.ts
@@ -116,6 +116,7 @@ export interface LayoutSlice {
   skipDeleteWorktreeConfirm: boolean
   newlyAddedWorktreeId: string | null
   missionControlActive: boolean
+  projectAvatarVisible: boolean
   sidebarPanelOpen: boolean
   rightPanelVisible: boolean
   sidebarWidth: number
@@ -145,6 +146,7 @@ export interface LayoutSlice {
   setSkipDeleteWorktreeConfirm: (skip: boolean) => void
   setNewlyAddedWorktreeId: (id: string | null) => void
   prependWorktreeToOrder: (projectId: string, worktreeId: string) => void
+  setProjectAvatarVisible: (visible: boolean) => void
   toggleMissionControl: () => void
   setMissionControlActive: (active: boolean) => void
   toggleSidebar: () => void
@@ -199,6 +201,7 @@ export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (se
   activeCenterViewByWorktree: {},
   skipDeleteWorktreeConfirm: localStorage.getItem(SK.skipDeleteWorktreeConfirm) === 'true',
   newlyAddedWorktreeId: null,
+  projectAvatarVisible: loadBool(SK.projectAvatarVisible, true),
   missionControlActive: loadBool(SK.missionControlActive, false),
   sidebarPanelOpen: (() => {
     const saved = localStorage.getItem(SK.sidebarPanelOpen)
@@ -451,6 +454,11 @@ export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (se
     orders[projectId] = [worktreeId, ...current.filter((id) => id !== worktreeId)]
     saveWorktreeOrders(orders)
     set({ worktreeOrders: orders, newlyAddedWorktreeId: worktreeId })
+  },
+
+  setProjectAvatarVisible: (visible) => {
+    localStorage.setItem(SK.projectAvatarVisible, String(visible))
+    set({ projectAvatarVisible: visible })
   },
 
   toggleMissionControl: () => {


### PR DESCRIPTION
## Summary

- Adds a "Project Avatar" toggle to Settings > Appearance that controls whether project icons are shown next to project names in the sidebar
- Defaults to visible (on), matching current behavior

## Layers touched

- [x] **Renderer** (`src/renderer/`) — components, stores, lib

## Changes

**Sidebar:**
- `ProjectList.tsx` - Conditionally renders `<ProjectAvatar>` based on the new `projectAvatarVisible` state

**Settings:**
- `SettingsAppearance.tsx` - Adds a new `Toggle` field for "Project Avatar" with localized label and hint

**Stores** (`ui/layout.ts`):
- New `projectAvatarVisible` boolean in `LayoutSlice`, persisted to localStorage, defaults to `true`
- New `setProjectAvatarVisible` action

**Other:**
- `storageKeys.ts` - New `projectAvatarVisible` storage key
- `locales/{en,ja,id}/settings.json` - Translations for the new toggle

## How to test

1. `yarn dev`
2. Open Settings > Appearance
3. Find the "Project Avatar" toggle near the bottom of the section
4. Toggle it off - project icons should disappear from the sidebar
5. Toggle it on - project icons should reappear
6. Reload the app - the setting should persist

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [x] New state is added to the correct Zustand store