### PR TITLE
feat(agentUtils): add plugin enablement filtering via settings

### DIFF
--- a/src/main/services/__tests__/agentUtils.test.ts
+++ b/src/main/services/__tests__/agentUtils.test.ts
@@ -18,11 +18,17 @@ function installFsMock(files: FsFiles, dirs: FsDirs = new Set()): void {
       const key = String(p)
       return key in files || dirs.has(key)
     }
+    const statSync = (p: string | Buffer | URL): { mtimeMs: number } => {
+      const key = String(p)
+      if (key in files) return { mtimeMs: Date.now() }
+      throw Object.assign(new Error(`ENOENT: ${key}`), { code: 'ENOENT' })
+    }
     return {
       ...actual,
-      default: { ...actual, readFileSync, existsSync },
+      default: { ...actual, readFileSync, existsSync, statSync },
       readFileSync,
-      existsSync
+      existsSync,
+      statSync
     }
   })
   vi.doMock('os', async () => {
@@ -138,6 +144,16 @@ describe('loadPlugins', () => {
     installFsMock({
       [installedPluginsPath]: installedPlugins,
       [settingsPath]: '{ not json'
+    })
+    const { loadPlugins } = await import('../agentUtils')
+    const result = loadPlugins('/tmp/cwd')
+    expect(result).toHaveLength(3)
+  })
+
+  it('handles settings.json containing literal null without throwing', async () => {
+    installFsMock({
+      [installedPluginsPath]: installedPlugins,
+      [settingsPath]: 'null'
     })
     const { loadPlugins } = await import('../agentUtils')
     const result = loadPlugins('/tmp/cwd')

--- a/src/main/services/__tests__/agentUtils.test.ts
+++ b/src/main/services/__tests__/agentUtils.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Build per-test fs + os mocks. The module under test caches
+// installed_plugins.json at import time in a module-scoped IIFE,
+// so each scenario resets modules and re-imports.
+type FsFiles = Record<string, string>
+type FsDirs = Set<string>
+
+function installFsMock(files: FsFiles, dirs: FsDirs = new Set()): void {
+  vi.doMock('fs', async () => {
+    const actual = await vi.importActual<typeof import('fs')>('fs')
+    const readFileSync = (p: string | Buffer | URL, _enc?: unknown): string => {
+      const key = String(p)
+      if (key in files) return files[key]
+      throw Object.assign(new Error(`ENOENT: ${key}`), { code: 'ENOENT' })
+    }
+    const existsSync = (p: string | Buffer | URL): boolean => {
+      const key = String(p)
+      return key in files || dirs.has(key)
+    }
+    return {
+      ...actual,
+      default: { ...actual, readFileSync, existsSync },
+      readFileSync,
+      existsSync
+    }
+  })
+  vi.doMock('os', async () => {
+    const actual = await vi.importActual<typeof import('os')>('os')
+    return { ...actual, default: { ...actual, homedir: () => '/tmp/home' }, homedir: () => '/tmp/home' }
+  })
+}
+
+const installedPluginsPath = '/tmp/home/.claude/plugins/installed_plugins.json'
+const settingsPath = '/tmp/home/.claude/settings.json'
+
+const installedPlugins = JSON.stringify({
+  version: 2,
+  plugins: {
+    'superpowers@claude-plugins-official': [
+      { scope: 'user', installPath: '/plugins/superpowers', version: '5.0.7' }
+    ],
+    'swift-lsp@claude-plugins-official': [
+      { scope: 'user', installPath: '/plugins/swift-lsp', version: '1.0.0' }
+    ],
+    'extended@other-marketplace': [
+      { scope: 'user', installPath: '/plugins/extended', version: '4.3.3' }
+    ]
+  }
+})
+
+describe('loadPlugins', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.doUnmock('fs')
+    vi.doUnmock('os')
+  })
+
+  it('includes all installed user plugins when settings.json is missing', async () => {
+    installFsMock({ [installedPluginsPath]: installedPlugins })
+    const { loadPlugins } = await import('../agentUtils')
+    const result = loadPlugins('/tmp/cwd')
+    expect(result.map((p) => p.path).sort()).toEqual([
+      '/plugins/extended',
+      '/plugins/superpowers',
+      '/plugins/swift-lsp'
+    ])
+  })
+
+  it('filters out plugins marked false in enabledPlugins', async () => {
+    installFsMock({
+      [installedPluginsPath]: installedPlugins,
+      [settingsPath]: JSON.stringify({
+        enabledPlugins: {
+          'superpowers@claude-plugins-official': false,
+          'extended@other-marketplace': false
+        }
+      })
+    })
+    const { loadPlugins } = await import('../agentUtils')
+    const result = loadPlugins('/tmp/cwd')
+    expect(result.map((p) => p.path)).toEqual(['/plugins/swift-lsp'])
+  })
+
+  it('keeps plugins marked true or absent from enabledPlugins', async () => {
+    installFsMock({
+      [installedPluginsPath]: installedPlugins,
+      [settingsPath]: JSON.stringify({
+        enabledPlugins: {
+          'superpowers@claude-plugins-official': true
+          // swift-lsp and extended absent → default on
+        }
+      })
+    })
+    const { loadPlugins } = await import('../agentUtils')
+    const result = loadPlugins('/tmp/cwd')
+    expect(result.map((p) => p.path).sort()).toEqual([
+      '/plugins/extended',
+      '/plugins/superpowers',
+      '/plugins/swift-lsp'
+    ])
+  })
+
+  it('treats extended form (array of versions) as enabled', async () => {
+    installFsMock({
+      [installedPluginsPath]: installedPlugins,
+      [settingsPath]: JSON.stringify({
+        enabledPlugins: {
+          'superpowers@claude-plugins-official': ['5.0.7']
+        }
+      })
+    })
+    const { loadPlugins } = await import('../agentUtils')
+    const result = loadPlugins('/tmp/cwd')
+    expect(result.map((p) => p.path)).toContain('/plugins/superpowers')
+  })
+
+  it('still appends project-scope plugin when <cwd>/.claude/skills exists', async () => {
+    installFsMock(
+      {
+        [installedPluginsPath]: installedPlugins,
+        [settingsPath]: JSON.stringify({
+          enabledPlugins: { 'superpowers@claude-plugins-official': false }
+        })
+      },
+      new Set(['/tmp/cwd/.claude/skills'])
+    )
+    const { loadPlugins } = await import('../agentUtils')
+    const result = loadPlugins('/tmp/cwd')
+    expect(result.map((p) => p.path).sort()).toEqual([
+      '/plugins/extended',
+      '/plugins/swift-lsp',
+      '/tmp/cwd/.claude'
+    ])
+  })
+
+  it('falls back gracefully when settings.json is malformed JSON', async () => {
+    installFsMock({
+      [installedPluginsPath]: installedPlugins,
+      [settingsPath]: '{ not json'
+    })
+    const { loadPlugins } = await import('../agentUtils')
+    const result = loadPlugins('/tmp/cwd')
+    expect(result).toHaveLength(3)
+  })
+})

--- a/src/main/services/agentUtils.ts
+++ b/src/main/services/agentUtils.ts
@@ -37,24 +37,38 @@ const userPluginsCache: CachedPlugin[] = (() => {
 
 /**
  * Read `enabledPlugins` from ~/.claude/settings.json. A plugin is considered
- * disabled only when its value is explicitly `false` — `true`, an array of
+ * disabled only when its value is explicitly `false` - `true`, an array of
  * version strings, or an absent key all mean "enabled" (matches the Claude
  * Code settings schema).
+ *
+ * Results are cached and only re-read when the file's mtime changes, avoiding
+ * synchronous disk I/O on every loadPlugins() call.
+ *
+ * Note: claudeConfig.ts has a similar readJson helper for the same file.
+ * Both are kept separate because agentUtils must remain Electron-free.
  */
+let _disabledCache: { mtime: number; keys: Set<string> } | null = null
+const _settingsPath = path.join(os.homedir(), '.claude', 'settings.json')
+
 function readDisabledPluginKeys(): Set<string> {
   try {
-    const settingsFile = path.join(os.homedir(), '.claude', 'settings.json')
-    const data = JSON.parse(fs.readFileSync(settingsFile, 'utf-8')) as {
-      enabledPlugins?: Record<string, unknown>
+    const stat = fs.statSync(_settingsPath)
+    const mtime = stat.mtimeMs
+    if (_disabledCache && _disabledCache.mtime === mtime) {
+      return _disabledCache.keys
     }
+    const data = JSON.parse(fs.readFileSync(_settingsPath, 'utf-8')) as Record<string, unknown> | null
     const disabled = new Set<string>()
-    if (data.enabledPlugins) {
-      for (const [k, v] of Object.entries(data.enabledPlugins)) {
+    const enabledPlugins = data?.enabledPlugins
+    if (enabledPlugins && typeof enabledPlugins === 'object' && !Array.isArray(enabledPlugins)) {
+      for (const [k, v] of Object.entries(enabledPlugins as Record<string, unknown>)) {
         if (v === false) disabled.add(k)
       }
     }
+    _disabledCache = { mtime, keys: disabled }
     return disabled
   } catch {
+    _disabledCache = null
     return new Set()
   }
 }

--- a/src/main/services/agentUtils.ts
+++ b/src/main/services/agentUtils.ts
@@ -10,17 +10,25 @@ import path from 'path'
 import fs from 'fs'
 import os from 'os'
 
-/** User-installed plugins — read once and cached for the process lifetime. */
-const userPluginsCache: Array<{ type: 'local'; path: string }> = (() => {
+/**
+ * User-installed plugins — installed_plugins.json is read once at module load
+ * and cached for the process lifetime. Each entry keeps its `plugin@marketplace`
+ * key so `loadPlugins` can filter by the user's `enabledPlugins` setting, which
+ * is re-read on every call (so runtime toggles in the Claude settings UI are
+ * honored without restarting Braid).
+ */
+type CachedPlugin = { type: 'local'; path: string; key: string }
+
+const userPluginsCache: CachedPlugin[] = (() => {
   try {
     const pluginsFile = path.join(os.homedir(), '.claude', 'plugins', 'installed_plugins.json')
     const data = JSON.parse(fs.readFileSync(pluginsFile, 'utf-8')) as {
       plugins: Record<string, Array<{ scope: string; installPath: string }>>
     }
-    return Object.values(data.plugins).flatMap((versions) =>
+    return Object.entries(data.plugins).flatMap(([key, versions]) =>
       versions
         .filter((v) => v.scope === 'user' && v.installPath)
-        .map((v) => ({ type: 'local' as const, path: v.installPath }))
+        .map((v) => ({ type: 'local' as const, path: v.installPath, key }))
     )
   } catch {
     return []
@@ -28,16 +36,47 @@ const userPluginsCache: Array<{ type: 'local'; path: string }> = (() => {
 })()
 
 /**
+ * Read `enabledPlugins` from ~/.claude/settings.json. A plugin is considered
+ * disabled only when its value is explicitly `false` — `true`, an array of
+ * version strings, or an absent key all mean "enabled" (matches the Claude
+ * Code settings schema).
+ */
+function readDisabledPluginKeys(): Set<string> {
+  try {
+    const settingsFile = path.join(os.homedir(), '.claude', 'settings.json')
+    const data = JSON.parse(fs.readFileSync(settingsFile, 'utf-8')) as {
+      enabledPlugins?: Record<string, unknown>
+    }
+    const disabled = new Set<string>()
+    if (data.enabledPlugins) {
+      for (const [k, v] of Object.entries(data.enabledPlugins)) {
+        if (v === false) disabled.add(k)
+      }
+    }
+    return disabled
+  } catch {
+    return new Set()
+  }
+}
+
+/**
  * Returns plugin entries for a session rooted at `cwd`:
- *   • User-scope — ~/.claude/plugins/installed_plugins.json (cached at startup)
+ *   • User-scope — ~/.claude/plugins/installed_plugins.json, minus any keys
+ *     the user has disabled via `enabledPlugins` in ~/.claude/settings.json.
+ *     Without this filter, SessionStart hooks from disabled plugins (e.g.
+ *     superpowers) would keep firing and injecting skill instructions.
  *   • Project-scope — <cwd>/.claude (if it contains a skills/ subdirectory)
  */
 export function loadPlugins(cwd: string): Array<{ type: 'local'; path: string }> {
+  const disabled = readDisabledPluginKeys()
+  const userPlugins = userPluginsCache
+    .filter((p) => !disabled.has(p.key))
+    .map(({ type, path: p }) => ({ type, path: p }))
   const projectPlugin = path.join(cwd, '.claude')
   const projectPlugins = fs.existsSync(path.join(projectPlugin, 'skills'))
     ? [{ type: 'local' as const, path: projectPlugin }]
     : []
-  return [...userPluginsCache, ...projectPlugins]
+  return [...userPlugins, ...projectPlugins]
 }
 
 export const BRAID_SYSTEM_PROMPT = `


### PR DESCRIPTION
## Summary

- Filters user-installed plugins by reading `enabledPlugins` from `~/.claude/settings.json` before passing them to each session
- Plugins explicitly set to `false` in `enabledPlugins` are excluded; `true`, version arrays, or absent keys all keep the plugin enabled
- Without this, disabled plugins (e.g. superpowers) would still fire their `SessionStart` hooks and inject skill instructions

## Layers touched

- [x] **Main process** (`src/main/`) — services, IPC handlers

## Changes

**Services** (`agentUtils.ts`):
- Extended `CachedPlugin` type to carry each plugin's `key` (`plugin@marketplace`) alongside its install path
- Added `readDisabledPluginKeys()` — reads `~/.claude/settings.json` on every `loadPlugins()` call so runtime toggles in the Claude settings UI are honored without restarting Braid
- `loadPlugins()` now filters `userPluginsCache` against the disabled-keys set before appending the project-scope plugin

**Tests** (`__tests__/agentUtils.test.ts`):
- New `loadPlugins` test suite with 6 cases: missing settings, disabled plugins, enabled plugins, extended (array) form, project-scope plugin coexistence, and malformed JSON fallback

## How to test

1. `yarn dev`
2. Install a plugin via Claude Code (e.g. superpowers)
3. Open Settings → Experimental and toggle a plugin off
4. Start a new session — the disabled plugin's `SessionStart` hook should no longer fire (no injected skill instructions in the system prompt)
5. Toggle the plugin back on and verify hooks resume

## Screenshots

N/A — no UI changes

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store