### PR TITLE
feat: chat input keyboard shortcuts, EPIPE hardening, Opus noise reduction

### DIFF
--- a/src/main/services/agentUtils.ts
+++ b/src/main/services/agentUtils.ts
@@ -91,6 +91,20 @@ Flutter Development:
 - Use mobile_open_devtools to launch Flutter DevTools in the browser.
 `.trim()
 
+/**
+ * Appended for Opus models to suppress excessive false-positive security
+ * warnings (e.g. "this looks like malware", "potential security risk") that
+ * burn tokens without adding value. See: reddit.com/r/ClaudeAI/comments/1snbtc9
+ */
+export const OPUS_NOISE_REDUCTION_PROMPT = `
+Security analysis calibration:
+- Do NOT preface tool calls or code with security/malware disclaimers unless the user is explicitly asking you to write malicious software.
+- Do NOT warn about "potential security implications" for routine operations (file I/O, git commands, network requests, shell scripts, dependency installation).
+- Do NOT ask for confirmation before reading, writing, or searching files in the project directory - these are normal development operations.
+- If code could theoretically be misused, assume the development context is legitimate and proceed without commentary.
+- Reserve security warnings for genuinely dangerous operations (rm -rf /, dropping production databases, exposing secrets in public repos).
+`.trim()
+
 /** Build the framework-specific system prompt suffix. */
 export function frameworkPrompt(mobileFramework?: string): string {
   if (mobileFramework === 'react-native') return `\n\n${RN_FRAMEWORK_PROMPT}`

--- a/src/main/services/agentWorker/core.ts
+++ b/src/main/services/agentWorker/core.ts
@@ -12,6 +12,7 @@ import {
   loadPlugins,
   BRAID_SYSTEM_PROMPT,
   MOBILE_SYSTEM_PROMPT,
+  OPUS_NOISE_REDUCTION_PROMPT,
   frameworkPrompt,
   buildUserContent
 } from '../agentUtils'
@@ -189,9 +190,10 @@ export class AgentWorker {
         ? `\n\nLinked worktrees (you have full read/write access):\n${linkedWorktreeContext}`
         : ''
       const mobileSuffix = connectedDeviceId ? `\n\n${MOBILE_SYSTEM_PROMPT}${frameworkPrompt(mobileFramework)}` : ''
+      const opusSuffix = model.includes('opus-4-7') ? `\n\n${OPUS_NOISE_REDUCTION_PROMPT}` : ''
       const systemAppend = settings.systemPromptSuffix
-        ? `${BRAID_SYSTEM_PROMPT}\n\n${settings.systemPromptSuffix}${linkedSuffix}${mobileSuffix}`
-        : `${BRAID_SYSTEM_PROMPT}${linkedSuffix}${mobileSuffix}`
+        ? `${BRAID_SYSTEM_PROMPT}\n\n${settings.systemPromptSuffix}${linkedSuffix}${mobileSuffix}${opusSuffix}`
+        : `${BRAID_SYSTEM_PROMPT}${linkedSuffix}${mobileSuffix}${opusSuffix}`
 
       const betas = (extendedContext && needsExtendedContextBeta(model))
         ? [CONTEXT_1M_BETA] : undefined


### PR DESCRIPTION
## Summary

- Add keyboard shortcuts to ChatInput: message history navigation (Up/Down arrows), double-Escape to clear input, Ctrl+C / single-Escape to stop running sessions
- Harden the agent worker process against EPIPE errors that crash the UtilityProcess when pipes close mid-stream
- Append an Opus-specific noise reduction system prompt to suppress excessive false-positive security warnings

## Layers touched

- [x] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib

## Changes

**Center panel:**
- `ChatInput.tsx` — message history navigation (Up/Down), double-Escape clear, Ctrl+C stop, snippet restoration from history entries
- `ChatView.tsx` — `SET_IMAGES` reducer guard to avoid unnecessary state updates

**Stores** (`sessions/`):
- `storeTypes.ts` — added `setDraftSnippets` action type
- `handlers/draftActions.ts` — implemented `setDraftSnippets` for bulk snippet replacement (used by history restore)

**Services** (`agentProcess.ts` / `agentUtils.ts` / `agentWorker/core.ts`):
- `agentProcess.ts` — wrap `postMessage` in EPIPE-safe helper, add stdout/stderr error listeners and global uncaught exception/rejection handlers
- `lib/errors.ts` — new `isEpipe()` type guard utility
- `agentUtils.ts` — new `OPUS_NOISE_REDUCTION_PROMPT` constant
- `agentWorker/core.ts` — conditionally append Opus noise reduction prompt for `opus-4-7` models

## How to test

1. `yarn dev`
2. **History navigation** — send a few messages, then press Up arrow in an empty input to cycle through sent messages; Down arrow to go forward; press Down past the newest to restore original draft
3. **Double-Escape** — type text in input, press Escape twice quickly to clear it
4. **Ctrl+C / Escape stop** — while Claude is responding, press Escape or Ctrl+C to stop the session
5. **EPIPE resilience** — kill/restart quickly during streaming to verify no crash
6. **Opus noise** — start a session with an Opus model and verify no excessive security disclaimers

## Checklist

- [x] Self-reviewed the diff
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store