### PR TITLE
fix(effort): remove xhigh level and improve error context

### DIFF
--- a/src/main/services/agentWorker/__tests__/enrichExitError.test.ts
+++ b/src/main/services/agentWorker/__tests__/enrichExitError.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { enrichExitError } from '../core'
+
+describe('enrichExitError', () => {
+  // ── passthrough ────────────────────────────────────────────────────────────
+
+  it('passes through messages that are not exit-code errors', () => {
+    expect(enrichExitError('Network timeout', 'some stderr output')).toBe('Network timeout')
+  })
+
+  it('passes through exit-code errors when stderr buffer is empty', () => {
+    expect(enrichExitError('Claude Code process exited with code 1', '')).toBe(
+      'Claude Code process exited with code 1'
+    )
+  })
+
+  it('passes through exit-code errors when stderr buffer is whitespace only', () => {
+    expect(enrichExitError('Claude Code process exited with code 1', '  \n\n  ')).toBe(
+      'Claude Code process exited with code 1'
+    )
+  })
+
+  // ── enrichment ─────────────────────────────────────────────────────────────
+
+  it('prepends stderr content to exit-code errors', () => {
+    const result = enrichExitError(
+      'Claude Code process exited with code 1',
+      'invalid --effort value: xhigh'
+    )
+    expect(result).toBe('invalid --effort value: xhigh (Claude Code process exited with code 1)')
+  })
+
+  it('keeps only the last 3 lines of stderr', () => {
+    const stderr = 'line1\nline2\nline3\nline4\nline5'
+    const result = enrichExitError('Claude Code process exited with code 127', stderr)
+    expect(result).toBe('line3\nline4\nline5 (Claude Code process exited with code 127)')
+  })
+
+  it('strips "Error:" prefix from each stderr line', () => {
+    const stderr = 'Error: first\nError: second\nError: third'
+    const result = enrichExitError('Claude Code process exited with code 1', stderr)
+    expect(result).toBe('first\nsecond\nthird (Claude Code process exited with code 1)')
+  })
+
+  it('strips "Error:" prefix case-insensitively and with leading whitespace', () => {
+    const stderr = '  error: indented\n\tERROR: tabbed\nError:   padded'
+    const result = enrichExitError('Claude Code process exited with code 1', stderr)
+    expect(result).toBe('indented\ntabbed\npadded (Claude Code process exited with code 1)')
+  })
+
+  // ── case sensitivity on the detection regex ────────────────────────────────
+
+  it('matches "process exited with code" case-insensitively', () => {
+    const result = enrichExitError(
+      'Claude Code PROCESS EXITED WITH CODE 42',
+      'subscriber limit reached'
+    )
+    expect(result).toBe('subscriber limit reached (Claude Code PROCESS EXITED WITH CODE 42)')
+  })
+})

--- a/src/main/services/agentWorker/core.ts
+++ b/src/main/services/agentWorker/core.ts
@@ -45,8 +45,13 @@ function enrichExitError(rawMessage: string, stderrBuffer: string): string {
   if (!/process exited with code/i.test(rawMessage)) return rawMessage
   const trimmed = stderrBuffer.trim()
   if (!trimmed) return rawMessage
-  const lastLines = trimmed.split('\n').slice(-3).join('\n')
-  return `${lastLines}\n(${rawMessage})`
+  // Strip "Error:" prefix from each stderr line - the renderer adds its own.
+  const lastLines = trimmed
+    .split('\n')
+    .slice(-3)
+    .map((line) => line.replace(/^\s*Error:\s*/i, ''))
+    .join('\n')
+  return `${lastLines} (${rawMessage})`
 }
 
 export class AgentWorker {

--- a/src/main/services/agentWorker/core.ts
+++ b/src/main/services/agentWorker/core.ts
@@ -41,7 +41,7 @@ function needsExtendedContextBeta(model: string): boolean {
  * --effort value, Claude.ai subscriber limits). Merge the last few stderr
  * lines into the message so the renderer can show a useful error.
  */
-function enrichExitError(rawMessage: string, stderrBuffer: string): string {
+export function enrichExitError(rawMessage: string, stderrBuffer: string): string {
   if (!/process exited with code/i.test(rawMessage)) return rawMessage
   const trimmed = stderrBuffer.trim()
   if (!trimmed) return rawMessage

--- a/src/main/services/agentWorker/core.ts
+++ b/src/main/services/agentWorker/core.ts
@@ -35,6 +35,20 @@ function needsExtendedContextBeta(model: string): boolean {
   return model.includes('sonnet')
 }
 
+/**
+ * The SDK throws a generic "Claude Code process exited with code N" when the
+ * underlying CLI dies. The actionable reason is in stderr (e.g. invalid
+ * --effort value, Claude.ai subscriber limits). Merge the last few stderr
+ * lines into the message so the renderer can show a useful error.
+ */
+function enrichExitError(rawMessage: string, stderrBuffer: string): string {
+  if (!/process exited with code/i.test(rawMessage)) return rawMessage
+  const trimmed = stderrBuffer.trim()
+  if (!trimmed) return rawMessage
+  const lastLines = trimmed.split('\n').slice(-3).join('\n')
+  return `${lastLines}\n(${rawMessage})`
+}
+
 export class AgentWorker {
   private sessions = new Map<string, SessionState>()
   private pendingUserInput = new Map<string, { resolve: (result: Record<string, unknown>) => void }>()
@@ -150,6 +164,8 @@ export class AgentWorker {
     this.sessions.set(sessionId, state)
     this.applyApiKey(settings)
 
+    let stderrBuffer = ''
+
     try {
       this.log(sessionId, 'Creating query...')
 
@@ -176,6 +192,13 @@ export class AgentWorker {
         ? [CONTEXT_1M_BETA] : undefined
       const effort = effortLevel && effortLevel !== 'high' ? effortLevel : undefined
 
+      const captureStderr = (data: string): void => {
+        const trimmed = data.trim()
+        if (!trimmed) return
+        stderrBuffer = (stderrBuffer + '\n' + trimmed).slice(-2000)
+        this.log(sessionId, 'stderr:', trimmed)
+      }
+
       const q = queryFn({
         prompt: promptParam as Parameters<typeof queryFn>[0]['prompt'],
         options: {
@@ -191,7 +214,7 @@ export class AgentWorker {
           plugins: loadPlugins(worktreePath),
           abortController,
           systemPrompt: { type: 'preset', preset: 'claude_code', append: systemAppend },
-          stderr: (data: string) => { this.log(sessionId, 'stderr:', data.trim()) },
+          stderr: captureStderr,
           ...(effort ? { effort } : {}),
           ...(betas ? { betas } : {}),
           ...(mcpServers ? { mcpServers } : {}),
@@ -266,9 +289,10 @@ export class AgentWorker {
         this.emit({ type: 'done', sessionId })
         return
       }
-      const message = err instanceof Error ? err.message : String(err)
-      this.log(sessionId, 'ERROR:', message)
+      const rawMessage = err instanceof Error ? err.message : String(err)
+      this.log(sessionId, 'ERROR:', rawMessage)
       if (err instanceof Error && err.stack) this.log(sessionId, 'Stack:', err.stack)
+      const message = enrichExitError(rawMessage, stderrBuffer)
       const errorKind = classifyError(message)
       this.emit({
         type: 'error', sessionId, message, errorKind,
@@ -334,6 +358,8 @@ export class AgentWorker {
     const abortController = new AbortController()
     state.abortController = abortController
 
+    let stderrBuffer = ''
+
     try {
       // Re-inject all MCP servers on resume (user-configured + Braid + mobile)
       const braidEmit = (e: BraidAction): void => { this.emit({ ...e, sessionId }) }
@@ -372,6 +398,13 @@ export class AgentWorker {
         ? [CONTEXT_1M_BETA] : undefined
       const effort = state.effortLevel && state.effortLevel !== 'high' ? state.effortLevel : undefined
 
+      const captureStderr = (data: string): void => {
+        const trimmed = data.trim()
+        if (!trimmed) return
+        stderrBuffer = (stderrBuffer + '\n' + trimmed).slice(-2000)
+        this.log(sessionId, 'resume stderr:', trimmed)
+      }
+
       const q = queryFn({
         prompt: promptParam as Parameters<typeof queryFn>[0]['prompt'],
         options: {
@@ -386,7 +419,7 @@ export class AgentWorker {
           settingSources: ['user', 'project', 'local'],
           plugins: loadPlugins(state.cwd),
           abortController,
-          stderr: (data: string) => { this.log(sessionId, 'resume stderr:', data.trim()) },
+          stderr: captureStderr,
           ...(effort ? { effort } : {}),
           ...(betas ? { betas } : {}),
           ...(mcpServers ? { mcpServers } : {}),
@@ -426,9 +459,10 @@ export class AgentWorker {
         this.emit({ type: 'done', sessionId })
         return
       }
-      const errMsg = err instanceof Error ? err.message : String(err)
-      this.log(sessionId, 'RESUME ERROR:', errMsg)
+      const rawErrMsg = err instanceof Error ? err.message : String(err)
+      this.log(sessionId, 'RESUME ERROR:', rawErrMsg)
       if (err instanceof Error && err.stack) this.log(sessionId, 'Stack:', err.stack)
+      const errMsg = enrichExitError(rawErrMsg, stderrBuffer)
 
       if (errMsg.includes('text content blocks must be non-empty')) {
         this.log(sessionId, 'Corrupt session history detected - falling back to fresh session')

--- a/src/renderer/lib/constants.ts
+++ b/src/renderer/lib/constants.ts
@@ -44,13 +44,11 @@ export const EFFORT_LEVELS: readonly { id: EffortLevel; label: string }[] = [
   { id: 'low', label: 'Low' },
   { id: 'medium', label: 'Med' },
   { id: 'high', label: 'High' },
-  { id: 'xhigh', label: 'XHigh' },
   { id: 'max', label: 'Max' },
 ]
 
 /** Returns the effort levels supported by a given model. */
 export function getEffortLevelsForModel(model: string): EffortLevel[] {
-  if (model.includes('opus') && model.includes('4-7')) return ['low', 'medium', 'high', 'xhigh', 'max']
   if (model.includes('opus') || model.includes('sonnet')) return ['low', 'medium', 'high', 'max']
   return [] // Haiku and others: effort not supported
 }

--- a/src/renderer/locales/en/center.json
+++ b/src/renderer/locales/en/center.json
@@ -33,7 +33,6 @@
   "effort_low": "Low",
   "effort_medium": "Med",
   "effort_high": "High",
-  "effort_xhigh": "XHigh",
   "effort_max": "Max",
   "attachImage": "Attach image (or drag & drop / paste)",
   "imageLabel": "Image",

--- a/src/renderer/locales/en/settings.json
+++ b/src/renderer/locales/en/settings.json
@@ -78,7 +78,6 @@
     "effort_low": "Low",
     "effort_medium": "Med",
     "effort_high": "High",
-    "effort_xhigh": "XHigh",
     "effort_max": "Max",
     "thinkingMode": "Thinking Mode",
     "thinkingModeHint": "Enable extended thinking for new sessions",

--- a/src/renderer/locales/id/center.json
+++ b/src/renderer/locales/id/center.json
@@ -33,7 +33,6 @@
   "effort_low": "Rendah",
   "effort_medium": "Sedang",
   "effort_high": "Tinggi",
-  "effort_xhigh": "Sangat Tinggi",
   "effort_max": "Maks",
   "attachImage": "Lampirkan gambar (atau seret & jatuhkan / tempel)",
   "imageLabel": "Gambar",

--- a/src/renderer/locales/id/settings.json
+++ b/src/renderer/locales/id/settings.json
@@ -78,7 +78,6 @@
     "effort_low": "Rendah",
     "effort_medium": "Sedang",
     "effort_high": "Tinggi",
-    "effort_xhigh": "Sangat Tinggi",
     "effort_max": "Maks",
     "thinkingMode": "Mode Berpikir",
     "thinkingModeHint": "Aktifkan berpikir mendalam untuk sesi baru",

--- a/src/renderer/locales/ja/center.json
+++ b/src/renderer/locales/ja/center.json
@@ -33,7 +33,6 @@
   "effort_low": "低",
   "effort_medium": "中",
   "effort_high": "高",
-  "effort_xhigh": "最高",
   "effort_max": "最大",
   "attachImage": "画像を添付（ドラッグ＆ドロップ / ペースト可）",
   "imageLabel": "画像",

--- a/src/renderer/locales/ja/settings.json
+++ b/src/renderer/locales/ja/settings.json
@@ -78,7 +78,6 @@
     "effort_low": "低",
     "effort_medium": "中",
     "effort_high": "高",
-    "effort_xhigh": "最高",
     "effort_max": "最大",
     "thinkingMode": "シンキングモード",
     "thinkingModeHint": "新しいセッションで拡張思考を有効にする",

--- a/src/renderer/types/session.ts
+++ b/src/renderer/types/session.ts
@@ -2,7 +2,7 @@
 
 export type SessionStatus = 'idle' | 'running' | 'waiting_input' | 'error' | 'inactive'
 export type ModelId = 'claude-opus-4-7' | 'claude-sonnet-4-6' | 'claude-opus-4-6' | 'claude-haiku-4-5-20251001'
-export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+export type EffortLevel = 'low' | 'medium' | 'high' | 'max'
 export type SettingsSection = string
 
 export interface PendingQuestion {


### PR DESCRIPTION
## Summary

- Remove the unsupported \`xhigh\` effort level (rejected by the Claude CLI, caused generic \"process exited with code N\" errors)
- Capture stderr from the agent CLI and merge the last few lines into the error message so the renderer shows an actionable reason instead of a bare exit code

## Layers touched

- [x] **Main process** (\`src/main/\`) — services, IPC handlers
- [ ] **Preload** (\`src/preload/\`) — context bridge API
- [x] **Renderer** (\`src/renderer/\`) — components, stores, lib
- [ ] **Styles** (\`App.css\`)

## Changes

**Services** (\`agentWorker/core.ts\`):
- Added \`enrichExitError()\` helper that prepends the last 3 lines of buffered stderr to any \"process exited with code N\" error
- Replaced inline \`stderr\` loggers in both the fresh-query and resume paths with a \`captureStderr\` function that appends to a rolling 2000-char buffer and still logs
- Error emission (initial + resume) now goes through \`enrichExitError\` before \`classifyError\` / \`this.emit\`

**Renderer** (\`lib/constants.ts\`, \`types/session.ts\`):
- Dropped \`xhigh\` from \`EffortLevel\` union and \`EFFORT_LEVELS\` list
- Removed the opus-4-7 branch in \`getEffortLevelsForModel\` that exposed \`xhigh\`

**i18n** (\`locales/{en,ja,id}/{center,settings}.json\`):
- Removed \`effort_xhigh\` translation keys across all three locales

## How to test

1. \`yarn dev\`
2. Open a session on an opus model and confirm the effort selector shows only Low / Med / High / Max
3. Force a CLI error (e.g. invalid API key) and verify the displayed error contains stderr context rather than just \"Claude Code process exited with code 1\"

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with \`yarn dev\`
- [x] Types pass — \`yarn typecheck\`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer) — n/a
- [ ] New state is added to the correct Zustand store — n/a