### PR TITLE
feat: make URLs in chat messages clickable

### DIFF
--- a/src/renderer/components/Center/ToolCallGroup/toolMeta.ts
+++ b/src/renderer/components/Center/ToolCallGroup/toolMeta.ts
@@ -53,16 +53,13 @@ export const TOOL_SUMMARY_GROUPS: Record<string, string> = {
   TodoWrite: 'todo',
 }
 
-/** Prevent default and open a URL in the OS default browser via Electron shell. */
-export function openExternalLink(e: React.MouseEvent<HTMLAnchorElement>, href: string) {
-  e.preventDefault()
-  window.api.shell.openExternal(href)
-}
-
 // Markdown link renderer
 export function LinkRenderer({ href, children }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    if (href) openExternalLink(e, href)
+    if (href) {
+      e.preventDefault()
+      window.api.shell.openExternal(href)
+    }
   }
   return createElement('a', { href, onClick: handleClick }, children)
 }

--- a/src/renderer/components/Center/ToolCallGroup/toolMeta.ts
+++ b/src/renderer/components/Center/ToolCallGroup/toolMeta.ts
@@ -53,13 +53,16 @@ export const TOOL_SUMMARY_GROUPS: Record<string, string> = {
   TodoWrite: 'todo',
 }
 
+/** Prevent default and open a URL in the OS default browser via Electron shell. */
+export function openExternalLink(e: React.MouseEvent<HTMLAnchorElement>, href: string) {
+  e.preventDefault()
+  window.api.shell.openExternal(href)
+}
+
 // Markdown link renderer
 export function LinkRenderer({ href, children }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    if (href) {
-      e.preventDefault()
-      window.api.shell.openExternal(href)
-    }
+    if (href) openExternalLink(e, href)
   }
   return createElement('a', { href, onClick: handleClick }, children)
 }

--- a/src/renderer/components/Center/ToolCallGroup/toolMeta.ts
+++ b/src/renderer/components/Center/ToolCallGroup/toolMeta.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { createElement } from 'react'
+import { openExternalLink } from '@/lib/openExternalLink'
 import {
   IconPencil, IconFile, IconTerminal, IconSearch, IconGlobe,
   IconGitFork, IconChecklist, IconInbox, IconXCircle, IconBook,
@@ -56,10 +57,7 @@ export const TOOL_SUMMARY_GROUPS: Record<string, string> = {
 // Markdown link renderer
 export function LinkRenderer({ href, children }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    if (href) {
-      e.preventDefault()
-      window.api.shell.openExternal(href)
-    }
+    if (href) openExternalLink(e, href)
   }
   return createElement('a', { href, onClick: handleClick }, children)
 }

--- a/src/renderer/components/Center/__tests__/mentionHighlight.test.tsx
+++ b/src/renderer/components/Center/__tests__/mentionHighlight.test.tsx
@@ -114,4 +114,33 @@ describe('parseMentions', () => {
     // The @-prefix causes the mention branch to win
     expect(parts[0]).toEqual({ type: 'mention', text: '@https://example.com' })
   })
+
+  it('strips trailing punctuation from URLs', () => {
+    const parts = extractParts(parseMentions('Check https://google.com.', 'cls'))
+    expect(parts).toEqual([
+      { type: 'text', text: 'Check ' },
+      { type: 'link', text: 'https://google.com', href: 'https://google.com' },
+      { type: 'text', text: '.' },
+    ])
+  })
+
+  it('strips trailing comma from URLs', () => {
+    const parts = extractParts(parseMentions('see https://example.com, thanks', 'cls'))
+    expect(parts[1]).toEqual({
+      type: 'link',
+      text: 'https://example.com',
+      href: 'https://example.com',
+    })
+    expect(parts[2]).toEqual({ type: 'text', text: ', thanks' })
+  })
+
+  it('does not linkify URLs in backdrop mode (mark tag)', () => {
+    const parts = extractParts(parseMentions('see https://example.com ok', 'cls', 'mark'))
+    // URL should be plain text, not a link
+    expect(parts).toEqual([
+      { type: 'text', text: 'see ' },
+      { type: 'text', text: 'https://example.com' },
+      { type: 'text', text: ' ok' },
+    ])
+  })
 })

--- a/src/renderer/components/Center/__tests__/mentionHighlight.test.tsx
+++ b/src/renderer/components/Center/__tests__/mentionHighlight.test.tsx
@@ -93,4 +93,25 @@ describe('parseMentions', () => {
       { type: 'text', text: ' is great' },
     ])
   })
+
+  it('handles URLs with query strings and anchors', () => {
+    const parts = extractParts(
+      parseMentions('see https://example.com/page?q=1&b=2#section done', 'cls')
+    )
+    expect(parts).toEqual([
+      { type: 'text', text: 'see ' },
+      {
+        type: 'link',
+        text: 'https://example.com/page?q=1&b=2#section',
+        href: 'https://example.com/page?q=1&b=2#section',
+      },
+      { type: 'text', text: ' done' },
+    ])
+  })
+
+  it('treats @https://... as a mention, not a URL', () => {
+    const parts = extractParts(parseMentions('@https://example.com rest', 'cls'))
+    // The @-prefix causes the mention branch to win
+    expect(parts[0]).toEqual({ type: 'mention', text: '@https://example.com' })
+  })
 })

--- a/src/renderer/components/Center/__tests__/mentionHighlight.test.tsx
+++ b/src/renderer/components/Center/__tests__/mentionHighlight.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+import { parseMentions } from '../mentionHighlight'
+
+// Stub window.api.shell.openExternal for link click tests
+beforeEach(() => {
+  ;(window as any).api = { shell: { openExternal: vi.fn() } }
+})
+
+function extractParts(nodes: React.ReactNode[]): Array<{ type: string; text: string; href?: string }> {
+  return nodes.map((n) => {
+    if (typeof n === 'string') return { type: 'text', text: n }
+    if (React.isValidElement(n)) {
+      const el = n as React.ReactElement<any>
+      if (el.type === 'a') {
+        return { type: 'link', text: String(el.props.children), href: el.props.href }
+      }
+      return { type: 'mention', text: String(el.props.children) }
+    }
+    return { type: 'unknown', text: String(n) }
+  })
+}
+
+describe('parseMentions', () => {
+  it('returns empty array for empty string', () => {
+    expect(parseMentions('', 'cls')).toEqual([])
+  })
+
+  it('returns plain text with no matches', () => {
+    const parts = parseMentions('hello world', 'cls')
+    expect(parts).toEqual(['hello world'])
+  })
+
+  it('highlights @mentions', () => {
+    const parts = extractParts(parseMentions('hi @alice bye', 'cls'))
+    expect(parts).toEqual([
+      { type: 'text', text: 'hi ' },
+      { type: 'mention', text: '@alice' },
+      { type: 'text', text: ' bye' },
+    ])
+  })
+
+  it('renders URLs as clickable links', () => {
+    const parts = extractParts(parseMentions('check https://example.com please', 'cls'))
+    expect(parts).toEqual([
+      { type: 'text', text: 'check ' },
+      { type: 'link', text: 'https://example.com', href: 'https://example.com' },
+      { type: 'text', text: ' please' },
+    ])
+  })
+
+  it('handles http URLs', () => {
+    const parts = extractParts(parseMentions('go to http://localhost:3000/api', 'cls'))
+    expect(parts[1]).toEqual({
+      type: 'link',
+      text: 'http://localhost:3000/api',
+      href: 'http://localhost:3000/api',
+    })
+  })
+
+  it('handles mixed mentions and URLs', () => {
+    const parts = extractParts(parseMentions('@bob see https://github.com/pr/1', 'cls'))
+    expect(parts).toEqual([
+      { type: 'mention', text: '@bob' },
+      { type: 'text', text: ' see ' },
+      { type: 'link', text: 'https://github.com/pr/1', href: 'https://github.com/pr/1' },
+    ])
+  })
+
+  it('does not include trailing parenthesis in URL', () => {
+    const parts = extractParts(parseMentions('(https://example.com/path)', 'cls'))
+    expect(parts[1]).toEqual({
+      type: 'link',
+      text: 'https://example.com/path',
+      href: 'https://example.com/path',
+    })
+    // Trailing ) should be plain text
+    expect(parts[2]).toEqual({ type: 'text', text: ')' })
+  })
+
+  it('handles URL at end of text', () => {
+    const parts = extractParts(parseMentions('visit https://example.com', 'cls'))
+    expect(parts).toEqual([
+      { type: 'text', text: 'visit ' },
+      { type: 'link', text: 'https://example.com', href: 'https://example.com' },
+    ])
+  })
+
+  it('handles URL at start of text', () => {
+    const parts = extractParts(parseMentions('https://example.com is great', 'cls'))
+    expect(parts).toEqual([
+      { type: 'link', text: 'https://example.com', href: 'https://example.com' },
+      { type: 'text', text: ' is great' },
+    ])
+  })
+})

--- a/src/renderer/components/Center/__tests__/mentionHighlight.test.tsx
+++ b/src/renderer/components/Center/__tests__/mentionHighlight.test.tsx
@@ -134,6 +134,20 @@ describe('parseMentions', () => {
     expect(parts[2]).toEqual({ type: 'text', text: ', thanks' })
   })
 
+  it('opens URLs externally on click and prevents default navigation', () => {
+    const nodes = parseMentions('check https://example.com please', 'cls')
+    const link = nodes.find(
+      (node): node is React.ReactElement<any> => React.isValidElement(node) && node.type === 'a',
+    )
+    expect(link).toBeDefined()
+
+    const event = { preventDefault: vi.fn() }
+    link!.props.onClick(event)
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect((window as any).api.shell.openExternal).toHaveBeenCalledWith('https://example.com')
+  })
+
   it('does not linkify URLs in backdrop mode (mark tag)', () => {
     const parts = extractParts(parseMentions('see https://example.com ok', 'cls', 'mark'))
     // URL should be plain text, not a link

--- a/src/renderer/components/Center/mentionHighlight.tsx
+++ b/src/renderer/components/Center/mentionHighlight.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { openExternalLink } from '@/lib/openExternalLink'
 
 /** Combined regex: @mentions (groups 1-2) and URLs (group 3) in a single pass */
-const MENTION_OR_URL_RE = /(?:(^|\s)(@\S+))|(https?:\/\/[^\s)>\]]+)/g
+const MENTION_OR_URL_RE = /(?:(^|\s)(@\S+))|(https?:\/\/[^\s)>\]]+(?<![.,!?:;]))/g
 
 /**
  * Parses text and returns React nodes with @mentions wrapped in highlighted spans
@@ -30,21 +30,25 @@ export function parseMentions(
       }
       parts.push(<Tag key={`m${start}`} className={className}>{mention}</Tag>)
     } else if (match[3]) {
-      // URL match
+      // URL match — only linkify in display contexts (span), not input backdrop (mark)
       const url = match[3]
       if (start > lastIndex) {
         parts.push(text.slice(lastIndex, start))
       }
-      parts.push(
-        <a
-          key={`u${start}`}
-          href={url}
-          className="chat-msg-inline-link"
-          onClick={(e) => openExternalLink(e, url)}
-        >
-          {url}
-        </a>
-      )
+      if (Tag === 'span') {
+        parts.push(
+          <a
+            key={`u${start}`}
+            href={url}
+            className="chat-msg-inline-link"
+            onClick={(e) => openExternalLink(e, url)}
+          >
+            {url}
+          </a>
+        )
+      } else {
+        parts.push(url)
+      }
     }
     lastIndex = start + match[0].length
   }

--- a/src/renderer/components/Center/mentionHighlight.tsx
+++ b/src/renderer/components/Center/mentionHighlight.tsx
@@ -1,8 +1,5 @@
 import React from 'react'
-import { openExternalLink } from './ToolCallGroup/toolMeta'
-
-/** Regex matching @mention tokens: `@` preceded by start-of-string or whitespace, followed by non-space chars */
-export const MENTION_RE = /(^|\s)(@\S+)/g
+import { openExternalLink } from '@/lib/openExternalLink'
 
 /** Combined regex: @mentions (groups 1-2) and URLs (group 3) in a single pass */
 const MENTION_OR_URL_RE = /(?:(^|\s)(@\S+))|(https?:\/\/[^\s)>\]]+)/g

--- a/src/renderer/components/Center/mentionHighlight.tsx
+++ b/src/renderer/components/Center/mentionHighlight.tsx
@@ -1,10 +1,15 @@
 import React from 'react'
+import { openExternalLink } from './ToolCallGroup/toolMeta'
 
 /** Regex matching @mention tokens: `@` preceded by start-of-string or whitespace, followed by non-space chars */
 export const MENTION_RE = /(^|\s)(@\S+)/g
 
+/** Combined regex: @mentions (groups 1-2) and URLs (group 3) in a single pass */
+const MENTION_OR_URL_RE = /(?:(^|\s)(@\S+))|(https?:\/\/[^\s)>\]]+)/g
+
 /**
- * Parses text and returns React nodes with @mentions wrapped in highlighted spans.
+ * Parses text and returns React nodes with @mentions wrapped in highlighted spans
+ * and URLs rendered as clickable links that open in the default browser.
  * Used by both the input backdrop overlay and sent message bubbles.
  */
 export function parseMentions(
@@ -15,15 +20,35 @@ export function parseMentions(
   const parts: React.ReactNode[] = []
   let lastIndex = 0
   let match: RegExpExecArray | null
-  MENTION_RE.lastIndex = 0
-  while ((match = MENTION_RE.exec(text)) !== null) {
-    const prefix = match[1]
-    const mention = match[2]
+  MENTION_OR_URL_RE.lastIndex = 0
+  while ((match = MENTION_OR_URL_RE.exec(text)) !== null) {
     const start = match.index
-    if (start + prefix.length > lastIndex) {
-      parts.push(text.slice(lastIndex, start + prefix.length))
+
+    if (match[2]) {
+      // @mention match
+      const prefix = match[1]
+      const mention = match[2]
+      if (start + prefix.length > lastIndex) {
+        parts.push(text.slice(lastIndex, start + prefix.length))
+      }
+      parts.push(<Tag key={`m${start}`} className={className}>{mention}</Tag>)
+    } else if (match[3]) {
+      // URL match
+      const url = match[3]
+      if (start > lastIndex) {
+        parts.push(text.slice(lastIndex, start))
+      }
+      parts.push(
+        <a
+          key={`u${start}`}
+          href={url}
+          className="chat-msg-inline-link"
+          onClick={(e) => openExternalLink(e, url)}
+        >
+          {url}
+        </a>
+      )
     }
-    parts.push(<Tag key={start} className={className}>{mention}</Tag>)
     lastIndex = start + match[0].length
   }
   if (lastIndex < text.length) parts.push(text.slice(lastIndex))

--- a/src/renderer/lib/openExternalLink.ts
+++ b/src/renderer/lib/openExternalLink.ts
@@ -1,0 +1,7 @@
+import type React from 'react'
+
+/** Prevent default and open a URL in the OS default browser via Electron shell. */
+export function openExternalLink(e: React.MouseEvent<HTMLAnchorElement>, href: string) {
+  e.preventDefault()
+  window.api.shell.openExternal(href)
+}

--- a/src/renderer/lib/openExternalLink.ts
+++ b/src/renderer/lib/openExternalLink.ts
@@ -1,7 +1,8 @@
 import type React from 'react'
+import { shell } from './ipc'
 
 /** Prevent default and open a URL in the OS default browser via Electron shell. */
 export function openExternalLink(e: React.MouseEvent<HTMLAnchorElement>, href: string) {
   e.preventDefault()
-  window.api.shell.openExternal(href)
+  shell.openExternal(href)
 }

--- a/src/renderer/styles/chat-messages.css
+++ b/src/renderer/styles/chat-messages.css
@@ -403,12 +403,14 @@
   font-size: inherit;
 }
 
-.chat-msg-assistant-content a {
+.chat-msg-assistant-content a,
+.chat-msg-inline-link {
   color: var(--accent);
   text-decoration: none;
 }
 
-.chat-msg-assistant-content a:hover {
+.chat-msg-assistant-content a:hover,
+.chat-msg-inline-link:hover {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary

- チャットメッセージ内のURLを自動検出してクリック可能なリンクとして表示する機能を追加
  Add auto-detection of URLs in chat messages, rendering them as clickable links
- リンクをクリックするとOSデフォルトブラウザで開く（Electron shell経由）
  Clicking a link opens it in the OS default browser via Electron shell
- `parseMentions`を拡張し、@メンションとURLを単一の正規表現で同時に処理
  Extends `parseMentions` to handle both @mentions and URLs in a single combined regex pass

## Layers touched

- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Center panel:**
- `mentionHighlight.tsx` — combined `MENTION_OR_URL_RE` regex replaces the mention-only regex; URLs render as `<a class="chat-msg-inline-link">` elements with click handler
- `ToolCallGroup/toolMeta.ts` — extracted `openExternalLink()` helper from `LinkRenderer` for reuse across components
- `__tests__/mentionHighlight.test.tsx` — new test suite covering plain text, @mentions, URLs, mixed content, and edge cases (trailing parens, URL position)

**Styles:**
- `chat-messages.css` — extended accent-colored link styles to `.chat-msg-inline-link` class

## How to test

1. `yarn dev`
2. チャットメッセージにURLを含むテキストを送信する（例: `check https://github.com`）
   Send a chat message containing a URL (e.g. `check https://github.com`)
3. URLがアクセントカラーのリンクとして表示されることを確認
   Verify the URL renders as an accent-colored link
4. リンクをクリックしてデフォルトブラウザで開くことを確認
   Click the link and verify it opens in the default browser
5. `@mention`とURLが混在するメッセージでも正しく動作することを確認
   Verify messages with both @mentions and URLs render correctly
6. `yarn test mentionHighlight` でユニットテストが全て通ることを確認
   Run `yarn test mentionHighlight` and verify all unit tests pass

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [ ] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store