### PR TITLE
feat: show per-file diff stats (additions/deletions) in changes panel

### DIFF
--- a/src/main/services/git/status.ts
+++ b/src/main/services/git/status.ts
@@ -21,30 +21,48 @@ export function invalidateTrackedFiles(worktreePath: string): void {
   trackedFilesCache.invalidate(worktreePath)
 }
 
-/** Parse `git diff --numstat` output into a file-keyed map. */
-function parseNumstat(raw: string): Map<string, { additions: number; deletions: number }> {
-  const map = new Map<string, { additions: number; deletions: number }>()
+interface LineStats { additions: number; deletions: number }
+
+/**
+ * Parse `git diff --numstat` output into a file-keyed map.
+ * Format: `<additions>\t<deletions>\t<path>` per line. Binary files emit '-' for counts.
+ * Filenames may contain tabs, so the path is everything after the second tab.
+ */
+function parseNumstat(raw: string): Map<string, LineStats> {
+  const map = new Map<string, LineStats>()
   for (const line of raw.split('\n')) {
     if (!line) continue
-    const parts = line.split('\t')
-    if (parts.length < 3) continue
-    const [add, del, file] = parts
+    const firstTab = line.indexOf('\t')
+    if (firstTab < 0) continue
+    const secondTab = line.indexOf('\t', firstTab + 1)
+    if (secondTab < 0) continue
+    const add = line.slice(0, firstTab)
+    const del = line.slice(firstTab + 1, secondTab)
+    const file = line.slice(secondTab + 1)
     // Binary files show '-' for both counts
     if (add === '-' || del === '-') continue
-    map.set(file, { additions: parseInt(add, 10), deletions: parseInt(del, 10) })
+    const additions = parseInt(add, 10)
+    const deletions = parseInt(del, 10)
+    if (!Number.isFinite(additions) || !Number.isFinite(deletions)) continue
+    map.set(file, { additions, deletions })
   }
   return map
 }
+
+// `-c core.quotePath=false` forces literal UTF-8 paths instead of octal-escaped
+// quoted strings, so lookups by path match regardless of locale (e.g. Japanese filenames).
+const NUMSTAT_ARGS_UNSTAGED = ['-c', 'core.quotePath=false', 'diff', '--numstat']
+const NUMSTAT_ARGS_STAGED = ['-c', 'core.quotePath=false', 'diff', '--cached', '--numstat']
 
 export async function getStatus(worktreePath: string): Promise<GitChangeInfo[]> {
   const git = await getValidGit(worktreePath)
   if (!git) return []
 
-  // Fetch status and numstat in parallel
+  // Fetch status and numstat in parallel for both indexes
   const [status, unstagedNumstat, stagedNumstat] = await Promise.all([
     git.status(),
-    git.diff(['--numstat']).catch(() => ''),
-    git.diff(['--cached', '--numstat']).catch(() => ''),
+    git.raw(NUMSTAT_ARGS_UNSTAGED).catch(() => ''),
+    git.raw(NUMSTAT_ARGS_STAGED).catch(() => ''),
   ])
 
   const unstagedStats = parseNumstat(unstagedNumstat)

--- a/src/main/services/git/status.ts
+++ b/src/main/services/git/status.ts
@@ -82,7 +82,7 @@ export async function getStatus(worktreePath: string): Promise<GitChangeInfo[]> 
         f.index === 'R' ? 'R' : null
       if (mapped) {
         const stat = stagedStats.get(file)
-        changes.push({ file, status: mapped, staged: true, additions: stat?.additions, deletions: stat?.deletions })
+        changes.push({ file, status: mapped, staged: true, ...stat })
       }
     }
 
@@ -94,7 +94,7 @@ export async function getStatus(worktreePath: string): Promise<GitChangeInfo[]> 
         f.working_dir === '?' ? '?' : null
       if (mapped) {
         const stat = unstagedStats.get(file)
-        changes.push({ file, status: mapped, staged: false, additions: stat?.additions, deletions: stat?.deletions })
+        changes.push({ file, status: mapped, staged: false, ...stat })
       }
     }
   }

--- a/src/main/services/git/status.ts
+++ b/src/main/services/git/status.ts
@@ -21,10 +21,35 @@ export function invalidateTrackedFiles(worktreePath: string): void {
   trackedFilesCache.invalidate(worktreePath)
 }
 
+/** Parse `git diff --numstat` output into a file-keyed map. */
+function parseNumstat(raw: string): Map<string, { additions: number; deletions: number }> {
+  const map = new Map<string, { additions: number; deletions: number }>()
+  for (const line of raw.split('\n')) {
+    if (!line) continue
+    const parts = line.split('\t')
+    if (parts.length < 3) continue
+    const [add, del, file] = parts
+    // Binary files show '-' for both counts
+    if (add === '-' || del === '-') continue
+    map.set(file, { additions: parseInt(add, 10), deletions: parseInt(del, 10) })
+  }
+  return map
+}
+
 export async function getStatus(worktreePath: string): Promise<GitChangeInfo[]> {
   const git = await getValidGit(worktreePath)
   if (!git) return []
-  const status = await git.status()
+
+  // Fetch status and numstat in parallel
+  const [status, unstagedNumstat, stagedNumstat] = await Promise.all([
+    git.status(),
+    git.diff(['--numstat']).catch(() => ''),
+    git.diff(['--cached', '--numstat']).catch(() => ''),
+  ])
+
+  const unstagedStats = parseNumstat(unstagedNumstat)
+  const stagedStats = parseNumstat(stagedNumstat)
+
   const changes: GitChangeInfo[] = []
 
   for (const f of status.files) {
@@ -37,7 +62,10 @@ export async function getStatus(worktreePath: string): Promise<GitChangeInfo[]> 
         f.index === 'A' ? 'A' :
         f.index === 'D' ? 'D' :
         f.index === 'R' ? 'R' : null
-      if (mapped) changes.push({ file, status: mapped, staged: true })
+      if (mapped) {
+        const stat = stagedStats.get(file)
+        changes.push({ file, status: mapped, staged: true, additions: stat?.additions, deletions: stat?.deletions })
+      }
     }
 
     // Working directory (unstaged) status
@@ -46,7 +74,10 @@ export async function getStatus(worktreePath: string): Promise<GitChangeInfo[]> 
         f.working_dir === 'M' ? 'M' :
         f.working_dir === 'D' ? 'D' :
         f.working_dir === '?' ? '?' : null
-      if (mapped) changes.push({ file, status: mapped, staged: false })
+      if (mapped) {
+        const stat = unstagedStats.get(file)
+        changes.push({ file, status: mapped, staged: false, additions: stat?.additions, deletions: stat?.deletions })
+      }
     }
   }
 

--- a/src/main/services/git/types.ts
+++ b/src/main/services/git/types.ts
@@ -15,4 +15,6 @@ export interface GitChangeInfo {
   file: string
   status: string
   staged: boolean
+  additions?: number
+  deletions?: number
 }

--- a/src/renderer/components/Right/ChangeFileList.tsx
+++ b/src/renderer/components/Right/ChangeFileList.tsx
@@ -16,25 +16,29 @@ function sumStats(changes: GitChange[]): { additions: number; deletions: number 
   return { additions, deletions }
 }
 
-function DiffStats({ additions, deletions }: { additions?: number; deletions?: number }) {
-  if (!additions && !deletions) return null
-  return (
-    <span className="change-diff-stats">
-      {(additions ?? 0) > 0 && <span className="change-diff-add">+{additions}</span>}
-      {(deletions ?? 0) > 0 && <span className="change-diff-del">-{deletions}</span>}
-    </span>
-  )
+interface DiffStatsProps {
+  additions?: number
+  deletions?: number
+  /** Variant controls layout/spacing; visual color tokens are shared. */
+  variant?: 'row' | 'section'
 }
 
-function SectionStats({ changes }: { changes: GitChange[] }) {
-  const { additions, deletions } = useMemo(() => sumStats(changes), [changes])
-  if (!additions && !deletions) return null
+/** Renders `+N -N` stats; returns null when there's nothing to show. */
+function DiffStats({ additions = 0, deletions = 0, variant = 'row' }: DiffStatsProps) {
+  if (additions <= 0 && deletions <= 0) return null
+  const className = variant === 'section' ? 'change-section-stats' : 'change-diff-stats'
   return (
-    <span className="change-section-stats">
+    <span className={className}>
       {additions > 0 && <span className="change-diff-add">+{additions}</span>}
       {deletions > 0 && <span className="change-diff-del">-{deletions}</span>}
     </span>
   )
+}
+
+/** Aggregates line stats across a set of changes. Thin wrapper over `DiffStats`. */
+function SectionStats({ changes }: { changes: GitChange[] }) {
+  const { additions, deletions } = useMemo(() => sumStats(changes), [changes])
+  return <DiffStats additions={additions} deletions={deletions} variant="section" />
 }
 
 interface ChangeFileListProps {

--- a/src/renderer/components/Right/ChangeFileList.tsx
+++ b/src/renderer/components/Right/ChangeFileList.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { GitChange } from '@/types'
 import type { GitStatusCode } from '@/store/ui'
@@ -5,6 +6,36 @@ import { Tooltip } from '@/components/shared/Tooltip'
 import { STATUS_META } from './changesState'
 import { basename, dirname } from '@/lib/diffUtils'
 import { NekoWalk } from './NekoWalk'
+
+function sumStats(changes: GitChange[]): { additions: number; deletions: number } {
+  let additions = 0, deletions = 0
+  for (const c of changes) {
+    additions += c.additions ?? 0
+    deletions += c.deletions ?? 0
+  }
+  return { additions, deletions }
+}
+
+function DiffStats({ additions, deletions }: { additions?: number; deletions?: number }) {
+  if (!additions && !deletions) return null
+  return (
+    <span className="change-diff-stats">
+      {(additions ?? 0) > 0 && <span className="change-diff-add">+{additions}</span>}
+      {(deletions ?? 0) > 0 && <span className="change-diff-del">-{deletions}</span>}
+    </span>
+  )
+}
+
+function SectionStats({ changes }: { changes: GitChange[] }) {
+  const { additions, deletions } = useMemo(() => sumStats(changes), [changes])
+  if (!additions && !deletions) return null
+  return (
+    <span className="change-section-stats">
+      {additions > 0 && <span className="change-diff-add">+{additions}</span>}
+      {deletions > 0 && <span className="change-diff-del">-{deletions}</span>}
+    </span>
+  )
+}
 
 interface ChangeFileListProps {
   stagedChanges: GitChange[]
@@ -53,6 +84,7 @@ export function ChangeFileList({
         <span className={`changes-section-chevron${stagedCollapsed ? ' collapsed' : ''}`}>▾</span>
         <span className="changes-section-title">{t('stagedChanges')}</span>
         <span className="changes-section-count">{stagedChanges.length}</span>
+        <SectionStats changes={stagedChanges} />
         {stagedChanges.length > 0 && (
           <>
             <button className="changes-section-btn" onClick={onUnstageAll} disabled={stagingInProgress}>
@@ -94,6 +126,7 @@ export function ChangeFileList({
                   <span className="change-file-name">{name}</span>
                   {dir && <span className="change-file-dir">{dir}</span>}
                 </span>
+                <DiffStats additions={change.additions} deletions={change.deletions} />
               </div>
             )
           })
@@ -108,6 +141,7 @@ export function ChangeFileList({
         <span className={`changes-section-chevron${unstagedCollapsed ? ' collapsed' : ''}`}>▾</span>
         <span className="changes-section-title">{t('unstagedChanges')}</span>
         <span className="changes-section-count">{unstagedChanges.length}</span>
+        <SectionStats changes={unstagedChanges} />
         {unstagedChanges.length > 0 && (
           <>
             <button className="changes-section-btn" onClick={onStageAll} disabled={stagingInProgress}>
@@ -144,6 +178,7 @@ export function ChangeFileList({
                 <span className="change-file-name">{name}</span>
                 {dir && <span className="change-file-dir">{dir}</span>}
               </span>
+              <DiffStats additions={change.additions} deletions={change.deletions} />
               <div className="change-row-actions">
                 <Tooltip content={t('discardChanges')} position="left">
                   <button

--- a/src/renderer/lib/prPrompt.ts
+++ b/src/renderer/lib/prPrompt.ts
@@ -3,16 +3,21 @@ export const DEFAULT_PR_PROMPT = `Create a pull request for the current branch.
 Steps:
 1. Check if the current branch has an upstream remote. If not, push it with \`git push -u origin HEAD\`.
 2. If there are unpushed commits, push them.
-3. Look for a PR template file in any of these locations:
+3. Compute the merge-base ONCE and store it, then use it for all subsequent git commands. This avoids races if the base branch advances mid-flow:
+   \`\`\`
+   BASE=$(git merge-base HEAD <base-branch>)
+   git log $BASE..HEAD --oneline
+   git diff $BASE..HEAD --stat
+   git diff $BASE..HEAD
+   \`\`\`
+   IMPORTANT: Cross-check the diff output against the commit list. If the diff contains files or features not mentioned in any commit message, re-run with a fresh merge-base - the base branch may have changed.
+4. Read the PR template file. Check these locations in order and read the first one found:
    - \`.github/pull_request_template.md\`
    - \`.github/PULL_REQUEST_TEMPLATE.md\`
    - \`docs/pull_request_template.md\`
    - \`.github/PULL_REQUEST_TEMPLATE/\` directory
-4. If a template exists, follow its structure and guidelines when writing the PR description. Fill in each section thoughtfully based on the actual changes.
-5. Review only the commits and changes introduced by this branch. Use the merge-base to avoid including unrelated changes from the base branch:
-   - \`git log $(git merge-base HEAD <base-branch>)..HEAD --oneline\` to see commits on this branch only
-   - \`git diff $(git merge-base HEAD <base-branch>)..HEAD\` to see the combined diff of this branch's changes
-   This ensures the comparison is accurate even if the base branch (e.g. main) has newer commits that are not yet in this branch.
-6. Create the PR using \`gh pr create\`, with a clear title and a well-written description that follows the template (if found) or otherwise summarizes the changes clearly.
+   You MUST actually read the file contents before writing the PR body. If a template exists, use its exact section structure.
+5. Write the PR title and body based ONLY on the commits and diff from step 3. Do not describe changes that are not in the diff. If the diff is large, focus on the commit messages and diffstat to avoid hallucinating details from truncated output.
+6. Create the PR using \`gh pr create\`, filling in the template sections (if found) or summarizing the changes clearly.
 
 Do not ask me for confirmation — just go ahead and create it.`

--- a/src/renderer/styles/changes.css
+++ b/src/renderer/styles/changes.css
@@ -278,7 +278,7 @@
   gap: var(--space-4);
   flex-shrink: 0;
   font-family: var(--font-mono);
-  font-size: var(--text-2xs);
+  font-size: var(--text-base);
   font-weight: var(--weight-medium);
 }
 
@@ -296,7 +296,7 @@
   align-items: center;
   gap: var(--space-4);
   font-family: var(--font-mono);
-  font-size: var(--text-2xs);
+  font-size: var(--text-base);
   font-weight: var(--weight-medium);
   margin-left: var(--space-4);
 }

--- a/src/renderer/styles/changes.css
+++ b/src/renderer/styles/changes.css
@@ -251,6 +251,7 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
+  flex: 1;
   gap: 1px;
 }
 
@@ -268,6 +269,36 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* ============= Per-file diff stats ============= */
+.change-diff-stats {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-medium);
+}
+
+.change-diff-add {
+  color: var(--green);
+}
+
+.change-diff-del {
+  color: var(--red);
+}
+
+/* ============= Section-level stats ============= */
+.change-section-stats {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-medium);
+  margin-left: var(--space-4);
 }
 
 /* Empty state */

--- a/src/renderer/types/git.ts
+++ b/src/renderer/types/git.ts
@@ -69,4 +69,6 @@ export interface GitChange {
   status: 'M' | 'A' | 'D' | '?' | 'R'
   staged: boolean
   diff?: string
+  additions?: number
+  deletions?: number
 }


### PR DESCRIPTION
## Summary

- Display per-file `+N -N` line counts next to each changed file in the Changes panel
- Show aggregated stats per section (staged / unstaged) in the section headers
- Fetch `git diff --numstat` in parallel with `git status` so there is no extra latency

## Changes

### `src/main/services/git/status.ts`
- Added `parseNumstat()` to parse `git diff --numstat` output into a `Map<path, {additions, deletions}>`
  - Uses tab-index slicing instead of `.split('\t')` to handle filenames that contain tabs
  - Skips binary files (which emit `-` for counts)
  - Uses `-c core.quotePath=false` so UTF-8 paths (e.g. Japanese filenames) match without octal escaping
- `getStatus()` now runs `git status`, unstaged numstat, and staged numstat in parallel via `Promise.all`, then attaches `additions`/`deletions` to each `GitChangeInfo`

### `src/main/services/git/types.ts` + `src/renderer/types/git.ts`
- Added optional `additions` and `deletions` fields to `GitChangeInfo` / `GitChange`

### `src/renderer/components/Right/ChangeFileList.tsx`
- New `DiffStats` component - renders `+N -N` with green/red color tokens, returns null when both are zero
- New `SectionStats` component - aggregates line stats across a set of changes using `useMemo`
- Integrated into both staged and unstaged file rows and section headers

### `src/renderer/styles/changes.css`
- Added `.change-diff-stats`, `.change-section-stats`, `.change-diff-add`, `.change-diff-del` classes
- Uses monospace font, design tokens for spacing and color

## How to test

1. `yarn dev`
2. Open a worktree with modified files
3. Changes tab should show `+N -N` next to each file and aggregated in section headers
4. Stage/unstage files - stats should update correctly