### PR TITLE
feat: persist update dismissal and add activity bar update button

### DIFF
--- a/src/renderer/components/Sidebar/ActivityBar.tsx
+++ b/src/renderer/components/Sidebar/ActivityBar.tsx
@@ -1,8 +1,9 @@
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useUIStore } from '@/store/ui'
+import { useUpdaterStore } from '@/store/updater'
 import { Tooltip } from '@/components/shared/Tooltip'
-import { IconGitBranch, IconGrid, IconSettings } from '@/components/shared/icons'
+import { IconGitBranch, IconGrid, IconSettings, IconArrowUp } from '@/components/shared/icons'
 import { ActivityBarApps } from './ActivityBarApps'
 
 interface ActivityBarItemProps {
@@ -38,6 +39,18 @@ export const ActivityBar = memo(function ActivityBar() {
   const toggleSidebar = useUIStore((s) => s.toggleSidebar)
   const toggleMissionControl = useUIStore((s) => s.toggleMissionControl)
   const openSettings = useUIStore((s) => s.openSettings)
+  const updaterState = useUpdaterStore((s) => s.state)
+  const updaterDispatch = useUpdaterStore((s) => s.dispatch)
+
+  const dismissedUpdate =
+    (updaterState.status === 'available' || updaterState.status === 'ready') &&
+    updaterState.dismissed
+
+  const updateTooltip = dismissedUpdate
+    ? updaterState.status === 'ready'
+      ? t('updateReady', { version: updaterState.version })
+      : t('updateAvailable', { version: updaterState.version })
+    : ''
 
   return (
     <div className="activity-bar">
@@ -60,6 +73,18 @@ export const ActivityBar = memo(function ActivityBar() {
         <div className="activity-bar-drag-spacer" />
       </div>
       <div className="activity-bar-bottom">
+        {dismissedUpdate && (
+          <Tooltip content={updateTooltip} position="right">
+            <button
+              className="activity-bar-item activity-bar-update-btn"
+              onClick={() => updaterDispatch({ type: 'undismiss' })}
+              aria-label={updateTooltip}
+            >
+              <IconArrowUp size={18} />
+              <span className="activity-bar-update-dot" />
+            </button>
+          </Tooltip>
+        )}
         <ActivityBarItem
           icon={<IconSettings size={20} />}
           label={`${t('settings')} (\u2318,)`}

--- a/src/renderer/components/Sidebar/ActivityBar.tsx
+++ b/src/renderer/components/Sidebar/ActivityBar.tsx
@@ -39,17 +39,17 @@ export const ActivityBar = memo(function ActivityBar() {
   const toggleSidebar = useUIStore((s) => s.toggleSidebar)
   const toggleMissionControl = useUIStore((s) => s.toggleMissionControl)
   const openSettings = useUIStore((s) => s.openSettings)
-  const updaterState = useUpdaterStore((s) => s.state)
+  const dismissedUpdate = useUpdaterStore(
+    (s) => (s.state.status === 'available' || s.state.status === 'ready') && s.state.dismissed
+  )
+  const updaterStatus = useUpdaterStore((s) => s.state.status)
+  const updaterVersion = useUpdaterStore((s) => ('version' in s.state ? s.state.version : undefined))
   const updaterDispatch = useUpdaterStore((s) => s.dispatch)
 
-  const dismissedUpdate =
-    (updaterState.status === 'available' || updaterState.status === 'ready') &&
-    updaterState.dismissed
-
   const updateTooltip = dismissedUpdate
-    ? updaterState.status === 'ready'
-      ? t('updateReady', { version: updaterState.version })
-      : t('updateAvailable', { version: updaterState.version })
+    ? updaterStatus === 'ready'
+      ? t('updateReady', { version: updaterVersion })
+      : t('updateAvailable', { version: updaterVersion })
     : ''
 
   return (

--- a/src/renderer/hooks/useAutoUpdate.ts
+++ b/src/renderer/hooks/useAutoUpdate.ts
@@ -89,10 +89,23 @@ if (import.meta.env.DEV) {
       version: '99.0.0',
       releaseNotes: '- Simulated update\n- For testing the full flow',
     })
-    console.log('[updater:sim] Showing available dialog. Call __simulateUpdate() again to continue.')
+    console.log('[updater:sim] Showing available dialog. Click "Download" to continue, or "Later" to dismiss.')
 
-    await sleep(3000)
-    dispatch({ type: 'startDownload' })
+    // Wait for the user to click Download (startDownload action moves state to 'downloading')
+    const MAX_WAIT_MS = 60_000
+    const POLL_MS = 200
+    let waited = 0
+    while (waited < MAX_WAIT_MS) {
+      await sleep(POLL_MS)
+      waited += POLL_MS
+      const s = useUpdaterStore.getState().state
+      if (s.status === 'downloading') break
+      // User dismissed — stop here so the activity bar button appears
+      if (s.status === 'available' && s.dismissed) {
+        console.log('[updater:sim] Dismissed — activity bar update button should now be visible.')
+        return
+      }
+    }
 
     for (let i = 0; i <= 100; i += 10) {
       dispatch({ type: 'progress', percent: i })

--- a/src/renderer/locales/en/sidebar.json
+++ b/src/renderer/locales/en/sidebar.json
@@ -130,5 +130,7 @@
   "quickStartNextjsFailed": "Failed to scaffold Next.js project. See the console for details.",
   "quickStartNextjsToolMissing": "Could not find npx. Install Node.js (which includes npx) and try again.",
   "quickStartNextjsTimeout": "Scaffolding timed out after 10 minutes. Check your network and try again.",
-  "quickStartParentNotDirectory": "The selected location is not a directory or could not be accessed"
+  "quickStartParentNotDirectory": "The selected location is not a directory or could not be accessed",
+  "updateAvailable": "Update available — v{{version}}",
+  "updateReady": "Restart to update — v{{version}}"
 }

--- a/src/renderer/locales/id/sidebar.json
+++ b/src/renderer/locales/id/sidebar.json
@@ -130,5 +130,7 @@
   "quickStartNextjsFailed": "Gagal membuat proyek Next.js. Lihat konsol untuk detailnya.",
   "quickStartNextjsToolMissing": "npx tidak ditemukan. Pasang Node.js (yang menyertakan npx) lalu coba lagi.",
   "quickStartNextjsTimeout": "Scaffolding melebihi batas waktu 10 menit. Periksa koneksi Anda lalu coba lagi.",
-  "quickStartParentNotDirectory": "Lokasi yang dipilih bukan folder atau tidak dapat diakses"
+  "quickStartParentNotDirectory": "Lokasi yang dipilih bukan folder atau tidak dapat diakses",
+  "updateAvailable": "Pembaruan tersedia — v{{version}}",
+  "updateReady": "Mulai ulang untuk memperbarui — v{{version}}"
 }

--- a/src/renderer/locales/ja/sidebar.json
+++ b/src/renderer/locales/ja/sidebar.json
@@ -130,5 +130,7 @@
   "quickStartNextjsFailed": "Next.js プロジェクトの作成に失敗しました。詳細はコンソールを確認してください。",
   "quickStartNextjsToolMissing": "npx が見つかりませんでした。Node.js (npx を含む) をインストールしてから再試行してください。",
   "quickStartNextjsTimeout": "スキャフォールディングが10分でタイムアウトしました。ネットワークを確認して再試行してください。",
-  "quickStartParentNotDirectory": "選択された場所はフォルダではないか、アクセスできません"
+  "quickStartParentNotDirectory": "選択された場所はフォルダではないか、アクセスできません",
+  "updateAvailable": "アップデートあり — v{{version}}",
+  "updateReady": "再起動してアップデート — v{{version}}"
 }

--- a/src/renderer/store/updater.ts
+++ b/src/renderer/store/updater.ts
@@ -44,9 +44,12 @@ type UpdateAction =
 function updateReducer(state: UpdateState, action: UpdateAction): UpdateState {
   switch (action.type) {
     case 'available': {
+      // Don't downgrade from ready → available for the same version: the update
+      // is already downloaded and we'd lose that state on the next periodic check.
+      if (state.status === 'ready' && state.version === action.version) return state
       // Keep dismissed=true if the user already skipped this exact version
       const alreadyDismissed =
-        state.status === 'available' &&
+        (state.status === 'available' || state.status === 'ready') &&
         state.dismissed &&
         state.version === action.version
       return {

--- a/src/renderer/store/updater.ts
+++ b/src/renderer/store/updater.ts
@@ -35,6 +35,7 @@ type UpdateAction =
   | { type: 'ready'; version: string }
   | { type: 'error'; message: string }
   | { type: 'dismiss' }
+  | { type: 'undismiss' }
   | { type: 'startDownload' }
   | { type: 'retry' }
   | { type: 'check' }
@@ -42,13 +43,19 @@ type UpdateAction =
 
 function updateReducer(state: UpdateState, action: UpdateAction): UpdateState {
   switch (action.type) {
-    case 'available':
+    case 'available': {
+      // Keep dismissed=true if the user already skipped this exact version
+      const alreadyDismissed =
+        state.status === 'available' &&
+        state.dismissed &&
+        state.version === action.version
       return {
         status: 'available',
         version: action.version,
         releaseNotes: action.releaseNotes,
-        dismissed: false,
+        dismissed: alreadyDismissed,
       }
+    }
     case 'startDownload':
       if (state.status !== 'available') return state
       return {
@@ -68,6 +75,10 @@ function updateReducer(state: UpdateState, action: UpdateAction): UpdateState {
       if (state.status === 'available') return { ...state, dismissed: true }
       if (state.status === 'ready') return { ...state, dismissed: true }
       if (state.status === 'error') return { status: 'idle' }
+      return state
+    case 'undismiss':
+      if (state.status === 'available') return { ...state, dismissed: false }
+      if (state.status === 'ready') return { ...state, dismissed: false }
       return state
     case 'retry':
       return { status: 'idle' }

--- a/src/renderer/styles/activity-bar.css
+++ b/src/renderer/styles/activity-bar.css
@@ -148,3 +148,29 @@
 .activity-bar-app--drag-over {
   box-shadow: inset 0 2px 0 0 var(--accent);
 }
+
+/* ── Update available button ───────────────────────────────────────── */
+
+.activity-bar-update-btn {
+  color: var(--green);
+}
+
+.activity-bar-update-btn:hover {
+  color: var(--green);
+}
+
+.activity-bar-update-dot {
+  position: absolute;
+  top: var(--space-4);
+  right: var(--space-4);
+  width: var(--space-8);
+  height: var(--space-8);
+  border-radius: var(--radius-full);
+  background: var(--green);
+  animation: update-dot-pulse 2s ease-in-out infinite;
+}
+
+@keyframes update-dot-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}


### PR DESCRIPTION
## Summary

- Fix update modal re-appearing after dismiss when the periodic check fires for the same version
- Add activity bar button (↑) that appears when an update has been dismissed, so the user can reopen the modal at any time
- Fix dev simulator auto-advancing to download even when user clicks "Later"

## Layers touched

- [ ] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`activity-bar.css`)

## Changes

- `store/updater.ts` — preserve `dismissed: true` when the same version re-triggers `available`; add `undismiss` action to reopen the modal
- `components/Sidebar/ActivityBar.tsx` — show a pulsing green ↑ button above the settings gear when an update is dismissed; uses granular Zustand selectors to avoid re-renders during download
- `styles/activity-bar.css` — styles for the update button and pulsing dot badge
- `hooks/useAutoUpdate.ts` — fix dev simulator to stop and return when user dismisses instead of blindly advancing to download
- `locales/{en,ja,id}/sidebar.json` — add `updateAvailable` and `updateReady` tooltip strings

## How to test

1. `yarn dev`
2. Open DevTools console and run `__simulateUpdate()`
3. When the "Update available" dialog appears, click **"Later"**
4. Confirm the green ↑ button appears above the settings gear in the activity bar
5. Click the ↑ button — the update dialog should reopen
6. Run `__simulateUpdate()` again, click **"Download"**, let it finish, dismiss the "Restart" dialog — confirm ↑ button reappears

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [x] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store