### PR TITLE
fix(diff): refresh diff view on stage/unstage and clean up worktree state

### DIFF
--- a/src/renderer/components/Center/DiffReviewView.tsx
+++ b/src/renderer/components/Center/DiffReviewView.tsx
@@ -22,7 +22,7 @@ import { isBinaryFile, isGitBinaryDiff } from '@/lib/binaryFile'
 import { useShikiHighlight } from '@/hooks/useShikiHighlight'
 import * as ipc from '@/lib/ipc'
 import type { DiffComment } from '@/types'
-import type { GitStatusCode } from '@/store/ui'
+import { useUIStore, type GitStatusCode } from '@/store/ui'
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -61,6 +61,9 @@ export function DiffReviewView({ filePath, worktreePath, fileStatus = 'M', fileS
     () => (filePath ? state.comments.filter((c) => c.file === filePath) : []),
     [state.comments, filePath],
   )
+
+  // Subscribe to diff revision so we re-fetch when changes are detected (e.g. new stage/unstage)
+  const diffRevision = useUIStore((s) => s.diffRevisionByWorktree[worktreePath] ?? 0)
 
   useEffect(() => { onCommentsChange(state.comments) }, [state.comments, onCommentsChange])
   useEffect(() => { onRegisterClear?.(() => dispatch({ type: 'CLEAR_COMMENTS' })) }, [onRegisterClear])
@@ -102,7 +105,7 @@ export function DiffReviewView({ filePath, worktreePath, fileStatus = 'M', fileS
     }
     load()
     return () => { cancelled = true }
-  }, [worktreePath, filePath, fileStatus, fileStaged])
+  }, [worktreePath, filePath, fileStatus, fileStaged, diffRevision])
 
   // ─── Gap expansion ─────────────────────────────────────────────────────────
 

--- a/src/renderer/components/Center/DiffReviewView.tsx
+++ b/src/renderer/components/Center/DiffReviewView.tsx
@@ -65,6 +65,13 @@ export function DiffReviewView({ filePath, worktreePath, fileStatus = 'M', fileS
   // Subscribe to diff revision so we re-fetch when changes are detected (e.g. new stage/unstage)
   const diffRevision = useUIStore((s) => s.diffRevisionByWorktree[worktreePath] ?? 0)
 
+  // Refs used by the fetch effect to detect "silent reloads" (poll-driven refreshes
+  // for the same file selection) so we can skip the LOADING flicker and avoid
+  // dispatching LOADED when the diff content is unchanged.
+  const prevSelectionKeyRef = useRef<string | null>(null)
+  const currentDiffRef = useRef<string>('')
+  useEffect(() => { currentDiffRef.current = state.diff }, [state.diff])
+
   useEffect(() => { onCommentsChange(state.comments) }, [state.comments, onCommentsChange])
   useEffect(() => { onRegisterClear?.(() => dispatch({ type: 'CLEAR_COMMENTS' })) }, [onRegisterClear])
 
@@ -73,8 +80,16 @@ export function DiffReviewView({ filePath, worktreePath, fileStatus = 'M', fileS
   useEffect(() => {
     if (!worktreePath || !filePath) return
     let cancelled = false
+
+    // A "silent reload" is when only diffRevision changed - i.e. the same file is
+    // still selected but the changes panel detected new git state. In that case
+    // we keep the existing diff visible while fetching, avoiding a 10s UI flicker.
+    const selectionKey = `${worktreePath}|${filePath}|${fileStatus}|${fileStaged}`
+    const isSilentReload = prevSelectionKeyRef.current === selectionKey
+    prevSelectionKeyRef.current = selectionKey
+
     async function load() {
-      dispatch({ type: 'LOADING' })
+      if (!isSilentReload) dispatch({ type: 'LOADING' })
 
       // Detect binary by extension before attempting a text read
       if (isBinaryFile(filePath!)) {
@@ -91,6 +106,10 @@ export function DiffReviewView({ filePath, worktreePath, fileStatus = 'M', fileS
           dispatch({ type: 'LOADED_BINARY' })
           return
         }
+
+        // Skip dispatch on silent reloads when content is byte-identical to current.
+        // Avoids re-parse, re-render, and Shiki re-highlight churn on the 10s poll.
+        if (isSilentReload && raw === currentDiffRef.current) return
 
         const hunks = parseDiff(raw)
         let add = 0, del = 0

--- a/src/renderer/components/Right/useChangesActions.ts
+++ b/src/renderer/components/Right/useChangesActions.ts
@@ -51,6 +51,7 @@ export function useChangesActions(
       const status = await ipc.git.getStatus(worktreePath) as GitChange[]
       dispatch({ type: 'SET_CHANGES', changes: status })
       useUIStore.getState().setChangesCount(worktreePath, status.length)
+      useUIStore.getState().bumpDiffRevision(worktreePath)
     } catch (err) {
       const { cache } = usePrCacheStore.getState()
       const st = cache[worktreePath]?.data?.state

--- a/src/renderer/store/projects.ts
+++ b/src/renderer/store/projects.ts
@@ -356,6 +356,9 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
       }
     }
 
+    // Prune per-worktree state from the UI store (and persisted localStorage entries)
+    ui.cleanupWorktreeState(worktreeId, worktree.path)
+
     // Optimistically remove from UI immediately
     set({
       projects: get().projects.map((p) =>

--- a/src/renderer/store/projects.ts
+++ b/src/renderer/store/projects.ts
@@ -356,9 +356,6 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
       }
     }
 
-    // Prune per-worktree state from the UI store (and persisted localStorage entries)
-    ui.cleanupWorktreeState(worktreeId, worktree.path)
-
     // Optimistically remove from UI immediately
     set({
       projects: get().projects.map((p) =>
@@ -372,10 +369,16 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
       await ipc.git.removeWorktree(project.path, worktree.path)
     } catch (err) {
       console.error('[Projects] removeWorktree failed:', err)
-      // Revert by refreshing actual state from disk
+      // Revert by refreshing actual state from disk. Per-worktree UI state
+      // (open tabs, selected file, localStorage) is preserved because the
+      // cleanup below only runs after the IPC call succeeds.
       await get().refreshWorktrees(projectId)
       return
     }
+
+    // IPC succeeded - now safe to prune per-worktree UI state and localStorage.
+    // Doing this before the IPC would cause permanent state loss on git failure.
+    ui.cleanupWorktreeState(worktreeId, worktree.path)
 
     // Sync with actual git state
     await get().refreshWorktrees(projectId)

--- a/src/renderer/store/ui/__tests__/layout.test.ts
+++ b/src/renderer/store/ui/__tests__/layout.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useUIStore } from '../store'
+import { SK } from '@/lib/storageKeys'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Snapshot a few per-worktree maps that we want to guarantee untouched. */
+function snapshot() {
+  const s = useUIStore.getState()
+  return {
+    diffRevisionByWorktree: { ...s.diffRevisionByWorktree },
+    changesOpenByWorktree: { ...s.changesOpenByWorktree },
+    selectedDiffFileByWorktree: { ...s.selectedDiffFileByWorktree },
+    activeCenterViewByWorktree: { ...s.activeCenterViewByWorktree },
+    changesCounts: { ...s.changesCounts },
+  }
+}
+
+beforeEach(() => {
+  // Reset only the per-worktree maps we touch in these tests so we don't
+  // bleed state across tests. We don't fully reset the store because that
+  // would interfere with module-level localStorage initialization.
+  useUIStore.setState({
+    diffRevisionByWorktree: {},
+    changesOpenByWorktree: {},
+    selectedDiffFileByWorktree: {},
+    activeCenterViewByWorktree: {},
+    changesCounts: {},
+  })
+})
+
+// ---------------------------------------------------------------------------
+// bumpDiffRevision
+// ---------------------------------------------------------------------------
+
+describe('bumpDiffRevision', () => {
+  it('initializes the counter to 1 on first bump', () => {
+    useUIStore.getState().bumpDiffRevision('/path/to/wt-a')
+    expect(useUIStore.getState().diffRevisionByWorktree['/path/to/wt-a']).toBe(1)
+  })
+
+  it('increments an existing counter monotonically', () => {
+    const { bumpDiffRevision } = useUIStore.getState()
+    bumpDiffRevision('/path/to/wt-a')
+    bumpDiffRevision('/path/to/wt-a')
+    bumpDiffRevision('/path/to/wt-a')
+    expect(useUIStore.getState().diffRevisionByWorktree['/path/to/wt-a']).toBe(3)
+  })
+
+  it('keeps revisions independent across worktrees', () => {
+    const { bumpDiffRevision } = useUIStore.getState()
+    bumpDiffRevision('/path/to/wt-a')
+    bumpDiffRevision('/path/to/wt-a')
+    bumpDiffRevision('/path/to/wt-b')
+
+    const map = useUIStore.getState().diffRevisionByWorktree
+    expect(map['/path/to/wt-a']).toBe(2)
+    expect(map['/path/to/wt-b']).toBe(1)
+  })
+
+  it('does not mutate the previous map reference', () => {
+    useUIStore.getState().bumpDiffRevision('/path/to/wt-a')
+    const before = useUIStore.getState().diffRevisionByWorktree
+    useUIStore.getState().bumpDiffRevision('/path/to/wt-a')
+    const after = useUIStore.getState().diffRevisionByWorktree
+    // New reference each bump (Zustand consumers rely on this for re-renders)
+    expect(after).not.toBe(before)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// cleanupWorktreeState
+// ---------------------------------------------------------------------------
+
+describe('cleanupWorktreeState', () => {
+  const WT_ID = 'wt-1'
+  const WT_PATH = '/path/to/wt-1'
+
+  function seed() {
+    useUIStore.setState({
+      diffRevisionByWorktree: { [WT_PATH]: 5, '/other/wt': 3 },
+      changesOpenByWorktree: { [WT_ID]: true, 'wt-other': true },
+      selectedDiffFileByWorktree: {
+        [WT_ID]: { path: 'src/foo.ts', status: 'M', staged: true },
+        'wt-other': { path: 'src/bar.ts', status: 'A', staged: false },
+      },
+      activeCenterViewByWorktree: {
+        [WT_ID]: { type: 'changes' },
+        'wt-other': { type: 'session', sessionId: 'sess-1' },
+      },
+      changesCounts: { [WT_PATH]: 7, '/other/wt': 2 },
+    })
+  }
+
+  it('removes entries keyed by worktreeId', () => {
+    seed()
+    useUIStore.getState().cleanupWorktreeState(WT_ID, WT_PATH)
+    const s = useUIStore.getState()
+    expect(s.changesOpenByWorktree).not.toHaveProperty(WT_ID)
+    expect(s.selectedDiffFileByWorktree).not.toHaveProperty(WT_ID)
+    expect(s.activeCenterViewByWorktree).not.toHaveProperty(WT_ID)
+  })
+
+  it('removes entries keyed by worktreePath', () => {
+    seed()
+    useUIStore.getState().cleanupWorktreeState(WT_ID, WT_PATH)
+    const s = useUIStore.getState()
+    expect(s.changesCounts).not.toHaveProperty(WT_PATH)
+    expect(s.diffRevisionByWorktree).not.toHaveProperty(WT_PATH)
+  })
+
+  it('preserves entries for other worktrees', () => {
+    seed()
+    useUIStore.getState().cleanupWorktreeState(WT_ID, WT_PATH)
+    const s = useUIStore.getState()
+    expect(s.changesOpenByWorktree['wt-other']).toBe(true)
+    expect(s.selectedDiffFileByWorktree['wt-other']?.path).toBe('src/bar.ts')
+    expect(s.activeCenterViewByWorktree['wt-other']).toEqual({ type: 'session', sessionId: 'sess-1' })
+    expect(s.changesCounts['/other/wt']).toBe(2)
+    expect(s.diffRevisionByWorktree['/other/wt']).toBe(3)
+  })
+
+  it('is a no-op when neither id nor path appears in any map', () => {
+    seed()
+    const before = snapshot()
+    useUIStore.getState().cleanupWorktreeState('nonexistent-id', '/nonexistent/path')
+    const after = snapshot()
+    // Each map reference is preserved (no spurious set) when no key matches
+    expect(after.diffRevisionByWorktree).toStrictEqual(before.diffRevisionByWorktree)
+    expect(after.changesOpenByWorktree).toStrictEqual(before.changesOpenByWorktree)
+    expect(after.selectedDiffFileByWorktree).toStrictEqual(before.selectedDiffFileByWorktree)
+    expect(after.activeCenterViewByWorktree).toStrictEqual(before.activeCenterViewByWorktree)
+    expect(after.changesCounts).toStrictEqual(before.changesCounts)
+  })
+
+  it('clears persisted localStorage entries for the worktree', () => {
+    const filesKey = SK.openFilePathsPrefix + WT_ID
+    const tabsKey = SK.tabOrderPrefix + WT_ID
+    localStorage.setItem(filesKey, JSON.stringify(['a.ts']))
+    localStorage.setItem(tabsKey, JSON.stringify(['changes']))
+    // Sanity check
+    expect(localStorage.getItem(filesKey)).not.toBeNull()
+    useUIStore.getState().cleanupWorktreeState(WT_ID, WT_PATH)
+    expect(localStorage.getItem(filesKey)).toBeNull()
+    expect(localStorage.getItem(tabsKey)).toBeNull()
+  })
+})

--- a/src/renderer/store/ui/layout.ts
+++ b/src/renderer/store/ui/layout.ts
@@ -158,6 +158,7 @@ export interface LayoutSlice {
   persistRightPanelWidth: () => void
   setChangesCount: (worktreePath: string, count: number) => void
   bumpDiffRevision: (worktreePath: string) => void
+  cleanupWorktreeState: (worktreeId: string, worktreePath: string) => void
 }
 
 export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (set, get) => ({
@@ -566,6 +567,27 @@ export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (se
   bumpDiffRevision: (worktreePath) => {
     const current = get().diffRevisionByWorktree[worktreePath] ?? 0
     set({ diffRevisionByWorktree: { ...get().diffRevisionByWorktree, [worktreePath]: current + 1 } })
+  },
+
+  cleanupWorktreeState: (worktreeId, worktreePath) => {
+    // Prune all per-worktree maps to avoid leaking entries after worktree deletion.
+    // Some maps key by worktreeId, others by worktreePath - clean both consistently.
+    const omit = <V,>(obj: Record<string, V>, key: string): Record<string, V> => {
+      if (!(key in obj)) return obj
+      const { [key]: _, ...rest } = obj
+      return rest
+    }
+    const s = get()
+    set({
+      changesOpenByWorktree: omit(s.changesOpenByWorktree, worktreeId),
+      selectedDiffFileByWorktree: omit(s.selectedDiffFileByWorktree, worktreeId),
+      activeCenterViewByWorktree: omit(s.activeCenterViewByWorktree, worktreeId),
+      changesCounts: omit(s.changesCounts, worktreePath),
+      diffRevisionByWorktree: omit(s.diffRevisionByWorktree, worktreePath),
+    })
+    // Also clear persisted per-worktree localStorage entries
+    try { localStorage.removeItem(SK.openFilePathsPrefix + worktreeId) } catch {}
+    try { localStorage.removeItem(SK.tabOrderPrefix + worktreeId) } catch {}
   },
 })
 

--- a/src/renderer/store/ui/layout.ts
+++ b/src/renderer/store/ui/layout.ts
@@ -122,6 +122,7 @@ export interface LayoutSlice {
   sidebarWidth: number
   rightPanelWidth: number
   changesCounts: Record<string, number>
+  diffRevisionByWorktree: Record<string, number>
 
   selectWorktree: (projectId: string, worktreeId: string) => void
   toggleProject: (projectId: string) => void
@@ -156,6 +157,7 @@ export interface LayoutSlice {
   setRightPanelWidth: (width: number) => void
   persistRightPanelWidth: () => void
   setChangesCount: (worktreePath: string, count: number) => void
+  bumpDiffRevision: (worktreePath: string) => void
 }
 
 export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (set, get) => ({
@@ -212,6 +214,7 @@ export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (se
   sidebarWidth: loadInt(SK.sidebarWidth, 290),
   rightPanelWidth: loadInt(SK.rightPanelWidth, 400),
   changesCounts: {},
+  diffRevisionByWorktree: {},
 
   selectWorktree: (projectId, worktreeId) => {
     const expanded = new Set(get().expandedProjects)
@@ -558,6 +561,11 @@ export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (se
     const prev = get().changesCounts[worktreePath]
     if (prev === count) return
     set({ changesCounts: { ...get().changesCounts, [worktreePath]: count } })
+  },
+
+  bumpDiffRevision: (worktreePath) => {
+    const current = get().diffRevisionByWorktree[worktreePath] ?? 0
+    set({ diffRevisionByWorktree: { ...get().diffRevisionByWorktree, [worktreePath]: current + 1 } })
   },
 })
 


### PR DESCRIPTION
Closes #44

## Summary

- Refresh the diff review panel when files are staged/unstaged, using a per-worktree revision counter (`bumpDiffRevision`) that triggers a re-fetch without LOADING flicker
- Add `cleanupWorktreeState()` to prune per-worktree maps (changesCounts, diffRevision, changesOpen, selectedDiffFile, activeCenterView, localStorage) when a worktree is deleted
- Add comprehensive unit tests for `bumpDiffRevision` and `cleanupWorktreeState`

## Layers touched

- [x] **Renderer** (`src/renderer/`) - components, stores, lib

## Changes

**Center panel:**
- `DiffReviewView.tsx`: Subscribe to `diffRevisionByWorktree` so the diff re-fetches after stage/unstage. Silent reloads (same file selection) skip the LOADING dispatch and bail early when content is byte-identical, avoiding re-parse/re-render/Shiki churn on the 10s poll.

**Right panel:**
- `useChangesActions.ts`: Call `bumpDiffRevision()` after a successful git status refresh so the diff panel picks up stage/unstage changes.

**Stores** (`projects.ts` / `ui/layout.ts`):
- `layout.ts`: Add `diffRevisionByWorktree` map, `bumpDiffRevision()` action, and `cleanupWorktreeState()` action that prunes all per-worktree maps and localStorage entries.
- `projects.ts`: Call `cleanupWorktreeState()` when a worktree is deleted.

**Tests:**
- `ui/__tests__/layout.test.ts`: New test suite covering `bumpDiffRevision` (initialization, monotonic increment, cross-worktree independence, immutable map reference) and `cleanupWorktreeState` (id-keyed cleanup, path-keyed cleanup, preservation of other worktrees, no-op safety, localStorage cleanup).

## How to test

1. `yarn dev`
2. Open a worktree with uncommitted changes
3. Select a changed file to open the diff review panel
4. Stage or unstage the file - the diff should refresh without a loading flash
5. Delete a worktree and verify no stale entries leak in DevTools > Application > Local Storage
6. `yarn test src/renderer/store/ui/__tests__/layout.test.ts` - all tests pass

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with \`yarn dev\`
- [x] Types pass - \`yarn typecheck\`
- [x] No console errors or warnings in DevTools
- [x] New state is added to the correct Zustand store