### PR TITLE
feat: add rate limit visualization in chat footer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ src/renderer/components/
 src/renderer/hooks/    # useTabReorder, useChatScroll, useGesture, useLspProviders, etc.
 src/renderer/lib/      # ipc, i18n, branchValidation, kanbanColumns, sounds, shortcuts, constants, etc.
 src/renderer/types/    # session.ts, git.ts, ui.ts, claude-config.ts, lsp.ts (re-exported via index.ts)
-src/renderer/locales/  # en/, ja/, id/ - namespaces: common, center, sidebar, right, missionControl, settings, shortcuts
+src/renderer/locales/  # en/, ja/, id/, zh/ - namespaces: common, center, sidebar, right, missionControl, settings, shortcuts
 src/renderer/styles/   # Modular CSS stylesheets imported via styles/index.css
 ```
 
@@ -135,7 +135,7 @@ export function SettingsMyPage() {
 #### Adding a new settings page
 
 1. Create `Settings/SettingsMyPage.tsx` using the skeleton above
-2. Add translations to `locales/{en,ja,id}/settings.json`
+2. Add translations to `locales/{en,ja,id,zh}/settings.json`
 3. Add to `sectionMap` in `SettingsOverlay.tsx`
 4. Add to the relevant group in `NAV_GROUPS` in `SettingsNav.tsx`
 
@@ -149,12 +149,12 @@ export function SettingsMyPage() {
 ## Internationalization (i18n)
 
 - **i18next** + **react-i18next**, config in `src/renderer/lib/i18n.ts`
-- Languages: English (`en`), Japanese (`ja`), Indonesian (`id`). Fallback: English.
+- Languages: English (`en`), Japanese (`ja`), Indonesian (`id`), Chinese (`zh`). Fallback: English.
 - Namespaces: `common`, `center`, `sidebar`, `right`, `missionControl`, `settings`, `shortcuts`
 
 ### Adding New Strings
 
-1. Add the key to **all three** `en/<ns>.json`, `ja/<ns>.json`, `id/<ns>.json`
+1. Add the key to **all four** `en/<ns>.json`, `ja/<ns>.json`, `id/<ns>.json`, `zh/<ns>.json`
 2. Use `useTranslation('<namespace>')` and call `t('yourKey')`
 3. For plurals: `"key_one": "1 item"`, `"key_other": "{{count}} items"`
 4. Outside React: `import i18n from '@/lib/i18n'; i18n.t('key', { ns: 'center' })`

--- a/src/renderer/components/Center/ChatView.tsx
+++ b/src/renderer/components/Center/ChatView.tsx
@@ -27,6 +27,7 @@ import { flash } from '@/store/flash'
 import { useTranslation } from 'react-i18next'
 import { useMentionAutocomplete } from './useMentionAutocomplete'
 import { BranchBar } from './BranchBar'
+import { RateLimitBars } from './RateLimitBars'
 
 const DiffReviewView = lazy(() => import('./DiffReviewView').then((m) => ({ default: m.DiffReviewView })))
 
@@ -459,6 +460,7 @@ export function ChatView({ worktreePath = '' }: ChatViewProps) {
       {!isChangesMode && (
         <div className="chat-input-footer">
           <BranchBar />
+          {activeSession && <RateLimitBars sessionId={activeSession.id} />}
         </div>
       )}
     </>

--- a/src/renderer/components/Center/ChatView.tsx
+++ b/src/renderer/components/Center/ChatView.tsx
@@ -460,7 +460,7 @@ export function ChatView({ worktreePath = '' }: ChatViewProps) {
       {!isChangesMode && (
         <div className="chat-input-footer">
           <BranchBar />
-          {activeSession && <RateLimitBars sessionId={activeSession.id} />}
+          <RateLimitBars />
         </div>
       )}
     </>

--- a/src/renderer/components/Center/RateLimitBars.tsx
+++ b/src/renderer/components/Center/RateLimitBars.tsx
@@ -10,9 +10,6 @@ interface RateLimitBarsProps {
   sessionId: string
 }
 
-// Load cached data once at module init (not on every render)
-const cachedRateLimits = loadRateLimits()
-
 function getBarColor(utilization: number): string {
   if (utilization >= 0.80) return 'var(--red)'
   if (utilization >= 0.60) return 'var(--amber)'
@@ -38,11 +35,14 @@ export function RateLimitBars({ sessionId }: RateLimitBarsProps) {
     useShallow((s) => s.sessions[sessionId]?.rateLimits ?? null)
   )
 
-  // Use live data from store, fall back to localStorage cache
-  const effectiveLimits = rateLimits ?? cachedRateLimits
+  // Merge live store data with localStorage cache so both windows show even if
+  // the store only has one. Store data takes precedence over stale cache entries.
+  const effectiveLimits = useMemo(() => ({
+    ...(loadRateLimits() ?? {}),
+    ...(rateLimits ?? {})
+  }), [rateLimits])
 
   const { fiveHour, sevenDay } = useMemo(() => {
-    if (!effectiveLimits) return { fiveHour: null, sevenDay: null }
     const fiveHour = effectiveLimits['five_hour'] ?? null
     const sevenDay = effectiveLimits['seven_day']
       ?? effectiveLimits['seven_day_opus']
@@ -76,19 +76,26 @@ function RateLimitRow({ label, info, t }: {
   t: (k: string, opts?: Record<string, unknown>) => string
 }) {
   // When utilization is null, the SDK hasn't reported a percentage yet.
-  // Show a status dot based on the status field instead of a bar.
+  // Show a status indicator based on the status field instead of a percentage bar.
   if (info.utilization === null) {
     const statusColor = getStatusColor(info.status)
+    const isOk = info.status === 'allowed'
+    const bgColor = info.status === 'rejected' ? 'var(--red-tint-15)'
+      : info.status === 'allowed_warning' ? 'var(--amber-tint-15)'
+      : 'var(--green-tint-15)'
+
     return (
       <div className="rate-limit-row">
         <span className="rate-limit-label">{label}</span>
-        <div className="rate-limit-track" style={{ background: 'var(--green-tint-15)' }}>
+        <div className="rate-limit-track" style={{ background: bgColor }}>
           <div
             className="rate-limit-fill rate-limit-fill--low"
             style={{ background: statusColor }}
           />
         </div>
-        <span className="rate-limit-percent rate-limit-percent--ok">OK</span>
+        <span className={`rate-limit-percent ${isOk ? 'rate-limit-percent--ok' : ''}`}>
+          {isOk ? 'OK' : '!'}
+        </span>
       </div>
     )
   }

--- a/src/renderer/components/Center/RateLimitBars.tsx
+++ b/src/renderer/components/Center/RateLimitBars.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from 'react'
+import { useShallow } from 'zustand/shallow'
+import { useSessionsStore } from '@/store/sessions'
+import { Tooltip } from '@/components/shared/Tooltip'
+import { useTranslation } from 'react-i18next'
+import { loadRateLimits } from '@/lib/rateLimitCache'
+import type { RateLimitInfo } from '@/types'
+
+interface RateLimitBarsProps {
+  sessionId: string
+}
+
+// Load cached data once at module init (not on every render)
+const cachedRateLimits = loadRateLimits()
+
+function getBarColor(utilization: number): string {
+  if (utilization >= 0.80) return 'var(--red)'
+  if (utilization >= 0.60) return 'var(--amber)'
+  return 'var(--green)'
+}
+
+function getBarBgColor(utilization: number): string {
+  if (utilization >= 0.80) return 'var(--red-tint-15)'
+  if (utilization >= 0.60) return 'var(--amber-tint-15)'
+  return 'var(--green-tint-15)'
+}
+
+function getStatusColor(status: string): string {
+  if (status === 'rejected') return 'var(--red)'
+  if (status === 'allowed_warning') return 'var(--amber)'
+  return 'var(--green)'
+}
+
+export function RateLimitBars({ sessionId }: RateLimitBarsProps) {
+  const { t } = useTranslation('center')
+
+  const rateLimits = useSessionsStore(
+    useShallow((s) => s.sessions[sessionId]?.rateLimits ?? null)
+  )
+
+  // Use live data from store, fall back to localStorage cache
+  const effectiveLimits = rateLimits ?? cachedRateLimits
+
+  const { fiveHour, sevenDay } = useMemo(() => {
+    if (!effectiveLimits) return { fiveHour: null, sevenDay: null }
+    const fiveHour = effectiveLimits['five_hour'] ?? null
+    const sevenDay = effectiveLimits['seven_day']
+      ?? effectiveLimits['seven_day_opus']
+      ?? effectiveLimits['seven_day_sonnet']
+      ?? null
+    return { fiveHour, sevenDay }
+  }, [effectiveLimits])
+
+  if (!fiveHour && !sevenDay) return null
+
+  return (
+    <Tooltip content={t('rateLimitHeader')} position="top">
+      <div className="rate-limit-bars">
+        <span className="rate-limit-title">{t('rateLimitTitle')}</span>
+        <div className="rate-limit-tracks">
+          {fiveHour && (
+            <RateLimitRow label={t('rateLimitFiveHour')} info={fiveHour} t={t} />
+          )}
+          {sevenDay && (
+            <RateLimitRow label={t('rateLimitSevenDay')} info={sevenDay} t={t} />
+          )}
+        </div>
+      </div>
+    </Tooltip>
+  )
+}
+
+function RateLimitRow({ label, info, t }: {
+  label: string
+  info: RateLimitInfo
+  t: (k: string, opts?: Record<string, unknown>) => string
+}) {
+  // When utilization is null, the SDK hasn't reported a percentage yet.
+  // Show a status dot based on the status field instead of a bar.
+  if (info.utilization === null) {
+    const statusColor = getStatusColor(info.status)
+    return (
+      <div className="rate-limit-row">
+        <span className="rate-limit-label">{label}</span>
+        <div className="rate-limit-track" style={{ background: 'var(--green-tint-15)' }}>
+          <div
+            className="rate-limit-fill rate-limit-fill--low"
+            style={{ background: statusColor }}
+          />
+        </div>
+        <span className="rate-limit-percent rate-limit-percent--ok">OK</span>
+      </div>
+    )
+  }
+
+  const percent = Math.round(info.utilization * 100)
+  const barColor = getBarColor(info.utilization)
+  const bgColor = getBarBgColor(info.utilization)
+
+  return (
+    <div className="rate-limit-row">
+      <span className="rate-limit-label">{label}</span>
+      <div className="rate-limit-track" style={{ background: bgColor }}>
+        <div
+          className="rate-limit-fill"
+          style={{ width: `${percent}%`, background: barColor }}
+        />
+      </div>
+      <span className="rate-limit-percent">{percent}%</span>
+    </div>
+  )
+}

--- a/src/renderer/components/Center/RateLimitBars.tsx
+++ b/src/renderer/components/Center/RateLimitBars.tsx
@@ -1,14 +1,9 @@
 import { useMemo } from 'react'
 import { useShallow } from 'zustand/shallow'
-import { useSessionsStore } from '@/store/sessions'
+import { useRateLimitsStore } from '@/store/rateLimits'
 import { Tooltip } from '@/components/shared/Tooltip'
 import { useTranslation } from 'react-i18next'
-import { loadRateLimits } from '@/lib/rateLimitCache'
 import type { RateLimitInfo } from '@/types'
-
-interface RateLimitBarsProps {
-  sessionId: string
-}
 
 function getBarColor(utilization: number): string {
   if (utilization >= 0.80) return 'var(--red)'
@@ -28,28 +23,21 @@ function getStatusColor(status: string): string {
   return 'var(--green)'
 }
 
-export function RateLimitBars({ sessionId }: RateLimitBarsProps) {
+export function RateLimitBars() {
   const { t } = useTranslation('center')
 
-  const rateLimits = useSessionsStore(
-    useShallow((s) => s.sessions[sessionId]?.rateLimits ?? null)
+  const limits = useRateLimitsStore(
+    useShallow((s) => s.limits)
   )
 
-  // Merge live store data with localStorage cache so both windows show even if
-  // the store only has one. Store data takes precedence over stale cache entries.
-  const effectiveLimits = useMemo(() => ({
-    ...(loadRateLimits() ?? {}),
-    ...(rateLimits ?? {})
-  }), [rateLimits])
-
   const { fiveHour, sevenDay } = useMemo(() => {
-    const fiveHour = effectiveLimits['five_hour'] ?? null
-    const sevenDay = effectiveLimits['seven_day']
-      ?? effectiveLimits['seven_day_opus']
-      ?? effectiveLimits['seven_day_sonnet']
+    const fiveHour = limits['five_hour'] ?? null
+    const sevenDay = limits['seven_day']
+      ?? limits['seven_day_opus']
+      ?? limits['seven_day_sonnet']
       ?? null
     return { fiveHour, sevenDay }
-  }, [effectiveLimits])
+  }, [limits])
 
   if (!fiveHour && !sevenDay) return null
 
@@ -59,10 +47,10 @@ export function RateLimitBars({ sessionId }: RateLimitBarsProps) {
         <span className="rate-limit-title">{t('rateLimitTitle')}</span>
         <div className="rate-limit-tracks">
           {fiveHour && (
-            <RateLimitRow label={t('rateLimitFiveHour')} info={fiveHour} t={t} />
+            <RateLimitRow label={t('rateLimitFiveHour')} info={fiveHour} />
           )}
           {sevenDay && (
-            <RateLimitRow label={t('rateLimitSevenDay')} info={sevenDay} t={t} />
+            <RateLimitRow label={t('rateLimitSevenDay')} info={sevenDay} />
           )}
         </div>
       </div>
@@ -70,11 +58,7 @@ export function RateLimitBars({ sessionId }: RateLimitBarsProps) {
   )
 }
 
-function RateLimitRow({ label, info, t }: {
-  label: string
-  info: RateLimitInfo
-  t: (k: string, opts?: Record<string, unknown>) => string
-}) {
+function RateLimitRow({ label, info }: { label: string; info: RateLimitInfo }) {
   // When utilization is null, the SDK hasn't reported a percentage yet.
   // Show a status indicator based on the status field instead of a percentage bar.
   if (info.utilization === null) {

--- a/src/renderer/components/Center/RateLimitBars.tsx
+++ b/src/renderer/components/Center/RateLimitBars.tsx
@@ -43,17 +43,17 @@ export function RateLimitBars() {
 
   return (
     <Tooltip content={t('rateLimitHeader')} position="top">
-      <div className="rate-limit-bars">
+      <span className="rate-limit-bars">
         <span className="rate-limit-title">{t('rateLimitTitle')}</span>
-        <div className="rate-limit-tracks">
+        <span className="rate-limit-tracks">
           {fiveHour && (
             <RateLimitRow label={t('rateLimitFiveHour')} info={fiveHour} />
           )}
           {sevenDay && (
             <RateLimitRow label={t('rateLimitSevenDay')} info={sevenDay} />
           )}
-        </div>
-      </div>
+        </span>
+      </span>
     </Tooltip>
   )
 }
@@ -69,18 +69,18 @@ function RateLimitRow({ label, info }: { label: string; info: RateLimitInfo }) {
       : 'var(--green-tint-15)'
 
     return (
-      <div className="rate-limit-row">
+      <span className="rate-limit-row">
         <span className="rate-limit-label">{label}</span>
-        <div className="rate-limit-track" style={{ background: bgColor }}>
-          <div
+        <span className="rate-limit-track" style={{ background: bgColor }}>
+          <span
             className="rate-limit-fill rate-limit-fill--low"
             style={{ background: statusColor }}
           />
-        </div>
+        </span>
         <span className={`rate-limit-percent ${isOk ? 'rate-limit-percent--ok' : ''}`}>
           {isOk ? 'OK' : '!'}
         </span>
-      </div>
+      </span>
     )
   }
 
@@ -89,15 +89,15 @@ function RateLimitRow({ label, info }: { label: string; info: RateLimitInfo }) {
   const bgColor = getBarBgColor(info.utilization)
 
   return (
-    <div className="rate-limit-row">
+    <span className="rate-limit-row">
       <span className="rate-limit-label">{label}</span>
-      <div className="rate-limit-track" style={{ background: bgColor }}>
-        <div
+      <span className="rate-limit-track" style={{ background: bgColor }}>
+        <span
           className="rate-limit-fill"
           style={{ width: `${percent}%`, background: barColor }}
         />
-      </div>
+      </span>
       <span className="rate-limit-percent">{percent}%</span>
-    </div>
+    </span>
   )
 }

--- a/src/renderer/components/Center/RateLimitBars.tsx
+++ b/src/renderer/components/Center/RateLimitBars.tsx
@@ -47,10 +47,10 @@ export function RateLimitBars() {
         <span className="rate-limit-title">{t('rateLimitTitle')}</span>
         <span className="rate-limit-tracks">
           {fiveHour && (
-            <RateLimitRow label={t('rateLimitFiveHour')} info={fiveHour} />
+            <RateLimitRow label={t('rateLimitFiveHour')} info={fiveHour} t={t} />
           )}
           {sevenDay && (
-            <RateLimitRow label={t('rateLimitSevenDay')} info={sevenDay} />
+            <RateLimitRow label={t('rateLimitSevenDay')} info={sevenDay} t={t} />
           )}
         </span>
       </span>
@@ -58,7 +58,7 @@ export function RateLimitBars() {
   )
 }
 
-function RateLimitRow({ label, info }: { label: string; info: RateLimitInfo }) {
+function RateLimitRow({ label, info, t }: { label: string; info: RateLimitInfo; t: (k: string) => string }) {
   // When utilization is null, the SDK hasn't reported a percentage yet.
   // Show a status indicator based on the status field instead of a percentage bar.
   if (info.utilization === null) {
@@ -78,7 +78,7 @@ function RateLimitRow({ label, info }: { label: string; info: RateLimitInfo }) {
           />
         </span>
         <span className={`rate-limit-percent ${isOk ? 'rate-limit-percent--ok' : ''}`}>
-          {isOk ? 'OK' : '!'}
+          {isOk ? t('rateLimitOk') : t('rateLimitWarning')}
         </span>
       </span>
     )

--- a/src/renderer/lib/__tests__/rateLimitCache.test.ts
+++ b/src/renderer/lib/__tests__/rateLimitCache.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { loadRateLimits, saveRateLimitEntry } from '../rateLimitCache'
+import type { RateLimitInfo } from '@/types'
+
+// Mock localStorage
+const store: Record<string, string> = {}
+const localStorageMock = {
+  getItem: vi.fn((key: string) => store[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => { store[key] = value }),
+  removeItem: vi.fn((key: string) => { delete store[key] }),
+}
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+function makeEntry(overrides: Partial<RateLimitInfo> = {}): RateLimitInfo {
+  return {
+    rateLimitType: 'five_hour',
+    utilization: 0.42,
+    status: 'allowed',
+    updatedAt: Date.now(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(store)) delete store[key]
+  vi.clearAllMocks()
+})
+
+describe('loadRateLimits', () => {
+  it('returns null when nothing is cached', () => {
+    expect(loadRateLimits()).toBeNull()
+  })
+
+  it('returns valid entries and filters out expired ones', () => {
+    const now = Date.now()
+    const cached = {
+      five_hour: { data: makeEntry(), expiresAt: now + 10_000 },
+      seven_day: { data: makeEntry({ rateLimitType: 'seven_day' }), expiresAt: now - 1 },
+    }
+    store['braid:rateLimits'] = JSON.stringify(cached)
+
+    const result = loadRateLimits()
+    expect(result).not.toBeNull()
+    expect(result!['five_hour']).toBeDefined()
+    expect(result!['seven_day']).toBeUndefined()
+  })
+
+  it('persists pruned data back to localStorage when some entries expired', () => {
+    const now = Date.now()
+    const cached = {
+      five_hour: { data: makeEntry(), expiresAt: now + 10_000 },
+      seven_day: { data: makeEntry({ rateLimitType: 'seven_day' }), expiresAt: now - 1 },
+    }
+    store['braid:rateLimits'] = JSON.stringify(cached)
+
+    loadRateLimits()
+
+    // Should have written back only the valid entry
+    const persisted = JSON.parse(store['braid:rateLimits'])
+    expect(Object.keys(persisted)).toEqual(['five_hour'])
+  })
+
+  it('removes localStorage key when all entries are expired', () => {
+    const now = Date.now()
+    const cached = {
+      five_hour: { data: makeEntry(), expiresAt: now - 1 },
+      seven_day: { data: makeEntry({ rateLimitType: 'seven_day' }), expiresAt: now - 1 },
+    }
+    store['braid:rateLimits'] = JSON.stringify(cached)
+
+    const result = loadRateLimits()
+    expect(result).toBeNull()
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('braid:rateLimits')
+  })
+
+  it('returns null for corrupted JSON', () => {
+    store['braid:rateLimits'] = '{not valid json'
+    expect(loadRateLimits()).toBeNull()
+  })
+})
+
+describe('saveRateLimitEntry', () => {
+  it('saves an entry with appropriate TTL', () => {
+    const entry = makeEntry({ rateLimitType: 'five_hour' })
+    saveRateLimitEntry(entry)
+
+    const stored = JSON.parse(store['braid:rateLimits'])
+    expect(stored['five_hour']).toBeDefined()
+    expect(stored['five_hour'].data).toEqual(entry)
+    // 5-hour TTL
+    const expectedExpiry = entry.updatedAt + 5 * 60 * 60 * 1000
+    expect(stored['five_hour'].expiresAt).toBeGreaterThanOrEqual(expectedExpiry - 100)
+    expect(stored['five_hour'].expiresAt).toBeLessThanOrEqual(expectedExpiry + 100)
+  })
+
+  it('merges with existing entries', () => {
+    const now = Date.now()
+    const existing = {
+      five_hour: { data: makeEntry(), expiresAt: now + 10_000 },
+    }
+    store['braid:rateLimits'] = JSON.stringify(existing)
+
+    saveRateLimitEntry(makeEntry({ rateLimitType: 'seven_day', utilization: 0.1 }))
+
+    const stored = JSON.parse(store['braid:rateLimits'])
+    expect(stored['five_hour']).toBeDefined()
+    expect(stored['seven_day']).toBeDefined()
+  })
+
+  it('prunes expired entries on save', () => {
+    const now = Date.now()
+    const existing = {
+      five_hour: { data: makeEntry(), expiresAt: now - 1 },
+    }
+    store['braid:rateLimits'] = JSON.stringify(existing)
+
+    saveRateLimitEntry(makeEntry({ rateLimitType: 'seven_day' }))
+
+    const stored = JSON.parse(store['braid:rateLimits'])
+    expect(stored['five_hour']).toBeUndefined()
+    expect(stored['seven_day']).toBeDefined()
+  })
+
+  it('handles corrupted existing data gracefully', () => {
+    store['braid:rateLimits'] = 'garbage'
+    // Should not throw - silently caught
+    expect(() => saveRateLimitEntry(makeEntry())).not.toThrow()
+  })
+
+  it('uses default TTL for unknown rate limit types', () => {
+    const entry = makeEntry({ rateLimitType: 'exotic_new_type' })
+    saveRateLimitEntry(entry)
+
+    const stored = JSON.parse(store['braid:rateLimits'])
+    // Default is 1 hour
+    const expectedExpiry = Date.now() + 60 * 60 * 1000
+    expect(stored['exotic_new_type'].expiresAt).toBeGreaterThanOrEqual(expectedExpiry - 200)
+    expect(stored['exotic_new_type'].expiresAt).toBeLessThanOrEqual(expectedExpiry + 200)
+  })
+})

--- a/src/renderer/lib/rateLimitCache.ts
+++ b/src/renderer/lib/rateLimitCache.ts
@@ -1,0 +1,93 @@
+/**
+ * Persist and hydrate rate limit data with TTL-based expiry.
+ *
+ * Each entry expires based on its rate limit type:
+ * - five_hour: 5 hours
+ * - seven_day / seven_day_opus / seven_day_sonnet: 7 days
+ * - overage: 24 hours
+ * - unknown: 1 hour
+ */
+import { SK } from './storageKeys'
+import type { RateLimitInfo } from '@/types'
+
+interface CachedEntry {
+  data: RateLimitInfo
+  expiresAt: number
+}
+
+type CachedRateLimits = Record<string, CachedEntry>
+
+const TTL_MS: Record<string, number> = {
+  five_hour: 5 * 60 * 60 * 1000,        // 5 hours
+  seven_day: 7 * 24 * 60 * 60 * 1000,   // 7 days
+  seven_day_opus: 7 * 24 * 60 * 60 * 1000,
+  seven_day_sonnet: 7 * 24 * 60 * 60 * 1000,
+  overage: 24 * 60 * 60 * 1000,          // 24 hours
+}
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000    // 1 hour fallback
+
+function getTtl(rateLimitType: string): number {
+  return TTL_MS[rateLimitType] ?? DEFAULT_TTL_MS
+}
+
+/**
+ * Load cached rate limits from localStorage, filtering out expired entries.
+ */
+export function loadRateLimits(): Record<string, RateLimitInfo> | null {
+  try {
+    const raw = localStorage.getItem(SK.rateLimits)
+    if (!raw) return null
+
+    const cached: CachedRateLimits = JSON.parse(raw)
+    const now = Date.now()
+    const result: Record<string, RateLimitInfo> = {}
+    let hasValid = false
+
+    for (const [key, entry] of Object.entries(cached)) {
+      if (now < entry.expiresAt) {
+        result[key] = entry.data
+        hasValid = true
+      }
+    }
+
+    // Clean up expired entries from storage
+    if (!hasValid) {
+      localStorage.removeItem(SK.rateLimits)
+      return null
+    }
+
+    return result
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Save a single rate limit entry, merging with existing cached data.
+ * TTL is set based on the rate limit type's window.
+ */
+export function saveRateLimitEntry(info: RateLimitInfo): void {
+  try {
+    const raw = localStorage.getItem(SK.rateLimits)
+    const cached: CachedRateLimits = raw ? JSON.parse(raw) : {}
+    const now = Date.now()
+
+    // Prune expired entries while we're here
+    for (const [key, entry] of Object.entries(cached)) {
+      if (now >= entry.expiresAt) {
+        delete cached[key]
+      }
+    }
+
+    // Add/update the new entry with appropriate TTL
+    cached[info.rateLimitType] = {
+      data: info,
+      expiresAt: now + getTtl(info.rateLimitType),
+    }
+
+    localStorage.setItem(SK.rateLimits, JSON.stringify(cached))
+  } catch {
+    // Quota exceeded or access denied - silently ignore
+  }
+}

--- a/src/renderer/lib/rateLimitCache.ts
+++ b/src/renderer/lib/rateLimitCache.ts
@@ -42,22 +42,30 @@ export function loadRateLimits(): Record<string, RateLimitInfo> | null {
     const cached: CachedRateLimits = JSON.parse(raw)
     const now = Date.now()
     const result: Record<string, RateLimitInfo> = {}
+    const pruned: CachedRateLimits = {}
     let hasValid = false
+    let hasExpired = false
 
     for (const [key, entry] of Object.entries(cached)) {
       if (now < entry.expiresAt) {
         result[key] = entry.data
+        pruned[key] = entry
         hasValid = true
+      } else {
+        hasExpired = true
       }
     }
 
-    // Clean up expired entries from storage
-    if (!hasValid) {
-      localStorage.removeItem(SK.rateLimits)
-      return null
+    // Persist pruned data back to storage so expired entries don't accumulate
+    if (hasExpired) {
+      if (hasValid) {
+        localStorage.setItem(SK.rateLimits, JSON.stringify(pruned))
+      } else {
+        localStorage.removeItem(SK.rateLimits)
+      }
     }
 
-    return result
+    return hasValid ? result : null
   } catch {
     return null
   }

--- a/src/renderer/lib/storageKeys.ts
+++ b/src/renderer/lib/storageKeys.ts
@@ -106,6 +106,10 @@ export const SK = {
   // ── Settings — Integrations ────────────────────────────────────────────
   jiraBaseUrl:                `${prefix}:jiraBaseUrl`,
 
+  // ── Rate limits ────────────────────────────────────────────────────
+  /** Account-wide rate limit utilization from SDK, cached with TTL matching the limit window */
+  rateLimits:                 `${prefix}:rateLimits`,
+
   // ── Experimental / Web apps ────────────────────────────────────────────
   experimentalCapture:        `${prefix}:experimentalCapture`,
   bottomTerminalEnabled:      `${prefix}:bottomTerminalEnabled`,

--- a/src/renderer/locales/en/center.json
+++ b/src/renderer/locales/en/center.json
@@ -348,5 +348,7 @@
   "rateLimitFiveHour": "5h",
   "rateLimitSevenDay": "7d",
   "rateLimitTooltip": "{{label}} rolling window: {{percent}}% used",
-  "rateLimitStatusOk": "{{label}} rolling window: well within limits"
+  "rateLimitStatusOk": "{{label}} rolling window: well within limits",
+  "rateLimitOk": "OK",
+  "rateLimitWarning": "!"
 }

--- a/src/renderer/locales/en/center.json
+++ b/src/renderer/locales/en/center.json
@@ -342,5 +342,11 @@
   "rollback.cancel": "Cancel",
   "rollback.experimentalWarning": "This feature is experimental and still in development.",
   "rollback.genericError": "Rollback failed",
-  "rollback.snapshotExpired": "Snapshot expired - git may have garbage-collected it"
+  "rollback.snapshotExpired": "Snapshot expired - git may have garbage-collected it",
+  "rateLimitTitle": "Limit",
+  "rateLimitHeader": "Claude usage limits for your subscription plan",
+  "rateLimitFiveHour": "5h",
+  "rateLimitSevenDay": "7d",
+  "rateLimitTooltip": "{{label}} rolling window: {{percent}}% used",
+  "rateLimitStatusOk": "{{label}} rolling window: well within limits"
 }

--- a/src/renderer/locales/id/center.json
+++ b/src/renderer/locales/id/center.json
@@ -330,5 +330,7 @@
   "rateLimitFiveHour": "5j",
   "rateLimitSevenDay": "7h",
   "rateLimitTooltip": "Jendela bergulir {{label}}: {{percent}}% digunakan",
-  "rateLimitStatusOk": "Jendela bergulir {{label}}: dalam batas"
+  "rateLimitStatusOk": "Jendela bergulir {{label}}: dalam batas",
+  "rateLimitOk": "OK",
+  "rateLimitWarning": "!"
 }

--- a/src/renderer/locales/id/center.json
+++ b/src/renderer/locales/id/center.json
@@ -324,5 +324,11 @@
   "rollback.cancel": "Batal",
   "rollback.experimentalWarning": "Fitur ini masih eksperimental dan dalam pengembangan.",
   "rollback.genericError": "Rollback gagal",
-  "rollback.snapshotExpired": "Snapshot kedaluwarsa - git mungkin telah melakukan garbage collection"
+  "rollback.snapshotExpired": "Snapshot kedaluwarsa - git mungkin telah melakukan garbage collection",
+  "rateLimitTitle": "Batas",
+  "rateLimitHeader": "Batas penggunaan Claude untuk paket langganan Anda",
+  "rateLimitFiveHour": "5j",
+  "rateLimitSevenDay": "7h",
+  "rateLimitTooltip": "Jendela bergulir {{label}}: {{percent}}% digunakan",
+  "rateLimitStatusOk": "Jendela bergulir {{label}}: dalam batas"
 }

--- a/src/renderer/locales/ja/center.json
+++ b/src/renderer/locales/ja/center.json
@@ -331,5 +331,7 @@
   "rateLimitFiveHour": "5時",
   "rateLimitSevenDay": "7日",
   "rateLimitTooltip": "{{label}}ローリング: {{percent}}%使用済み",
-  "rateLimitStatusOk": "{{label}}ローリング: 制限内"
+  "rateLimitStatusOk": "{{label}}ローリング: 制限内",
+  "rateLimitOk": "OK",
+  "rateLimitWarning": "!"
 }

--- a/src/renderer/locales/ja/center.json
+++ b/src/renderer/locales/ja/center.json
@@ -325,5 +325,11 @@
   "rollback.cancel": "キャンセル",
   "rollback.experimentalWarning": "この機能は実験的であり、まだ開発中です。",
   "rollback.genericError": "巻き戻しに失敗しました",
-  "rollback.snapshotExpired": "スナップショットが期限切れ - gitがガベージコレクションした可能性があります"
+  "rollback.snapshotExpired": "スナップショットが期限切れ - gitがガベージコレクションした可能性があります",
+  "rateLimitTitle": "制限",
+  "rateLimitHeader": "サブスクリプションのClaude使用制限",
+  "rateLimitFiveHour": "5時",
+  "rateLimitSevenDay": "7日",
+  "rateLimitTooltip": "{{label}}ローリング: {{percent}}%使用済み",
+  "rateLimitStatusOk": "{{label}}ローリング: 制限内"
 }

--- a/src/renderer/locales/zh/center.json
+++ b/src/renderer/locales/zh/center.json
@@ -348,5 +348,7 @@
   "rateLimitFiveHour": "5时",
   "rateLimitSevenDay": "7天",
   "rateLimitTooltip": "{{label}}滚动窗口: 已使用{{percent}}%",
-  "rateLimitStatusOk": "{{label}}滚动窗口: 在限制范围内"
+  "rateLimitStatusOk": "{{label}}滚动窗口: 在限制范围内",
+  "rateLimitOk": "正常",
+  "rateLimitWarning": "!"
 }

--- a/src/renderer/locales/zh/center.json
+++ b/src/renderer/locales/zh/center.json
@@ -342,5 +342,11 @@
   "rollback.cancel": "取消",
   "rollback.experimentalWarning": "此功能为实验性功能，仍在开发中。",
   "rollback.genericError": "回退失败",
-  "rollback.snapshotExpired": "快照已过期 - git 可能已经回收了它"
+  "rollback.snapshotExpired": "快照已过期 - git 可能已经回收了它",
+  "rateLimitTitle": "限制",
+  "rateLimitHeader": "您的订阅计划的 Claude 使用限制",
+  "rateLimitFiveHour": "5时",
+  "rateLimitSevenDay": "7天",
+  "rateLimitTooltip": "{{label}}滚动窗口: 已使用{{percent}}%",
+  "rateLimitStatusOk": "{{label}}滚动窗口: 在限制范围内"
 }

--- a/src/renderer/store/rateLimits.ts
+++ b/src/renderer/store/rateLimits.ts
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------
+// Global rate limit store — account-wide, shared across all sessions
+// ---------------------------------------------------------------------------
+//
+// Rate limits are per-account, not per-session. Any session that receives a
+// rate_limit_event updates this global store so every RateLimitBars instance
+// reacts immediately — even if the event came from a different session.
+//
+// Hydrates from localStorage on init. Persists on every update with TTL-based
+// expiry matching the rate limit window (5h, 7d, etc.).
+//
+
+import { create } from 'zustand'
+import { loadRateLimits, saveRateLimitEntry } from '@/lib/rateLimitCache'
+import type { RateLimitInfo } from '@/types'
+
+interface RateLimitsState {
+  /** Keyed by rateLimitType (five_hour, seven_day, etc.) */
+  limits: Record<string, RateLimitInfo>
+
+  /** Called from eventHandler when any session receives a rate_limit_event */
+  update: (entry: RateLimitInfo) => void
+}
+
+export const useRateLimitsStore = create<RateLimitsState>((set) => ({
+  limits: loadRateLimits() ?? {},
+
+  update: (entry) => {
+    set((s) => ({
+      limits: { ...s.limits, [entry.rateLimitType]: entry }
+    }))
+    saveRateLimitEntry(entry)
+  },
+}))
+
+// Listen for cross-window localStorage changes (different Electron windows / worktrees)
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (e) => {
+    if (e.key?.endsWith(':rateLimits') && e.newValue) {
+      const fresh = loadRateLimits()
+      if (fresh) {
+        useRateLimitsStore.setState({ limits: fresh })
+      }
+    }
+  })
+}

--- a/src/renderer/store/sessions/eventHandler.ts
+++ b/src/renderer/store/sessions/eventHandler.ts
@@ -13,7 +13,7 @@ import { handleStreamEvent, handleToolProgress, handleResult } from './handlers/
 import { updateSession } from './stateUtils'
 import { flash } from '@/store/flash'
 import { useProjectsStore } from '@/store/projects'
-import { saveRateLimitEntry } from '@/lib/rateLimitCache'
+import { useRateLimitsStore } from '@/store/rateLimits'
 import type { ModelId } from '@/types'
 
 export function initAgentEventListener(): () => void {
@@ -74,14 +74,8 @@ export function initAgentEventListener(): () => void {
           isUsingOverage: info.isUsingOverage as boolean | undefined,
           updatedAt: Date.now()
         }
-        updateSession(store, sessionId, (current) => ({
-          rateLimits: {
-            ...(current.rateLimits ?? {}),
-            [rateLimitType]: entry
-          }
-        }))
-        // Persist to localStorage with TTL matching the rate limit window
-        saveRateLimitEntry(entry)
+        // Update global store (account-wide, not per-session) so all UI reacts
+        useRateLimitsStore.getState().update(entry)
         break
       }
       case 'elicitation_complete': {

--- a/src/renderer/store/sessions/eventHandler.ts
+++ b/src/renderer/store/sessions/eventHandler.ts
@@ -66,12 +66,17 @@ export function initAgentEventListener(): () => void {
         // When absent, store status only so the UI can show a green "all clear" dot.
         const rateLimitType = (info.rateLimitType as string) ?? 'unknown'
         const utilization = typeof info.utilization === 'number' ? info.utilization : null
+        const rawStatus = info.status as string | undefined
+        const VALID_STATUSES = new Set(['allowed', 'allowed_warning', 'rejected'])
+        const status = (rawStatus && VALID_STATUSES.has(rawStatus)
+          ? rawStatus
+          : 'allowed') as 'allowed' | 'allowed_warning' | 'rejected'
         const entry = {
           rateLimitType,
           utilization,
-          status: ((info.status as string) ?? 'allowed') as 'allowed' | 'allowed_warning' | 'rejected',
-          resetsAt: info.resetsAt as number | undefined,
-          isUsingOverage: info.isUsingOverage as boolean | undefined,
+          status,
+          resetsAt: typeof info.resetsAt === 'number' ? info.resetsAt : undefined,
+          isUsingOverage: typeof info.isUsingOverage === 'boolean' ? info.isUsingOverage : undefined,
           updatedAt: Date.now()
         }
         // Update global store (account-wide, not per-session) so all UI reacts

--- a/src/renderer/store/sessions/eventHandler.ts
+++ b/src/renderer/store/sessions/eventHandler.ts
@@ -13,6 +13,7 @@ import { handleStreamEvent, handleToolProgress, handleResult } from './handlers/
 import { updateSession } from './stateUtils'
 import { flash } from '@/store/flash'
 import { useProjectsStore } from '@/store/projects'
+import { saveRateLimitEntry } from '@/lib/rateLimitCache'
 import type { ModelId } from '@/types'
 
 export function initAgentEventListener(): () => void {
@@ -58,6 +59,32 @@ export function initAgentEventListener(): () => void {
         if (ev.subtype === 'status') return handleSystemStatus(ctx, ev)
         if (ev.subtype === 'compact_boundary') return handleCompactBoundary(ctx, ev)
         break
+      case 'rate_limit_event': {
+        const info = ev.rate_limit_info as Record<string, unknown> | undefined
+        console.log('[RateLimit] event received:', info)
+        if (!info) break
+        // The SDK only populates `utilization` when usage is meaningful (typically >= ~25%).
+        // When absent, store status only so the UI can show a green "all clear" dot.
+        const rateLimitType = (info.rateLimitType as string) ?? 'unknown'
+        const utilization = typeof info.utilization === 'number' ? info.utilization : null
+        const entry = {
+          rateLimitType,
+          utilization,
+          status: ((info.status as string) ?? 'allowed') as 'allowed' | 'allowed_warning' | 'rejected',
+          resetsAt: info.resetsAt as number | undefined,
+          isUsingOverage: info.isUsingOverage as boolean | undefined,
+          updatedAt: Date.now()
+        }
+        updateSession(store, sessionId, (current) => ({
+          rateLimits: {
+            ...(current.rateLimits ?? {}),
+            [rateLimitType]: entry
+          }
+        }))
+        // Persist to localStorage with TTL matching the rate limit window
+        saveRateLimitEntry(entry)
+        break
+      }
       case 'elicitation_complete': {
         const session = store.getState().sessions[sessionId]
         if (session?.pendingElicitation) {

--- a/src/renderer/store/sessions/eventHandler.ts
+++ b/src/renderer/store/sessions/eventHandler.ts
@@ -61,7 +61,6 @@ export function initAgentEventListener(): () => void {
         break
       case 'rate_limit_event': {
         const info = ev.rate_limit_info as Record<string, unknown> | undefined
-        console.log('[RateLimit] event received:', info)
         if (!info) break
         // The SDK only populates `utilization` when usage is meaningful (typically >= ~25%).
         // When absent, store status only so the UI can show a green "all clear" dot.

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -5,6 +5,7 @@
 @import './tabs.css';
 @import './sidebar.css';
 @import './branch-bar.css';
+@import './rate-limit-bars.css';
 @import './chat-messages.css';
 @import './tool-calls.css';
 @import './chat-input.css';

--- a/src/renderer/styles/rate-limit-bars.css
+++ b/src/renderer/styles/rate-limit-bars.css
@@ -1,0 +1,80 @@
+/* ============= Rate Limit Bars ============= */
+.rate-limit-bars {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  padding: var(--space-2) var(--space-8);
+  flex-shrink: 0;
+  border-radius: var(--radius);
+  background: var(--bg-tertiary);
+  cursor: default;
+}
+
+.rate-limit-title {
+  font-size: var(--text-2xs);
+  color: var(--text-tertiary);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.rate-limit-tracks {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-width: 70px;
+}
+
+.rate-limit-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.rate-limit-label {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  font-weight: var(--weight-medium);
+  white-space: nowrap;
+  min-width: 16px;
+  text-align: right;
+  user-select: none;
+}
+
+.rate-limit-track {
+  flex: 1;
+  height: 4px;
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  min-width: 40px;
+}
+
+.rate-limit-fill {
+  height: 100%;
+  border-radius: var(--radius-pill);
+  transition: width var(--duration-normal) var(--ease-out),
+              background var(--duration-normal);
+}
+
+/* Low-usage state: thin sliver to indicate "active but below threshold" */
+.rate-limit-fill--low {
+  width: 15%;
+  opacity: 0.6;
+}
+
+.rate-limit-percent {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  font-weight: var(--weight-normal);
+  min-width: 20px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  user-select: none;
+}
+
+.rate-limit-percent--ok {
+  color: var(--green);
+  font-weight: var(--weight-medium);
+}

--- a/src/renderer/styles/rate-limit-bars.css
+++ b/src/renderer/styles/rate-limit-bars.css
@@ -2,16 +2,16 @@
 .rate-limit-bars {
   display: flex;
   align-items: center;
-  gap: var(--space-6);
-  padding: var(--space-2) var(--space-8);
+  gap: var(--space-8);
+  padding: var(--space-4) var(--space-12);
   flex-shrink: 0;
-  border-radius: var(--radius);
+  border-radius: var(--radius-lg);
   background: var(--bg-tertiary);
   cursor: default;
 }
 
 .rate-limit-title {
-  font-size: var(--text-2xs);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
   font-weight: var(--weight-semibold);
   text-transform: uppercase;
@@ -23,32 +23,32 @@
 .rate-limit-tracks {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
-  min-width: 70px;
+  gap: var(--space-4);
+  min-width: 90px;
 }
 
 .rate-limit-row {
   display: flex;
   align-items: center;
-  gap: var(--space-4);
+  gap: var(--space-6);
 }
 
 .rate-limit-label {
-  font-size: var(--text-2xs);
+  font-size: var(--text-xs);
   color: var(--text-muted);
   font-weight: var(--weight-medium);
   white-space: nowrap;
-  min-width: 16px;
+  min-width: 18px;
   text-align: right;
   user-select: none;
 }
 
 .rate-limit-track {
   flex: 1;
-  height: 4px;
+  height: 6px;
   border-radius: var(--radius-pill);
   overflow: hidden;
-  min-width: 40px;
+  min-width: 56px;
 }
 
 .rate-limit-fill {
@@ -65,10 +65,10 @@
 }
 
 .rate-limit-percent {
-  font-size: var(--text-2xs);
+  font-size: var(--text-xs);
   color: var(--text-muted);
   font-weight: var(--weight-normal);
-  min-width: 20px;
+  min-width: 24px;
   text-align: right;
   font-variant-numeric: tabular-nums;
   user-select: none;

--- a/src/renderer/types/session.ts
+++ b/src/renderer/types/session.ts
@@ -93,8 +93,6 @@ export interface AgentSession {
    * Cleared after the IPC send succeeds. Preserved on failure so a retry can reuse it.
    */
   pendingResumeAt?: string
-  /** Rate limit utilization from SDK rate_limit_event, keyed by rateLimitType */
-  rateLimits?: Record<string, RateLimitInfo>
 }
 
 export type ContentBlock =

--- a/src/renderer/types/session.ts
+++ b/src/renderer/types/session.ts
@@ -93,6 +93,8 @@ export interface AgentSession {
    * Cleared after the IPC send succeeds. Preserved on failure so a retry can reuse it.
    */
   pendingResumeAt?: string
+  /** Rate limit utilization from SDK rate_limit_event, keyed by rateLimitType */
+  rateLimits?: Record<string, RateLimitInfo>
 }
 
 export type ContentBlock =
@@ -105,6 +107,21 @@ export interface TurnUsage {
   outputTokens: number
   cacheReadTokens: number
   cacheWriteTokens: number
+}
+
+export interface RateLimitInfo {
+  /** The rate limit type (five_hour, seven_day, seven_day_opus, etc.) */
+  rateLimitType: string
+  /** Utilization 0.0 to 1.0, null when usage is below reporting threshold */
+  utilization: number | null
+  /** Status: allowed, allowed_warning, rejected */
+  status: 'allowed' | 'allowed_warning' | 'rejected'
+  /** Unix timestamp when limit resets */
+  resetsAt?: number
+  /** Whether overage billing is active */
+  isUsingOverage?: boolean
+  /** Last updated timestamp */
+  updatedAt: number
 }
 
 export interface Message {


### PR DESCRIPTION
## Summary

- Add rate limit usage bars (5-hour and 7-day windows) to the chat footer, showing real-time utilization from SDK `rate_limit_event` data
- Persist rate limit data to localStorage with TTL matching each window so bars survive session restarts
- Update CLAUDE.md to reflect Chinese (zh) locale additions from prior PR

## Layers touched

- [ ] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Center panel:**
- New `RateLimitBars` component renders color-coded utilization bars (green/amber/red) with percentage labels
- Integrated into `ChatView` footer beside `BranchBar`

**Stores** (`sessions/eventHandler.ts`):
- Handle `rate_limit_event` from the SDK, parse utilization/status fields, and merge into session state via `updateSession`

**Lib:**
- `rateLimitCache.ts` - TTL-aware localStorage persistence (5h TTL for five_hour, 7d TTL for seven_day windows)
- `storageKeys.ts` - new `rateLimits` key

**Types:**
- `RateLimitInfo` interface on `AgentSession.rateLimits`

**Styles:**
- `rate-limit-bars.css` - compact bar layout using design tokens

**i18n:**
- Translations added in all four locales (en, ja, id, zh)

## How to test

1. `yarn dev`
2. Start a Claude session and use it enough to trigger rate limit events from the SDK
3. Observe the "Limit" bars appearing in the chat footer below the input
4. Bars should show 5h and 7d windows with green/amber/red coloring based on utilization
5. Refresh the app - bars should hydrate from localStorage cache

## Checklist

- [x] Self-reviewed the diff
- [ ] Tested locally with `yarn dev`
- [ ] Types pass — `yarn typecheck`
- [ ] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store