### PR TITLE
refactor: move copy button from turn actions to code blocks

### DIFF
--- a/src/renderer/components/Center/ChatMessage.tsx
+++ b/src/renderer/components/Center/ChatMessage.tsx
@@ -1,10 +1,11 @@
-import { memo, useState, useCallback, useRef, useEffect, useLayoutEffect } from 'react'
+import { memo, useState, useCallback, useRef, useLayoutEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import type { ContentBlock, Message, TurnUsage } from '@/types'
 import { useUIStore } from '@/store/ui'
 import { useSessionsStore } from '@/store/sessions'
 import { flash } from '@/store/flash'
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import { ToolCallGroup } from './ToolCallGroup'
 import { StreamingMarkdown } from './StreamingMarkdown'
 import { parseMentions } from './mentionHighlight'
@@ -17,27 +18,9 @@ import { parseDiffComments, parseSnippets, parseTerminalBlocks, stripAttachmentB
 import type { ParsedDiffComment, ParsedSnippet, ParsedTerminalBlock } from './diffCommentUtils'
 import { formatTokens } from '@/lib/constants'
 
-/** Renders text with @mentions highlighted as accent-coloured spans */
 function renderWithMentions(text: string): React.ReactNode {
   const parts = parseMentions(text, 'chat-msg-mention')
   return parts.length > 0 ? parts : text
-}
-
-function useCopyToClipboard(text: string) {
-  const [copied, setCopied] = useState(false)
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
-
-  useEffect(() => () => clearTimeout(timerRef.current), [])
-
-  const handleCopy = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
-    navigator.clipboard.writeText(text)
-    setCopied(true)
-    clearTimeout(timerRef.current)
-    timerRef.current = setTimeout(() => setCopied(false), 2000)
-  }, [text])
-
-  return { copied, handleCopy }
 }
 
 function AssistantCopyButton({ text }: { text: string }) {
@@ -127,27 +110,16 @@ function RollbackButton({ messageId }: { messageId: string }) {
 }
 
 interface TurnActionsProps {
-  text: string
   durationMs?: number
   turnUsage?: TurnUsage
 }
 
-function TurnActions({ text, durationMs, turnUsage }: TurnActionsProps) {
-  const { t } = useTranslation('common')
-  const { copied, handleCopy } = useCopyToClipboard(text)
+function TurnActions({ durationMs, turnUsage }: TurnActionsProps) {
+  if (durationMs == null || durationMs <= 0) return null
 
   return (
     <div className="turn-actions">
-      {durationMs != null && durationMs > 0 && (
-        <TurnDuration durationMs={durationMs} turnUsage={turnUsage} />
-      )}
-      <button
-        className={`turn-actions-btn${copied ? ' turn-actions-btn--copied' : ''}`}
-        onClick={handleCopy}
-        title={copied ? t('copied') : t('copy')}
-      >
-        {copied ? <IconCheckmark size={14} /> : <IconCopy size={14} />}
-      </button>
+      <TurnDuration durationMs={durationMs} turnUsage={turnUsage} />
     </div>
   )
 }
@@ -334,7 +306,6 @@ export const ChatMessage = memo(function ChatMessage({ message }: Props) {
     const groupBlocks = blocks.slice(0, lastToolIdx + 1)
     const trailingBlocks = blocks.slice(lastToolIdx + 1)
     const trailingText = joinTextBlocks(trailingBlocks)
-    const allText = joinTextBlocks(blocks)
 
     return (
       <div className="chat-msg chat-msg-assistant">
@@ -346,8 +317,8 @@ export const ChatMessage = memo(function ChatMessage({ message }: Props) {
           </div>
         )}
         {!message.isPartial && <TurnFooter blocks={groupBlocks} />}
-        {!message.isPartial && allText && (
-          <TurnActions text={allText} durationMs={message.turnDurationMs} turnUsage={message.turnUsage} />
+        {!message.isPartial && (
+          <TurnActions durationMs={message.turnDurationMs} turnUsage={message.turnUsage} />
         )}
       </div>
     )
@@ -362,8 +333,8 @@ export const ChatMessage = memo(function ChatMessage({ message }: Props) {
           {!message.isPartial && <AssistantCopyButton text={message.content} />}
         </div>
       )}
-      {!message.isPartial && message.content && (
-        <TurnActions text={message.content} durationMs={message.turnDurationMs} turnUsage={message.turnUsage} />
+      {!message.isPartial && (
+        <TurnActions durationMs={message.turnDurationMs} turnUsage={message.turnUsage} />
       )}
     </div>
   )

--- a/src/renderer/components/Center/ChatMessage.tsx
+++ b/src/renderer/components/Center/ChatMessage.tsx
@@ -18,6 +18,7 @@ import { parseDiffComments, parseSnippets, parseTerminalBlocks, stripAttachmentB
 import type { ParsedDiffComment, ParsedSnippet, ParsedTerminalBlock } from './diffCommentUtils'
 import { formatTokens } from '@/lib/constants'
 
+/** Renders text with @mentions highlighted as accent-coloured spans */
 function renderWithMentions(text: string): React.ReactNode {
   const parts = parseMentions(text, 'chat-msg-mention')
   return parts.length > 0 ? parts : text

--- a/src/renderer/components/Center/CodeBlockCopy.tsx
+++ b/src/renderer/components/Center/CodeBlockCopy.tsx
@@ -1,0 +1,32 @@
+import { isValidElement, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { IconCopy, IconCheckmark } from '@/components/shared/icons'
+
+function extractText(node: React.ReactNode): string {
+  if (typeof node === 'string') return node
+  if (typeof node === 'number') return String(node)
+  if (node == null || typeof node === 'boolean') return ''
+  if (Array.isArray(node)) return node.map(extractText).join('')
+  if (isValidElement<{ children?: React.ReactNode }>(node)) return extractText(node.props.children)
+  return ''
+}
+
+export function CodeBlockWithCopy({ children, ...rest }: React.HTMLAttributes<HTMLPreElement>) {
+  const { t } = useTranslation('common')
+  const text = useMemo(() => extractText(children), [children])
+  const { copied, handleCopy } = useCopyToClipboard(text)
+
+  return (
+    <div className="code-block-wrapper">
+      <pre {...rest}>{children}</pre>
+      <button
+        className={`code-block-copy-btn${copied ? ' code-block-copy-btn--copied' : ''}`}
+        onClick={handleCopy}
+        title={copied ? t('copied') : t('copy')}
+      >
+        {copied ? <IconCheckmark size={14} /> : <IconCopy size={14} />}
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/Center/ToolCallGroup/toolMeta.ts
+++ b/src/renderer/components/Center/ToolCallGroup/toolMeta.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { createElement } from 'react'
 import { openExternalLink } from '@/lib/openExternalLink'
+import { CodeBlockWithCopy } from '../CodeBlockCopy'
 import {
   IconPencil, IconFile, IconTerminal, IconSearch, IconGlobe,
   IconGitFork, IconChecklist, IconInbox, IconXCircle, IconBook,
@@ -62,7 +63,7 @@ export function LinkRenderer({ href, children }: React.AnchorHTMLAttributes<HTML
   return createElement('a', { href, onClick: handleClick }, children)
 }
 
-export const markdownComponents = { a: LinkRenderer }
+export const markdownComponents = { a: LinkRenderer, pre: CodeBlockWithCopy }
 
 // ── File extension → highlight.js language mapping ────────────────────────────
 // Only includes languages that are registered in ToolCallRow.tsx at module level.

--- a/src/renderer/components/Center/__tests__/CodeBlockCopy.test.tsx
+++ b/src/renderer/components/Center/__tests__/CodeBlockCopy.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup } from '@testing-library/react'
+import { CodeBlockWithCopy } from '../CodeBlockCopy'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+const mockHandleCopy = vi.fn()
+let mockCopied = false
+
+vi.mock('@/hooks/useCopyToClipboard', () => ({
+  useCopyToClipboard: vi.fn((text: string) => {
+    // Store the text arg so tests can inspect it
+    ;(useCopyToClipboardSpy as any).__lastText = text
+    return { copied: mockCopied, handleCopy: mockHandleCopy }
+  }),
+}))
+
+// Re-import after mock so we can inspect calls
+import { useCopyToClipboard as useCopyToClipboardSpy } from '@/hooks/useCopyToClipboard'
+
+beforeEach(() => {
+  mockCopied = false
+  mockHandleCopy.mockClear()
+  ;(useCopyToClipboardSpy as any).__lastText = undefined
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CodeBlockWithCopy', () => {
+  it('renders a pre element with children', () => {
+    render(<CodeBlockWithCopy>console.log("hi")</CodeBlockWithCopy>)
+
+    const pre = screen.getByText('console.log("hi")')
+    expect(pre.tagName).toBe('PRE')
+  })
+
+  it('renders a copy button with "copy" title by default', () => {
+    render(<CodeBlockWithCopy>code</CodeBlockWithCopy>)
+
+    const btn = screen.getByRole('button')
+    expect(btn).toBeDefined()
+    expect(btn.title).toBe('copy')
+  })
+
+  it('applies --copied class and shows "copied" title when copied is true', () => {
+    mockCopied = true
+    render(<CodeBlockWithCopy>code</CodeBlockWithCopy>)
+
+    const btn = screen.getByRole('button')
+    expect(btn.className).toContain('code-block-copy-btn--copied')
+    expect(btn.title).toBe('copied')
+  })
+
+  it('does not apply --copied class when copied is false', () => {
+    mockCopied = false
+    render(<CodeBlockWithCopy>code</CodeBlockWithCopy>)
+
+    const btn = screen.getByRole('button')
+    expect(btn.className).not.toContain('code-block-copy-btn--copied')
+  })
+
+  it('wraps pre in a .code-block-wrapper div', () => {
+    const { container } = render(<CodeBlockWithCopy>code</CodeBlockWithCopy>)
+
+    const wrapper = container.firstElementChild
+    expect(wrapper?.className).toBe('code-block-wrapper')
+    expect(wrapper?.querySelector('pre')).toBeTruthy()
+    expect(wrapper?.querySelector('button')).toBeTruthy()
+  })
+
+  it('passes extra props to the pre element', () => {
+    render(<CodeBlockWithCopy className="language-ts" data-testid="my-pre">x</CodeBlockWithCopy>)
+
+    const pre = screen.getByTestId('my-pre')
+    expect(pre.className).toBe('language-ts')
+  })
+
+  // ---------------------------------------------------------------------------
+  // extractText (tested indirectly through useCopyToClipboard call)
+  // ---------------------------------------------------------------------------
+
+  it('extracts plain string children', () => {
+    render(<CodeBlockWithCopy>hello world</CodeBlockWithCopy>)
+    expect((useCopyToClipboardSpy as any).__lastText).toBe('hello world')
+  })
+
+  it('extracts text from nested elements', () => {
+    render(
+      <CodeBlockWithCopy>
+        <code>
+          <span>const</span> x = <span>42</span>
+        </code>
+      </CodeBlockWithCopy>,
+    )
+    expect((useCopyToClipboardSpy as any).__lastText).toBe('const x = 42')
+  })
+
+  it('extracts number children', () => {
+    render(<CodeBlockWithCopy>{123}</CodeBlockWithCopy>)
+    expect((useCopyToClipboardSpy as any).__lastText).toBe('123')
+  })
+
+  it('handles null and boolean children gracefully', () => {
+    render(
+      <CodeBlockWithCopy>
+        {null}
+        {true}
+        {false}
+        text
+      </CodeBlockWithCopy>,
+    )
+    expect((useCopyToClipboardSpy as any).__lastText).toBe('text')
+  })
+
+  it('concatenates array children', () => {
+    render(
+      <CodeBlockWithCopy>
+        {'line1'}
+        {'\n'}
+        {'line2'}
+      </CodeBlockWithCopy>,
+    )
+    expect((useCopyToClipboardSpy as any).__lastText).toBe('line1\nline2')
+  })
+})

--- a/src/renderer/hooks/__tests__/useCopyToClipboard.test.ts
+++ b/src/renderer/hooks/__tests__/useCopyToClipboard.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useCopyToClipboard } from '../useCopyToClipboard'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const writeText = vi.fn().mockResolvedValue(undefined)
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  Object.assign(navigator, { clipboard: { writeText } })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeClick(): React.MouseEvent {
+  return { stopPropagation: vi.fn() } as unknown as React.MouseEvent
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useCopyToClipboard', () => {
+  it('starts with copied = false', () => {
+    const { result } = renderHook(() => useCopyToClipboard('hello'))
+    expect(result.current.copied).toBe(false)
+  })
+
+  it('sets copied to true after handleCopy', () => {
+    const { result } = renderHook(() => useCopyToClipboard('hello'))
+
+    act(() => {
+      result.current.handleCopy(fakeClick())
+    })
+
+    expect(result.current.copied).toBe(true)
+  })
+
+  it('calls navigator.clipboard.writeText with the provided text', () => {
+    const { result } = renderHook(() => useCopyToClipboard('some code'))
+
+    act(() => {
+      result.current.handleCopy(fakeClick())
+    })
+
+    expect(writeText).toHaveBeenCalledWith('some code')
+  })
+
+  it('calls stopPropagation on the click event', () => {
+    const { result } = renderHook(() => useCopyToClipboard('x'))
+    const event = fakeClick()
+
+    act(() => {
+      result.current.handleCopy(event)
+    })
+
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets copied to false after 2 seconds', () => {
+    const { result } = renderHook(() => useCopyToClipboard('hello'))
+
+    act(() => {
+      result.current.handleCopy(fakeClick())
+    })
+    expect(result.current.copied).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(result.current.copied).toBe(false)
+  })
+
+  it('does not reset early if handleCopy is called again before timer fires', () => {
+    const { result } = renderHook(() => useCopyToClipboard('hello'))
+
+    act(() => {
+      result.current.handleCopy(fakeClick())
+    })
+
+    // Advance 1.5s, then copy again — should restart the timer
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+    expect(result.current.copied).toBe(true)
+
+    act(() => {
+      result.current.handleCopy(fakeClick())
+    })
+
+    // Advance another 1.5s — old timer would have fired, but new one hasn't
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+    expect(result.current.copied).toBe(true)
+
+    // Advance remaining 500ms to complete the 2s window
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(result.current.copied).toBe(false)
+  })
+
+  it('clears the timer on unmount', () => {
+    const { result, unmount } = renderHook(() => useCopyToClipboard('hello'))
+
+    act(() => {
+      result.current.handleCopy(fakeClick())
+    })
+
+    unmount()
+
+    // Advancing time after unmount should not throw
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+  })
+})

--- a/src/renderer/hooks/useCopyToClipboard.ts
+++ b/src/renderer/hooks/useCopyToClipboard.ts
@@ -9,7 +9,9 @@ export function useCopyToClipboard(text: string) {
 
   const handleCopy = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
-    navigator.clipboard.writeText(text).catch(() => {})
+    navigator.clipboard.writeText(text).catch((err) => {
+      console.error('Failed to copy to clipboard:', err)
+    })
     setCopied(true)
     clearTimeout(timerRef.current)
     timerRef.current = setTimeout(() => setCopied(false), 2000)

--- a/src/renderer/hooks/useCopyToClipboard.ts
+++ b/src/renderer/hooks/useCopyToClipboard.ts
@@ -1,0 +1,19 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+
+/** Copies text to clipboard on click, with a 2s "copied" feedback state. */
+export function useCopyToClipboard(text: string) {
+  const [copied, setCopied] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  useEffect(() => () => clearTimeout(timerRef.current), [])
+
+  const handleCopy = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    navigator.clipboard.writeText(text)
+    setCopied(true)
+    clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => setCopied(false), 2000)
+  }, [text])
+
+  return { copied, handleCopy }
+}

--- a/src/renderer/hooks/useCopyToClipboard.ts
+++ b/src/renderer/hooks/useCopyToClipboard.ts
@@ -9,7 +9,7 @@ export function useCopyToClipboard(text: string) {
 
   const handleCopy = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
-    navigator.clipboard.writeText(text)
+    navigator.clipboard.writeText(text).catch(() => {})
     setCopied(true)
     clearTimeout(timerRef.current)
     timerRef.current = setTimeout(() => setCopied(false), 2000)

--- a/src/renderer/styles/chat-messages.css
+++ b/src/renderer/styles/chat-messages.css
@@ -396,11 +396,62 @@
   line-height: 1.55;
 }
 
+/* When pre is inside a code-block-wrapper, the wrapper owns the margin */
+.chat-msg-assistant-content .code-block-wrapper {
+  margin: var(--space-12) 0;
+}
+
 .chat-msg-assistant-content pre code {
   background: transparent;
   border: none;
   padding: 0;
   font-size: inherit;
+}
+
+/* ============= Code Block Copy Button ============= */
+
+.code-block-wrapper {
+  position: relative;
+}
+
+.code-block-wrapper pre {
+  margin: 0;
+}
+
+.code-block-copy-btn {
+  position: absolute;
+  top: var(--space-8);
+  right: var(--space-8);
+  padding: var(--space-4);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--duration-normal);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-base);
+}
+
+.code-block-wrapper:hover .code-block-copy-btn {
+  opacity: 1;
+}
+
+.code-block-copy-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.code-block-copy-btn--copied {
+  color: var(--green);
+  opacity: 1;
+}
+
+.code-block-copy-btn--copied:hover {
+  color: var(--green);
 }
 
 .chat-msg-assistant-content a,
@@ -736,15 +787,6 @@
 .turn-actions-btn:hover {
   color: var(--text-primary);
   background: var(--bg-hover);
-}
-
-.turn-actions-btn--copied {
-  color: var(--green);
-}
-
-.turn-actions-btn--copied:hover {
-  color: var(--green);
-  background: none;
 }
 
 .turn-actions-btn--disabled {


### PR DESCRIPTION
## Summary

- ターンフッターのコピーボタンを削除し、各コードブロックにホバー時のコピーボタンを配置
  Remove the copy-all button from the turn actions footer and add a per-code-block copy button that appears on hover
- `useCopyToClipboard` フックを共有フックとして切り出し、再利用可能にした
  Extract `useCopyToClipboard` into a shared hook for reuse across components
- `TurnActions` を簡素化し、所要時間表示のみに変更（所要時間がない場合は非表示）
  Simplify `TurnActions` to only render duration info (hidden when no duration)

## Layers touched

- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Center panel:**
- `ChatMessage.tsx` — removed inline `useCopyToClipboard` definition and the copy button from `TurnActions`; `TurnActions` now only renders when `durationMs > 0`
- `CodeBlockCopy.tsx` — new component wrapping `<pre>` with a hover-visible copy button overlay
- `ToolCallGroup/toolMeta.ts` — wired `CodeBlockWithCopy` as the `pre` renderer in markdown components

**Hooks:**
- `useCopyToClipboard.ts` — extracted from `ChatMessage.tsx` into `hooks/` for shared use

**Styles:**
- `chat-messages.css` — added `.code-block-wrapper` and `.code-block-copy-btn` styles; removed unused `.turn-actions-btn--copied` styles

## How to test

1. `yarn dev`
2. チャットでコードブロックを含むメッセージを送信する
   Send a message that produces code blocks in the assistant response
3. コードブロックにホバーすると、右上にコピーボタンが表示されることを確認
   Hover over a code block — a copy button should appear in the top-right corner
4. コピーボタンをクリックし、チェックマークに変わることを確認
   Click the copy button — it should switch to a checkmark icon for 2 seconds
5. ターンフッターにコピーボタンが表示されないことを確認（所要時間のみ表示）
   Verify the turn footer no longer shows a copy button (only duration if available)

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [ ] Types pass — `yarn typecheck`
- [ ] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store