### PR TITLE
feat(settings): add GitHub integration settings panel

### DIFF
--- a/src/renderer/components/Settings/SettingsGitHub.tsx
+++ b/src/renderer/components/Settings/SettingsGitHub.tsx
@@ -1,6 +1,7 @@
 import { useReducer, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { shell } from '@/lib/ipc'
+import { flash } from '@/store/flash'
 import { Button } from '@/components/ui/Button'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { GhAuthDialog } from '@/components/shared/GhAuthDialog'
@@ -89,10 +90,11 @@ export function SettingsGitHub() {
 
   // Check auth status once gh is confirmed installed
   useEffect(() => {
-    if (state.ghStatus !== 'installed') {
+    if (state.ghStatus === 'not_installed') {
       dispatch({ type: 'setAuth', status: 'not_authenticated' })
       return
     }
+    if (state.ghStatus !== 'installed') return
     let cancelled = false
     dispatch({ type: 'setAuth', status: 'checking' })
     shell
@@ -104,7 +106,12 @@ export function SettingsGitHub() {
 
   const handleInstall = useCallback(async () => {
     dispatch({ type: 'setGh', status: 'installing' })
-    try { await shell.installTool('gh') } catch { /* recheck below */ }
+    try {
+      await shell.installTool('gh')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error'
+      flash('error', `Failed to install gh: ${msg}`, 5000)
+    }
     if (!mountedRef.current) return
     dispatch({ type: 'setGh', status: 'checking' })
     try {

--- a/src/renderer/components/Settings/SettingsGitHub.tsx
+++ b/src/renderer/components/Settings/SettingsGitHub.tsx
@@ -1,0 +1,172 @@
+import { useReducer, useEffect, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { shell, github } from '@/lib/ipc'
+import { Button } from '@/components/ui/Button'
+import { StatusDot } from '@/components/ui/StatusDot'
+import { GhAuthDialog } from '@/components/shared/GhAuthDialog'
+import { IconExternalLink } from '@/components/shared/icons'
+
+type ToolStatus = 'checking' | 'installed' | 'not_installed' | 'installing'
+type AuthStatus = 'checking' | 'authenticated' | 'not_authenticated'
+
+const GH_DOCS_URL = 'https://cli.github.com'
+
+interface State {
+  ghStatus: ToolStatus
+  authStatus: AuthStatus
+  showAuthDialog: boolean
+}
+
+type Action =
+  | { type: 'setGh'; status: ToolStatus }
+  | { type: 'setAuth'; status: AuthStatus }
+  | { type: 'showAuth'; show: boolean }
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'setGh': return { ...state, ghStatus: action.status }
+    case 'setAuth': return { ...state, authStatus: action.status }
+    case 'showAuth': return { ...state, showAuthDialog: action.show }
+  }
+}
+
+export function SettingsGitHub() {
+  const { t } = useTranslation('settings')
+
+  const [state, dispatch] = useReducer(reducer, {
+    ghStatus: 'checking',
+    authStatus: 'checking',
+    showAuthDialog: false,
+  })
+
+  // Check if gh CLI is installed
+  useEffect(() => {
+    shell
+      .checkTool('gh')
+      .then((ok: boolean) => dispatch({ type: 'setGh', status: ok ? 'installed' : 'not_installed' }))
+      .catch(() => dispatch({ type: 'setGh', status: 'not_installed' }))
+  }, [])
+
+  // Check auth status once gh is confirmed installed
+  useEffect(() => {
+    if (state.ghStatus !== 'installed') {
+      dispatch({ type: 'setAuth', status: 'not_authenticated' })
+      return
+    }
+    dispatch({ type: 'setAuth', status: 'checking' })
+    shell
+      .checkGhAuth()
+      .then((ok: boolean) => dispatch({ type: 'setAuth', status: ok ? 'authenticated' : 'not_authenticated' }))
+      .catch(() => dispatch({ type: 'setAuth', status: 'not_authenticated' }))
+  }, [state.ghStatus])
+
+  const handleInstall = useCallback(async () => {
+    dispatch({ type: 'setGh', status: 'installing' })
+    try { await shell.installTool('gh') } catch { /* recheck below */ }
+    dispatch({ type: 'setGh', status: 'checking' })
+    try {
+      const ok = await shell.checkTool('gh')
+      dispatch({ type: 'setGh', status: ok ? 'installed' : 'not_installed' })
+    } catch {
+      dispatch({ type: 'setGh', status: 'not_installed' })
+    }
+  }, [])
+
+  const handleAuthSuccess = useCallback(() => {
+    dispatch({ type: 'setAuth', status: 'authenticated' })
+  }, [])
+
+  const recheckAuth = useCallback(async () => {
+    dispatch({ type: 'setAuth', status: 'checking' })
+    try {
+      const ok = await shell.checkGhAuth()
+      dispatch({ type: 'setAuth', status: ok ? 'authenticated' : 'not_authenticated' })
+    } catch {
+      dispatch({ type: 'setAuth', status: 'not_authenticated' })
+    }
+  }, [])
+
+  const ghDot =
+    state.ghStatus === 'installed' ? 'success' as const
+      : state.ghStatus === 'not_installed' ? 'failure' as const
+      : 'pending' as const
+
+  const authDot =
+    state.authStatus === 'authenticated' ? 'success' as const
+      : state.authStatus === 'not_authenticated' ? 'failure' as const
+      : 'pending' as const
+
+  return (
+    <div className="settings-section">
+      <span className="settings-hint">{t('github.description')}</span>
+
+      <div className="settings-divider" />
+
+      {/* ── GitHub CLI installation ───────────────────────────────────── */}
+      <h4 className="settings-section-subtitle">{t('github.cliHeader')}</h4>
+      <div className="settings-field settings-field--row">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-8)' }}>
+          <StatusDot state={ghDot} />
+          <span className="settings-label">
+            {state.ghStatus === 'checking' && t('github.statusChecking')}
+            {state.ghStatus === 'installed' && t('github.statusInstalled')}
+            {state.ghStatus === 'not_installed' && t('github.statusNotInstalled')}
+            {state.ghStatus === 'installing' && t('github.statusInstalling')}
+          </span>
+        </div>
+        {state.ghStatus === 'not_installed' && (
+          <div style={{ display: 'flex', gap: 'var(--space-8)' }}>
+            <Button size="sm" variant="primary" onClick={handleInstall}>
+              {t('github.install')}
+            </Button>
+            <Button size="sm" onClick={() => shell.openExternal(GH_DOCS_URL)}>
+              {t('github.docs')} <IconExternalLink size={10} />
+            </Button>
+          </div>
+        )}
+        {state.ghStatus === 'installing' && (
+          <Button size="sm" variant="primary" disabled loading>
+            {t('github.installing')}
+          </Button>
+        )}
+      </div>
+      {state.ghStatus === 'not_installed' && (
+        <span className="settings-hint">{t('github.installHint')}</span>
+      )}
+
+      <div className="settings-divider" />
+
+      {/* ── Authentication ────────────────────────────────────────────── */}
+      <h4 className="settings-section-subtitle">{t('github.authHeader')}</h4>
+      <div className="settings-field settings-field--row">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-8)' }}>
+          <StatusDot state={authDot} />
+          <span className="settings-label">
+            {state.authStatus === 'checking' && t('github.authChecking')}
+            {state.authStatus === 'authenticated' && t('github.authAuthenticated')}
+            {state.authStatus === 'not_authenticated' && t('github.authNotAuthenticated')}
+          </span>
+        </div>
+        {state.ghStatus === 'installed' && state.authStatus === 'not_authenticated' && (
+          <Button size="sm" variant="primary" onClick={() => dispatch({ type: 'showAuth', show: true })}>
+            {t('github.signIn')}
+          </Button>
+        )}
+        {state.ghStatus === 'installed' && state.authStatus === 'authenticated' && (
+          <Button size="sm" onClick={recheckAuth}>
+            {t('github.recheck')}
+          </Button>
+        )}
+      </div>
+      {state.ghStatus === 'installed' && state.authStatus === 'not_authenticated' && (
+        <span className="settings-hint">{t('github.signInHint')}</span>
+      )}
+
+      <GhAuthDialog
+        isOpen={state.showAuthDialog}
+        onClose={() => dispatch({ type: 'showAuth', show: false })}
+        onSuccess={handleAuthSuccess}
+      />
+    </div>
+  )
+}

--- a/src/renderer/components/Settings/SettingsGitHub.tsx
+++ b/src/renderer/components/Settings/SettingsGitHub.tsx
@@ -1,15 +1,34 @@
-import { useReducer, useEffect, useCallback } from 'react'
+import { useReducer, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { shell, github } from '@/lib/ipc'
+import { shell } from '@/lib/ipc'
 import { Button } from '@/components/ui/Button'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { GhAuthDialog } from '@/components/shared/GhAuthDialog'
 import { IconExternalLink } from '@/components/shared/icons'
 
+// ── Types ──────────────────────────────────────────────────────────────────────
+
 type ToolStatus = 'checking' | 'installed' | 'not_installed' | 'installing'
 type AuthStatus = 'checking' | 'authenticated' | 'not_authenticated'
 
 const GH_DOCS_URL = 'https://cli.github.com'
+
+// ── Status label maps ──────────────────────────────────────────────────────────
+
+const GH_STATUS_KEY: Record<ToolStatus, string> = {
+  checking: 'github.statusChecking',
+  installed: 'github.statusInstalled',
+  not_installed: 'github.statusNotInstalled',
+  installing: 'github.statusInstalling',
+}
+
+const AUTH_STATUS_KEY: Record<AuthStatus, string> = {
+  checking: 'github.authChecking',
+  authenticated: 'github.authAuthenticated',
+  not_authenticated: 'github.authNotAuthenticated',
+}
+
+// ── Reducer ────────────────────────────────────────────────────────────────────
 
 interface State {
   ghStatus: ToolStatus
@@ -27,11 +46,30 @@ function reducer(state: State, action: Action): State {
     case 'setGh': return { ...state, ghStatus: action.status }
     case 'setAuth': return { ...state, authStatus: action.status }
     case 'showAuth': return { ...state, showAuthDialog: action.show }
+    default: return state
   }
 }
 
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function toStatusDot(status: ToolStatus): 'success' | 'failure' | 'pending' {
+  if (status === 'installed') return 'success'
+  if (status === 'not_installed') return 'failure'
+  return 'pending'
+}
+
+function toAuthDot(status: AuthStatus): 'success' | 'failure' | 'pending' {
+  if (status === 'authenticated') return 'success'
+  if (status === 'not_authenticated') return 'failure'
+  return 'pending'
+}
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
 export function SettingsGitHub() {
   const { t } = useTranslation('settings')
+  const mountedRef = useRef(true)
+  useEffect(() => () => { mountedRef.current = false }, [])
 
   const [state, dispatch] = useReducer(reducer, {
     ghStatus: 'checking',
@@ -41,10 +79,12 @@ export function SettingsGitHub() {
 
   // Check if gh CLI is installed
   useEffect(() => {
+    let cancelled = false
     shell
       .checkTool('gh')
-      .then((ok: boolean) => dispatch({ type: 'setGh', status: ok ? 'installed' : 'not_installed' }))
-      .catch(() => dispatch({ type: 'setGh', status: 'not_installed' }))
+      .then((ok: boolean) => { if (!cancelled) dispatch({ type: 'setGh', status: ok ? 'installed' : 'not_installed' }) })
+      .catch(() => { if (!cancelled) dispatch({ type: 'setGh', status: 'not_installed' }) })
+    return () => { cancelled = true }
   }, [])
 
   // Check auth status once gh is confirmed installed
@@ -53,22 +93,25 @@ export function SettingsGitHub() {
       dispatch({ type: 'setAuth', status: 'not_authenticated' })
       return
     }
+    let cancelled = false
     dispatch({ type: 'setAuth', status: 'checking' })
     shell
       .checkGhAuth()
-      .then((ok: boolean) => dispatch({ type: 'setAuth', status: ok ? 'authenticated' : 'not_authenticated' }))
-      .catch(() => dispatch({ type: 'setAuth', status: 'not_authenticated' }))
+      .then((ok: boolean) => { if (!cancelled) dispatch({ type: 'setAuth', status: ok ? 'authenticated' : 'not_authenticated' }) })
+      .catch(() => { if (!cancelled) dispatch({ type: 'setAuth', status: 'not_authenticated' }) })
+    return () => { cancelled = true }
   }, [state.ghStatus])
 
   const handleInstall = useCallback(async () => {
     dispatch({ type: 'setGh', status: 'installing' })
     try { await shell.installTool('gh') } catch { /* recheck below */ }
+    if (!mountedRef.current) return
     dispatch({ type: 'setGh', status: 'checking' })
     try {
       const ok = await shell.checkTool('gh')
-      dispatch({ type: 'setGh', status: ok ? 'installed' : 'not_installed' })
+      if (mountedRef.current) dispatch({ type: 'setGh', status: ok ? 'installed' : 'not_installed' })
     } catch {
-      dispatch({ type: 'setGh', status: 'not_installed' })
+      if (mountedRef.current) dispatch({ type: 'setGh', status: 'not_installed' })
     }
   }, [])
 
@@ -80,21 +123,15 @@ export function SettingsGitHub() {
     dispatch({ type: 'setAuth', status: 'checking' })
     try {
       const ok = await shell.checkGhAuth()
-      dispatch({ type: 'setAuth', status: ok ? 'authenticated' : 'not_authenticated' })
+      if (mountedRef.current) dispatch({ type: 'setAuth', status: ok ? 'authenticated' : 'not_authenticated' })
     } catch {
-      dispatch({ type: 'setAuth', status: 'not_authenticated' })
+      if (mountedRef.current) dispatch({ type: 'setAuth', status: 'not_authenticated' })
     }
   }, [])
 
-  const ghDot =
-    state.ghStatus === 'installed' ? 'success' as const
-      : state.ghStatus === 'not_installed' ? 'failure' as const
-      : 'pending' as const
-
-  const authDot =
-    state.authStatus === 'authenticated' ? 'success' as const
-      : state.authStatus === 'not_authenticated' ? 'failure' as const
-      : 'pending' as const
+  const openDocs = useCallback(() => shell.openExternal(GH_DOCS_URL), [])
+  const openAuthDialog = useCallback(() => dispatch({ type: 'showAuth', show: true }), [])
+  const closeAuthDialog = useCallback(() => dispatch({ type: 'showAuth', show: false }), [])
 
   return (
     <div className="settings-section">
@@ -106,20 +143,15 @@ export function SettingsGitHub() {
       <h4 className="settings-section-subtitle">{t('github.cliHeader')}</h4>
       <div className="settings-field settings-field--row">
         <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-8)' }}>
-          <StatusDot state={ghDot} />
-          <span className="settings-label">
-            {state.ghStatus === 'checking' && t('github.statusChecking')}
-            {state.ghStatus === 'installed' && t('github.statusInstalled')}
-            {state.ghStatus === 'not_installed' && t('github.statusNotInstalled')}
-            {state.ghStatus === 'installing' && t('github.statusInstalling')}
-          </span>
+          <StatusDot state={toStatusDot(state.ghStatus)} />
+          <span className="settings-label">{t(GH_STATUS_KEY[state.ghStatus])}</span>
         </div>
         {state.ghStatus === 'not_installed' && (
           <div style={{ display: 'flex', gap: 'var(--space-8)' }}>
             <Button size="sm" variant="primary" onClick={handleInstall}>
               {t('github.install')}
             </Button>
-            <Button size="sm" onClick={() => shell.openExternal(GH_DOCS_URL)}>
+            <Button size="sm" onClick={openDocs}>
               {t('github.docs')} <IconExternalLink size={10} />
             </Button>
           </div>
@@ -140,15 +172,11 @@ export function SettingsGitHub() {
       <h4 className="settings-section-subtitle">{t('github.authHeader')}</h4>
       <div className="settings-field settings-field--row">
         <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-8)' }}>
-          <StatusDot state={authDot} />
-          <span className="settings-label">
-            {state.authStatus === 'checking' && t('github.authChecking')}
-            {state.authStatus === 'authenticated' && t('github.authAuthenticated')}
-            {state.authStatus === 'not_authenticated' && t('github.authNotAuthenticated')}
-          </span>
+          <StatusDot state={toAuthDot(state.authStatus)} />
+          <span className="settings-label">{t(AUTH_STATUS_KEY[state.authStatus])}</span>
         </div>
         {state.ghStatus === 'installed' && state.authStatus === 'not_authenticated' && (
-          <Button size="sm" variant="primary" onClick={() => dispatch({ type: 'showAuth', show: true })}>
+          <Button size="sm" variant="primary" onClick={openAuthDialog}>
             {t('github.signIn')}
           </Button>
         )}
@@ -164,7 +192,7 @@ export function SettingsGitHub() {
 
       <GhAuthDialog
         isOpen={state.showAuthDialog}
-        onClose={() => dispatch({ type: 'showAuth', show: false })}
+        onClose={closeAuthDialog}
         onSuccess={handleAuthSuccess}
       />
     </div>

--- a/src/renderer/components/Settings/SettingsNav.tsx
+++ b/src/renderer/components/Settings/SettingsNav.tsx
@@ -21,7 +21,7 @@ const NAV_GROUPS = [
   { header: 'general', items: ['general', 'editor', 'analytics', 'about'] },
   { header: 'claudeAgent', items: ['ai', 'claudePermissions', 'claudeHooks', 'claudeInstructions', 'claudePlugins', 'claudeMcp', 'claudeSkills'] },
   { header: 'appearance', items: ['appearance'] },
-  { header: 'integrations', items: ['apps', 'git', 'jira', 'notifications'] },
+  { header: 'integrations', items: ['apps', 'git', 'github', 'jira', 'notifications'] },
   { header: 'experimental', items: ['experimental'] },
 ]
 

--- a/src/renderer/components/Settings/SettingsOverlay.tsx
+++ b/src/renderer/components/Settings/SettingsOverlay.tsx
@@ -19,6 +19,7 @@ import { SettingsClaudePlugins } from './SettingsClaudePlugins'
 import { SettingsClaudeMcp } from './SettingsClaudeMcp'
 import { SettingsClaudeSkills } from './SettingsClaudeSkills'
 import { SettingsApps } from './SettingsApps'
+import { SettingsGitHub } from './SettingsGitHub'
 import { SettingsJira } from './SettingsJira'
 import { SettingsAnalytics } from './SettingsAnalytics'
 import { SettingsAbout } from './SettingsAbout'
@@ -49,6 +50,7 @@ const sectionMap: Record<string, React.ReactNode> = {
   claudeMcp: <SettingsClaudeMcp />,
   claudeSkills: <SettingsClaudeSkills />,
   apps: <SettingsApps />,
+  github: <SettingsGitHub />,
   jira: <SettingsJira />,
   analytics: <SettingsAnalytics />,
   about: <SettingsAbout />,

--- a/src/renderer/locales/en/settings.json
+++ b/src/renderer/locales/en/settings.json
@@ -15,6 +15,7 @@
     "claudeMcp": "MCP Servers",
     "claudeSkills": "Skills",
     "apps": "Apps",
+    "github": "GitHub",
     "jira": "Jira",
     "analytics": "Analytics",
     "about": "About",
@@ -328,6 +329,25 @@
     "invalidUrl": "URL must start with http:// or https://",
     "nameRequired": "Name is required",
     "workspaceRequired": "Workspace name is required"
+  },
+  "github": {
+    "description": "Connect to GitHub via the GitHub CLI (gh). Powers PR status, CI checks, deployments, and merge actions.",
+    "cliHeader": "GitHub CLI",
+    "statusChecking": "Checking...",
+    "statusInstalled": "Installed",
+    "statusNotInstalled": "Not installed",
+    "statusInstalling": "Installing...",
+    "install": "Install",
+    "installHint": "Installs via Homebrew (brew install gh). Homebrew must be installed first.",
+    "installing": "Installing...",
+    "docs": "Docs",
+    "authHeader": "Authentication",
+    "authChecking": "Checking...",
+    "authAuthenticated": "Authenticated",
+    "authNotAuthenticated": "Not authenticated",
+    "signIn": "Sign in",
+    "signInHint": "Authenticate using GitHub's Device Flow. Opens your browser to authorize Braid.",
+    "recheck": "Re-check"
   },
   "jira": {
     "description": "Connect to Jira via the Atlassian CLI (acli). Shows linked issues from branch names and enables ticket lookup when creating worktrees.",

--- a/src/renderer/locales/id/settings.json
+++ b/src/renderer/locales/id/settings.json
@@ -15,6 +15,7 @@
     "claudeMcp": "Server MCP",
     "claudeSkills": "Keahlian",
     "apps": "Aplikasi",
+    "github": "GitHub",
     "jira": "Jira",
     "analytics": "Analitik",
     "about": "Tentang",
@@ -328,6 +329,25 @@
     "invalidUrl": "URL harus diawali dengan http:// atau https://",
     "nameRequired": "Nama diperlukan",
     "workspaceRequired": "Nama workspace diperlukan"
+  },
+  "github": {
+    "description": "Hubungkan ke GitHub melalui GitHub CLI (gh). Mendukung status PR, CI check, deployment, dan aksi merge.",
+    "cliHeader": "GitHub CLI",
+    "statusChecking": "Memeriksa...",
+    "statusInstalled": "Terinstal",
+    "statusNotInstalled": "Belum terinstal",
+    "statusInstalling": "Menginstal...",
+    "install": "Instal",
+    "installHint": "Diinstal melalui Homebrew (brew install gh). Homebrew harus sudah terinstal terlebih dahulu.",
+    "installing": "Menginstal...",
+    "docs": "Dokumentasi",
+    "authHeader": "Autentikasi",
+    "authChecking": "Memeriksa...",
+    "authAuthenticated": "Terautentikasi",
+    "authNotAuthenticated": "Belum terautentikasi",
+    "signIn": "Masuk",
+    "signInHint": "Autentikasi menggunakan Device Flow GitHub. Membuka browser untuk mengotorisasi Braid.",
+    "recheck": "Periksa ulang"
   },
   "jira": {
     "description": "Hubungkan ke Jira melalui Atlassian CLI (acli). Menampilkan tiket terkait dari nama branch dan memungkinkan pencarian tiket saat membuat worktree.",

--- a/src/renderer/locales/ja/settings.json
+++ b/src/renderer/locales/ja/settings.json
@@ -15,6 +15,7 @@
     "claudeMcp": "MCPサーバー",
     "claudeSkills": "スキル",
     "apps": "アプリ",
+    "github": "GitHub",
     "jira": "Jira",
     "analytics": "アナリティクス",
     "about": "このアプリについて",
@@ -328,6 +329,25 @@
     "invalidUrl": "URLは http:// または https:// で始まる必要があります",
     "nameRequired": "名前は必須です",
     "workspaceRequired": "ワークスペース名は必須です"
+  },
+  "github": {
+    "description": "GitHub CLI (gh) を使用して GitHub に接続します。PRステータス、CIチェック、デプロイメント、マージ操作に使用されます。",
+    "cliHeader": "GitHub CLI",
+    "statusChecking": "確認中...",
+    "statusInstalled": "インストール済み",
+    "statusNotInstalled": "未インストール",
+    "statusInstalling": "インストール中...",
+    "install": "インストール",
+    "installHint": "Homebrew経由でインストールされます（brew install gh）。Homebrewが事前にインストールされている必要があります。",
+    "installing": "インストール中...",
+    "docs": "ドキュメント",
+    "authHeader": "認証",
+    "authChecking": "確認中...",
+    "authAuthenticated": "認証済み",
+    "authNotAuthenticated": "未認証",
+    "signIn": "サインイン",
+    "signInHint": "GitHubのDevice Flowを使用して認証します。ブラウザが開き、Braidを承認します。",
+    "recheck": "再確認"
   },
   "jira": {
     "description": "Atlassian CLI (acli) を使用して Jira に接続します。ブランチ名から関連チケットを表示し、ワークツリー作成時にチケット検索を有効にします。",

--- a/src/renderer/locales/zh/settings.json
+++ b/src/renderer/locales/zh/settings.json
@@ -15,6 +15,7 @@
     "claudeMcp": "MCP 服务器",
     "claudeSkills": "技能",
     "apps": "应用",
+    "github": "GitHub",
     "jira": "Jira",
     "analytics": "分析",
     "about": "关于",
@@ -328,6 +329,25 @@
     "invalidUrl": "URL 必须以 http:// 或 https:// 开头",
     "nameRequired": "名称为必填项",
     "workspaceRequired": "工作区名称为必填项"
+  },
+  "github": {
+    "description": "通过 GitHub CLI (gh) 连接 GitHub。支持 PR 状态、CI 检查、部署和合并操作。",
+    "cliHeader": "GitHub CLI",
+    "statusChecking": "检查中...",
+    "statusInstalled": "已安装",
+    "statusNotInstalled": "未安装",
+    "statusInstalling": "安装中...",
+    "install": "安装",
+    "installHint": "通过 Homebrew 安装（brew install gh）。需要先安装 Homebrew。",
+    "installing": "安装中...",
+    "docs": "文档",
+    "authHeader": "认证",
+    "authChecking": "检查中...",
+    "authAuthenticated": "已认证",
+    "authNotAuthenticated": "未认证",
+    "signIn": "登录",
+    "signInHint": "使用 GitHub 的 Device Flow 认证。将打开浏览器授权 Braid。",
+    "recheck": "重新检查"
   },
   "jira": {
     "description": "通过 Atlassian CLI (acli) 连接 Jira。从分支名显示关联工单，并在创建 worktree 时启用工单查找。",


### PR DESCRIPTION
## Summary

- Add a new GitHub settings page under Integrations that shows gh CLI installation status and authentication status
- Supports one-click install (via Homebrew) and sign-in (via Device Flow auth dialog)
- Full i18n support across all four locales (en, ja, id, zh)

## Layers touched

- [x] **Renderer** (`src/renderer/`) - components, stores, lib

## Changes

**Sidebar / Center / Right panel:**
- N/A

**Stores** (`projects.ts` / `sessions.ts` / `ui.ts`):
- N/A

**Services** (`git.ts` / `claude.ts` / `github.ts` / `pty.ts`):
- N/A

**Settings:**
- `SettingsGitHub.tsx` - new settings page with gh CLI status checking, install action, auth status checking, and sign-in via `GhAuthDialog`
- `SettingsNav.tsx` - added `github` to the integrations nav group
- `SettingsOverlay.tsx` - registered `SettingsGitHub` in the section map
- `locales/{en,ja,id,zh}/settings.json` - added `github.*` translation keys

## How to test

1. `yarn dev`
2. Open Settings (Cmd+,)
3. Navigate to Integrations > GitHub
4. Verify gh CLI status is detected correctly (installed/not installed)
5. If gh is installed, verify auth status is detected correctly
6. Test the "Re-check" button if already authenticated
7. Test the "Sign in" button if not authenticated - should open the GhAuthDialog

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass - `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store