### PR TITLE
feat(rate-limit): support multiple rate limit types with dynamic ordering

### DIFF
--- a/src/renderer/components/Center/RateLimitBars.tsx
+++ b/src/renderer/components/Center/RateLimitBars.tsx
@@ -23,6 +23,22 @@ function getStatusColor(status: string): string {
   return 'var(--green)'
 }
 
+/** Label keys per rate limit type */
+const LABEL_KEY: Record<string, string> = {
+  five_hour: 'rateLimitFiveHour',
+  seven_day: 'rateLimitSevenDay',
+  seven_day_opus: 'rateLimitSevenDayOpus',
+  seven_day_sonnet: 'rateLimitSevenDaySonnet',
+}
+
+/** Display order priority (lower = shown first) */
+const TYPE_ORDER: Record<string, number> = {
+  five_hour: 0,
+  seven_day: 1,
+  seven_day_opus: 2,
+  seven_day_sonnet: 3,
+}
+
 export function RateLimitBars() {
   const { t } = useTranslation('center')
 
@@ -30,28 +46,36 @@ export function RateLimitBars() {
     useShallow((s) => s.limits)
   )
 
-  const { fiveHour, sevenDay } = useMemo(() => {
-    const fiveHour = limits['five_hour'] ?? null
-    const sevenDay = limits['seven_day']
-      ?? limits['seven_day_opus']
-      ?? limits['seven_day_sonnet']
-      ?? null
-    return { fiveHour, sevenDay }
-  }, [limits])
+  const rows = useMemo(() => {
+    const result: { label: string; info: RateLimitInfo }[] = []
 
-  if (!fiveHour && !sevenDay) return null
+    // Collect all known rate limit types that have data
+    for (const [key, info] of Object.entries(limits)) {
+      const labelKey = LABEL_KEY[key]
+      if (!labelKey) continue // skip unknown types
+      result.push({ label: t(labelKey), info })
+    }
+
+    // Sort by display order
+    result.sort((a, b) => {
+      const orderA = TYPE_ORDER[a.info.rateLimitType] ?? 99
+      const orderB = TYPE_ORDER[b.info.rateLimitType] ?? 99
+      return orderA - orderB
+    })
+
+    return result
+  }, [limits, t])
+
+  if (rows.length === 0) return null
 
   return (
     <Tooltip content={t('rateLimitHeader')} position="top">
       <span className="rate-limit-bars">
         <span className="rate-limit-title">{t('rateLimitTitle')}</span>
         <span className="rate-limit-tracks">
-          {fiveHour && (
-            <RateLimitRow label={t('rateLimitFiveHour')} info={fiveHour} t={t} />
-          )}
-          {sevenDay && (
-            <RateLimitRow label={t('rateLimitSevenDay')} info={sevenDay} t={t} />
-          )}
+          {rows.map((row) => (
+            <RateLimitRow key={row.info.rateLimitType} label={row.label} info={row.info} t={t} />
+          ))}
         </span>
       </span>
     </Tooltip>

--- a/src/renderer/components/Center/RateLimitBars.tsx
+++ b/src/renderer/components/Center/RateLimitBars.tsx
@@ -23,21 +23,13 @@ function getStatusColor(status: string): string {
   return 'var(--green)'
 }
 
-/** Label keys per rate limit type */
-const LABEL_KEY: Record<string, string> = {
-  five_hour: 'rateLimitFiveHour',
-  seven_day: 'rateLimitSevenDay',
-  seven_day_opus: 'rateLimitSevenDayOpus',
-  seven_day_sonnet: 'rateLimitSevenDaySonnet',
-}
-
-/** Display order priority (lower = shown first) */
-const TYPE_ORDER: Record<string, number> = {
-  five_hour: 0,
-  seven_day: 1,
-  seven_day_opus: 2,
-  seven_day_sonnet: 3,
-}
+/** Single source of truth: supported types in display order + their i18n label key. */
+const ORDERED_TYPES: { key: string; labelKey: string }[] = [
+  { key: 'five_hour', labelKey: 'rateLimitFiveHour' },
+  { key: 'seven_day', labelKey: 'rateLimitSevenDay' },
+  { key: 'seven_day_opus', labelKey: 'rateLimitSevenDayOpus' },
+  { key: 'seven_day_sonnet', labelKey: 'rateLimitSevenDaySonnet' },
+]
 
 export function RateLimitBars() {
   const { t } = useTranslation('center')
@@ -46,25 +38,19 @@ export function RateLimitBars() {
     useShallow((s) => s.limits)
   )
 
-  const rows = useMemo(() => {
-    const result: { label: string; info: RateLimitInfo }[] = []
-
-    // Collect all known rate limit types that have data
-    for (const [key, info] of Object.entries(limits)) {
-      const labelKey = LABEL_KEY[key]
-      if (!labelKey) continue // skip unknown types
-      result.push({ label: t(labelKey), info })
-    }
-
-    // Sort by display order
-    result.sort((a, b) => {
-      const orderA = TYPE_ORDER[a.info.rateLimitType] ?? 99
-      const orderB = TYPE_ORDER[b.info.rateLimitType] ?? 99
-      return orderA - orderB
-    })
-
-    return result
-  }, [limits, t])
+  // Filter to types present in the store, preserving declared display order.
+  // Uses the store key (not info.rateLimitType) for ordering and React key
+  // to stay consistent even if cached data drifts.
+  const rows = useMemo(() =>
+    ORDERED_TYPES
+      .filter(({ key }) => !!limits[key])
+      .map(({ key, labelKey }) => ({
+        key,
+        label: t(labelKey),
+        info: limits[key],
+      })),
+    [limits, t],
+  )
 
   if (rows.length === 0) return null
 
@@ -74,7 +60,7 @@ export function RateLimitBars() {
         <span className="rate-limit-title">{t('rateLimitTitle')}</span>
         <span className="rate-limit-tracks">
           {rows.map((row) => (
-            <RateLimitRow key={row.info.rateLimitType} label={row.label} info={row.info} t={t} />
+            <RateLimitRow key={row.key} label={row.label} info={row.info} t={t} />
           ))}
         </span>
       </span>

--- a/src/renderer/locales/en/center.json
+++ b/src/renderer/locales/en/center.json
@@ -347,6 +347,8 @@
   "rateLimitHeader": "Claude usage limits for your subscription plan",
   "rateLimitFiveHour": "5h",
   "rateLimitSevenDay": "7d",
+  "rateLimitSevenDayOpus": "7d·Op",
+  "rateLimitSevenDaySonnet": "7d·So",
   "rateLimitTooltip": "{{label}} rolling window: {{percent}}% used",
   "rateLimitStatusOk": "{{label}} rolling window: well within limits",
   "rateLimitOk": "OK",

--- a/src/renderer/locales/id/center.json
+++ b/src/renderer/locales/id/center.json
@@ -329,6 +329,8 @@
   "rateLimitHeader": "Batas penggunaan Claude untuk paket langganan Anda",
   "rateLimitFiveHour": "5j",
   "rateLimitSevenDay": "7h",
+  "rateLimitSevenDayOpus": "7h·Op",
+  "rateLimitSevenDaySonnet": "7h·So",
   "rateLimitTooltip": "Jendela bergulir {{label}}: {{percent}}% digunakan",
   "rateLimitStatusOk": "Jendela bergulir {{label}}: dalam batas",
   "rateLimitOk": "OK",

--- a/src/renderer/locales/ja/center.json
+++ b/src/renderer/locales/ja/center.json
@@ -330,6 +330,8 @@
   "rateLimitHeader": "サブスクリプションのClaude使用制限",
   "rateLimitFiveHour": "5時",
   "rateLimitSevenDay": "7日",
+  "rateLimitSevenDayOpus": "7日·Op",
+  "rateLimitSevenDaySonnet": "7日·So",
   "rateLimitTooltip": "{{label}}ローリング: {{percent}}%使用済み",
   "rateLimitStatusOk": "{{label}}ローリング: 制限内",
   "rateLimitOk": "OK",

--- a/src/renderer/locales/zh/center.json
+++ b/src/renderer/locales/zh/center.json
@@ -347,6 +347,8 @@
   "rateLimitHeader": "您的订阅计划的 Claude 使用限制",
   "rateLimitFiveHour": "5时",
   "rateLimitSevenDay": "7天",
+  "rateLimitSevenDayOpus": "7天·Op",
+  "rateLimitSevenDaySonnet": "7天·So",
   "rateLimitTooltip": "{{label}}滚动窗口: 已使用{{percent}}%",
   "rateLimitStatusOk": "{{label}}滚动窗口: 在限制范围内",
   "rateLimitOk": "正常",

--- a/src/renderer/store/sessions/eventHandler.ts
+++ b/src/renderer/store/sessions/eventHandler.ts
@@ -64,7 +64,8 @@ export function initAgentEventListener(): () => void {
         if (!info) break
         // The SDK only populates `utilization` when usage is meaningful (typically >= ~25%).
         // When absent, store status only so the UI can show a green "all clear" dot.
-        const rateLimitType = (info.rateLimitType as string) ?? 'unknown'
+        // rateLimitType is optional in the SDK — default to 'five_hour' (the most common window).
+        const rateLimitType = (info.rateLimitType as string) ?? 'five_hour'
         const utilization = typeof info.utilization === 'number' ? info.utilization : null
         const rawStatus = info.status as string | undefined
         const VALID_STATUSES = new Set(['allowed', 'allowed_warning', 'rejected'])

--- a/src/renderer/store/sessions/eventHandler.ts
+++ b/src/renderer/store/sessions/eventHandler.ts
@@ -65,7 +65,9 @@ export function initAgentEventListener(): () => void {
         // The SDK only populates `utilization` when usage is meaningful (typically >= ~25%).
         // When absent, store status only so the UI can show a green "all clear" dot.
         // rateLimitType is optional in the SDK — default to 'five_hour' (the most common window).
-        const rateLimitType = (info.rateLimitType as string) ?? 'five_hour'
+        // Use || (not ??) to also catch empty string — ?? only handles null/undefined.
+        const rawType = info.rateLimitType
+        const rateLimitType = (typeof rawType === 'string' && rawType) ? rawType : 'five_hour'
         const utilization = typeof info.utilization === 'number' ? info.utilization : null
         const rawStatus = info.status as string | undefined
         const VALID_STATUSES = new Set(['allowed', 'allowed_warning', 'rejected'])

--- a/src/renderer/styles/rate-limit-bars.css
+++ b/src/renderer/styles/rate-limit-bars.css
@@ -2,8 +2,8 @@
 .rate-limit-bars {
   display: flex;
   align-items: center;
-  gap: var(--space-8);
-  padding: var(--space-4) var(--space-12);
+  gap: var(--space-6);
+  padding: var(--space-4) var(--space-8);
   flex-shrink: 0;
   border-radius: var(--radius-lg);
   background: var(--bg-tertiary);
@@ -23,8 +23,8 @@
 .rate-limit-tracks {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
-  min-width: 90px;
+  gap: 3px;
+  min-width: 64px;
 }
 
 .rate-limit-row {
@@ -45,10 +45,10 @@
 
 .rate-limit-track {
   flex: 1;
-  height: 6px;
+  height: 5px;
   border-radius: var(--radius-pill);
   overflow: hidden;
-  min-width: 56px;
+  min-width: 36px;
 }
 
 .rate-limit-fill {


### PR DESCRIPTION
## Summary

- Support displaying all rate limit types (five_hour, seven_day, seven_day_opus, seven_day_sonnet) simultaneously instead of collapsing 7-day variants into one
- Dynamically order and render rate limit bars based on a priority map, making the component extensible for future limit types
- Default missing `rateLimitType` to `five_hour` instead of `unknown` so bars render correctly when the SDK omits the field

## Layers touched

- [x] **Renderer** (`src/renderer/`) - components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Center panel:**
- `RateLimitBars.tsx`: Replaced hardcoded `fiveHour`/`sevenDay` pair with a data-driven loop over all known rate limit types. Added `LABEL_KEY` and `TYPE_ORDER` lookup maps for labels and display priority.

**Stores** (`sessions/eventHandler.ts`):
- Changed fallback for missing `rateLimitType` from `'unknown'` to `'five_hour'` (the most common window).

**Styles** (`rate-limit-bars.css`):
- Tightened spacing and reduced min-width/height to accommodate 3-4 bars without the widget growing too large.

**i18n** (all 4 locales):
- Added `rateLimitSevenDayOpus` and `rateLimitSevenDaySonnet` translation keys.

## How to test

1. `yarn dev`
2. Start a Claude session and use tokens until rate limit info appears in the chat footer
3. Verify that per-model 7-day limits (Opus, Sonnet) render as separate bars when the SDK reports them
4. Verify the bars are ordered: 5h, 7d, 7d-Opus, 7d-Sonnet

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [ ] Types pass - `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store