### PR TITLE
feat: add Claude Opus 4.7 model support

### DIFF
--- a/src/renderer/components/Center/ChatMessage.tsx
+++ b/src/renderer/components/Center/ChatMessage.tsx
@@ -78,6 +78,7 @@ function TurnActions({ text, durationMs, turnUsage }: TurnActionsProps) {
 }
 
 const MODEL_LABELS: Record<string, string> = {
+  'claude-opus-4-7': 'Opus 4.7',
   'claude-sonnet-4-6': 'Sonnet 4.6',
   'claude-opus-4-6': 'Opus 4.6',
   'claude-haiku-4-5': 'Haiku 4.5'

--- a/src/renderer/store/sessions/eventHandler.ts
+++ b/src/renderer/store/sessions/eventHandler.ts
@@ -103,7 +103,7 @@ export function initAgentEventListener(): () => void {
         store.getState().setActiveSession(sessionId)
 
         // Keep in sync with ModelId in types/index.ts
-        const validModels: string[] = ['claude-sonnet-4-6', 'claude-opus-4-6', 'claude-haiku-4-5-20251001']
+        const validModels: string[] = ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-opus-4-6', 'claude-haiku-4-5-20251001']
         if (model && validModels.includes(model)) {
           store.getState().updateModel(newId, model as ModelId)
         }


### PR DESCRIPTION
## Summary

- Adds `claude-opus-4-7` as a selectable model across the app
- Registers the new model ID in the type system, validation allowlist, and all label maps

## Layers touched

- [ ] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [ ] **Styles** (`App.css`)

## Changes

**Sidebar / Center / Right panel:**
- `ModelSelector.tsx` — added `{ id: 'claude-opus-4-7', label: 'Opus 4.7' }` to the MODELS list
- `ChatMessage.tsx` — added `'claude-opus-4-7': 'Opus 4.7'` to MODEL_LABELS display map

**Stores** (`projects.ts` / `sessions.ts` / `ui.ts`):
- `types/session.ts` — added `'claude-opus-4-7'` to `ModelId` union type
- `store/ui/settings.ts` — added `'claude-opus-4-7'` to `VALID_MODEL_IDS` allowlist

**Services** (`git.ts` / `claude.ts` / `github.ts` / `pty.ts`):
- N/A

**IPC** (`main/ipc.ts` → `preload/index.ts` → `lib/ipc.ts`):
- N/A

## How to test

1. `yarn dev`
2. Open the model selector in the chat header — Opus 4.7 should appear at the top of the list
3. Select Opus 4.7 and start a session — the model label should display correctly in message turn headers
4. Open Settings → AI — Opus 4.7 should appear in the model picker
5. Check the Analytics settings page — Opus 4.7 should be listed in model usage stats

## Screenshots

<!-- Before/after if UI changed. Remove if not applicable. -->

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store