### PR TITLE
fix(search): clicking a search result row gets stuck at the top of the editor

### DIFF
--- a/src/renderer/components/Right/FileViewer.tsx
+++ b/src/renderer/components/Right/FileViewer.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useEffect, useRef, useCallback } from 'react'
+import { useReducer, useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react'
 import Editor, { useMonaco, type OnMount } from '@monaco-editor/react'
 import type { editor } from 'monaco-editor'
 import { useShallow } from 'zustand/react/shallow'
@@ -19,6 +19,7 @@ import { LspInstallNudge } from './LspInstallNudge'
 import { DiagnosticsPanel } from './DiagnosticsPanel'
 import { BinaryImagePreview, BinaryPlaceholder } from './BinaryFilePreview'
 import { isBinaryFile, isImageFile } from '@/lib/binaryFile'
+import { pendingReveal } from '@/lib/pendingReveal'
 
 interface Props {
   filePath: string | null
@@ -191,13 +192,33 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
     return () => disposable.dispose()
   }, [monacoInstance, filePath])
 
-  // Load file content whenever filePath changes
-  useEffect(() => {
+  const pendingRevealRef = useRef<{ path: string; line: number } | null>(null)
+  const [revealing, setRevealing] = useState(false)
+
+  // NOTE:
+  // Load file content + pick up any pending reveal whenever filePath changes.
+  // useLayoutEffect (not useEffect) so the loadStart dispatch and the
+  // revealing flag are committed synchronously, before the browser paints.
+  // Otherwise the Editor from the previous file briefly shows under the new
+  // filePath, producing the flicker reported on rapid A→B switches.
+  useLayoutEffect(() => {
     if (!filePath) return
-    // Binary files are handled by a dedicated viewer, skip Monaco loading
+
+    editorRef.current = null
     if (isBinaryFile(filePath)) {
+      // NOTE:
+      // Binary files render via BinaryFilePreview, never through Monaco, so
+      // a pending reveal target is meaningless here. Drop it without
+      // toggling `revealing`, otherwise the flag would never clear.
+      pendingReveal.consume(filePath)
+      pendingRevealRef.current = null
       dispatch({ type: 'loadDone', content: '' })
       return
+    }
+    const target = pendingReveal.consume(filePath)
+    if (target) {
+      pendingRevealRef.current = target
+      setRevealing(true)
     }
     dispatch({ type: 'loadStart' })
     ipc.git
@@ -236,16 +257,14 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
     return () => window.removeEventListener('braid:saveFile', handler)
   }, [])
 
-  // Reveal-line (from search results). Pending ref covers the mount-gap when
-  // the editor for a just-opened file hasn't finished mounting yet.
-  const pendingRevealRef = useRef<{ path: string; line: number } | null>(null)
   const tryReveal = useCallback(() => {
     const p = pendingRevealRef.current
     if (!p || !editorRef.current || p.path !== filePath) return
-    editorRef.current.revealLineInCenter(p.line)
+    editorRef.current.revealLineInCenter(p.line, 1)
     editorRef.current.setPosition({ lineNumber: p.line, column: 1 })
     editorRef.current.focus()
     pendingRevealRef.current = null
+    setRevealing(false)
   }, [filePath])
 
   useEffect(() => {
@@ -264,7 +283,18 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
       monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS,
       () => handleSaveRef.current()
     )
-    tryReveal()
+    // NOTE
+    // Defer the reveal: at onMount time Monaco's viewport hasn't laid out
+    // yet, so revealLineInCenter has no real height to center against and
+    // ends up scrolling the line to the top. Force a layout, then wait one
+    // animation frame for the DOM to settle before centering. The wrapper
+    // div is already hidden via the `revealing` state, so the user sees a
+    // single committed paint of the centered line.
+    requestAnimationFrame(() => {
+      editorInstance.layout()
+      tryReveal()
+      setRevealing(false)
+    })
   }, [tryReveal])
 
   const handleChange = useCallback((value: string | undefined) => {
@@ -382,24 +412,30 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
             <StreamingMarkdown content={state.currentContent} enableAnimation={false} />
           </div>
         ) : (
-          <Editor
-            height="100%"
-            language={toMonacoLanguage(languageId)}
-            defaultValue={state.savedContent}
-            theme={MONACO_THEME_NAME}
-            onMount={handleEditorMount}
-            onChange={handleChange}
-            options={{
-              minimap: { enabled: false },
-              fontSize: 14,
-              lineNumbers: 'on',
-              scrollBeyondLastLine: false,
-              renderWhitespace: 'selection',
-              wordWrap: 'on',
-              padding: { top: 10 },
-              tabSize: 2,
-            }}
-          />
+          // Wrap the Editor so we can toggle visibility from React state.
+          // While `revealing` is true the user wouldn't see meaningful
+          // content anyway (the reveal is one rAF away), and hiding here
+          // guarantees Monaco never gets a chance to paint at line 1.
+          <div style={{ height: '100%', visibility: revealing ? 'hidden' : 'visible' }}>
+            <Editor
+              height="100%"
+              language={toMonacoLanguage(languageId)}
+              defaultValue={state.savedContent}
+              theme={MONACO_THEME_NAME}
+              onMount={handleEditorMount}
+              onChange={handleChange}
+              options={{
+                minimap: { enabled: false },
+                fontSize: 14,
+                lineNumbers: 'on',
+                scrollBeyondLastLine: false,
+                renderWhitespace: 'selection',
+                wordWrap: 'on',
+                padding: { top: 10 },
+                tabSize: 2,
+              }}
+            />
+          </div>
         )}
       </div>
 

--- a/src/renderer/components/Right/FileViewer.tsx
+++ b/src/renderer/components/Right/FileViewer.tsx
@@ -1,6 +1,6 @@
 import { useReducer, useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react'
 import Editor, { useMonaco, type OnMount } from '@monaco-editor/react'
-import type { editor } from 'monaco-editor'
+import { editor } from 'monaco-editor'
 import { useShallow } from 'zustand/react/shallow'
 import { Tooltip } from '@/components/shared/Tooltip'
 import { StreamingMarkdown } from '@/components/Center/StreamingMarkdown'
@@ -205,6 +205,9 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
     if (!filePath) return
 
     editorRef.current = null
+    pendingRevealRef.current = null
+    setRevealing(false)
+
     if (isBinaryFile(filePath)) {
       // NOTE:
       // Binary files render via BinaryFilePreview, never through Monaco, so
@@ -260,7 +263,7 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
   const tryReveal = useCallback(() => {
     const p = pendingRevealRef.current
     if (!p || !editorRef.current || p.path !== filePath) return
-    editorRef.current.revealLineInCenter(p.line, 1)
+    editorRef.current.revealLineInCenter(p.line, editor.ScrollType.Immediate)
     editorRef.current.setPosition({ lineNumber: p.line, column: 1 })
     editorRef.current.focus()
     pendingRevealRef.current = null
@@ -291,6 +294,8 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
     // div is already hidden via the `revealing` state, so the user sees a
     // single committed paint of the centered line.
     requestAnimationFrame(() => {
+      if (editorRef.current !== editorInstance) return
+      
       editorInstance.layout()
       tryReveal()
       setRevealing(false)

--- a/src/renderer/components/Right/SearchView/SearchResultRow.tsx
+++ b/src/renderer/components/Right/SearchView/SearchResultRow.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import type { SearchFileResult, SearchMatch } from '@shared/search'
 import { useUIStore } from '@/store/ui'
+import { pendingReveal } from '@/lib/pendingReveal'
 
 interface Props {
   file: SearchFileResult
@@ -16,13 +17,16 @@ export function SearchResultRow({ file, match, showReplace, onReplaceOne }: Prop
   const after = match.lineText.slice(match.matchEnd)
 
   const handleClick = () => {
+    // Stash the target in a module-level ref before opening the file. The
+    // FileViewer is lazy-loaded, so on the first open its event listener
+    // doesn't exist yet — the event would be lost. FileViewer reads from this
+    // ref once it mounts. The event below remains as a fast-path for the case
+    // where FileViewer is already mounted with the same file.
+    const target = { path: file.path, line: match.lineNumber }
+    pendingReveal.set(target)
     useUIStore.getState().openFile(file.path)
     requestAnimationFrame(() => {
-      window.dispatchEvent(
-        new CustomEvent('braid:revealLine', {
-          detail: { path: file.path, line: match.lineNumber },
-        }),
-      )
+      window.dispatchEvent(new CustomEvent('braid:revealLine', { detail: target }))
     })
   }
 

--- a/src/renderer/components/Right/SearchView/SearchResultRow.tsx
+++ b/src/renderer/components/Right/SearchView/SearchResultRow.tsx
@@ -17,9 +17,10 @@ export function SearchResultRow({ file, match, showReplace, onReplaceOne }: Prop
   const after = match.lineText.slice(match.matchEnd)
 
   const handleClick = () => {
+    // NOTE:
     // Stash the target in a module-level ref before opening the file. The
     // FileViewer is lazy-loaded, so on the first open its event listener
-    // doesn't exist yet — the event would be lost. FileViewer reads from this
+    // doesn't exist yet and the event would be lost. FileViewer reads from this
     // ref once it mounts. The event below remains as a fast-path for the case
     // where FileViewer is already mounted with the same file.
     const target = { path: file.path, line: match.lineNumber }

--- a/src/renderer/lib/pendingReveal.ts
+++ b/src/renderer/lib/pendingReveal.ts
@@ -1,0 +1,30 @@
+/*
+ * Shared "jump to line" target that survives the gap between a caller (e.g.
+ * SearchResultRow) requesting a file open and the lazy-loaded FileViewer
+ * finishing its mount. A custom event alone isn't enough because the event
+ * fires before any listener exists on the very first open.
+*/
+
+type Target = { path: string; line: number }
+
+let pending: Target | null = null
+
+export const pendingReveal = {
+  set(target: Target): void {
+    pending = target
+  },
+  peek(): Target | null {
+    return pending
+  },
+  consume(path: string): Target | null {
+    if (pending && pending.path === path) {
+      const taken = pending
+      pending = null
+      return taken
+    }
+    return null
+  },
+  clear(): void {
+    pending = null
+  },
+}


### PR DESCRIPTION
## Summary
- Fix search-result clicks: clicking a row now reliably opens the file and centers the matching line on the first click, not just
  the second.
- Eliminate the visible "scroll-from-top" flash and the file-switch flicker when jumping between files via the search panel.
- Keep behavior unchanged for every other path that opens a file (tabs, QuickOpen, tool calls, code review, checks, turn footer, file tree).


## Layers touched

- [ ] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [X] **Renderer** (`src/renderer/`) — components, stores, lib
- [ ] **Styles** (`App.css`)

## Changes

**Sidebar / Center / Right panel:**

- `src/renderer/lib/pendingReveal.ts` (new)
  Module-level store carrying `{ path, line }` across the gap between a search-result click and the lazy-loaded `FileViewer` finishing its mount.   A `CustomEvent` alone isn't enough because the listener doesn't exist yet on first open.

- `src/renderer/components/Right/SearchView/SearchResultRow.tsx`
  Writes the target into `pendingReveal` before calling `openFile`.  The dispatched `braid:revealLine` event remains as a fast-path for clicks while `FileViewer` is already mounted on the same file.

- `src/renderer/components/Right/FileViewer.tsx`
  - Consolidated the load-file effect with the pending-reveal pickup, and switched it from `useEffect` to `useLayoutEffect` so `loadStart` and the new `revealing` flag are committed synchronously.  
    This fixes the A→B switch flicker where the previous editor briefly shows under the new `filePath`.
  - Cleared `editorRef.current` at the start of every load so an in-flight `tryReveal` can't act on a now-disposed Monaco instance during file switches.
  - Added a React `revealing` state that drives `visibility: hidden` on a wrapper around `<Editor>`.  
    This replaces the previous DOM manipulation on `editor.getDomNode()`, which was racy with Monaco's first paint and caused intermittent top-of-file flashes.
  - In `handleEditorMount`, forces `editorInstance.layout()` and calls `tryReveal()` inside a single `requestAnimationFrame`.  
    Monaco's viewport isn't laid out at `onMount` time, so an immediate `revealLineInCenter` would land at line 1.
  - `tryReveal` now uses `ScrollType.Immediate (1)` to skip Monaco's smooth-scroll animation.
  - Hardened the binary-file branch to drain a stray pending target without setting `revealing`, ensuring the flag never gets stuck for files that never mount an editor.

## How to test

1. yarn dev.
2. Open the right panel Search tab and search for a term that matches across multiple files.
3. Cold first open --> with no file currently open in the center, click any search result. Expected: the file opens and the matching line is centered in the editor on the first click. No top-of-file flash, no scroll animation.
4. Cross-file switch --> click a result in file A, then click a result in a different file B. Expected: B's matching line is centered immediately; you should not see a frame of A's content with B's filename, nor a frame of B at line 1.
5. Same-file jump --> click two different results within the same file in succession. Expected: instant centered jumps.
6. Regression --> non-search openers: open files via tabs, QuickOpen (⌘P), the file tree, a tool-call row in chat, the code review view, and a check's "open" action. Expected: identical behavior to main, no hidden editor, no spurious loading state.
7. Regression --> markdown preview: open a .md file, toggle preview on/off. Expected: works as before.
8. Regression --> binary file: open an image or other binary file. Expected: BinaryImagePreview / BinaryPlaceholder renders normally.
9. yarn typecheck passes.

## Screenshots

### Before The Changes

https://github.com/user-attachments/assets/3a60c8ab-7fc1-4cd4-8450-b103b4830bf3


### After The Changes


https://github.com/user-attachments/assets/71761831-6815-49ed-a1ef-9e603150343e


## Checklist

- [X] Self-reviewed the diff
- [X] Tested locally with `yarn dev`
- [X] Types pass — `yarn typecheck`
- [X] No console errors or warnings in DevTools
- [X] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [X] New state is added to the correct Zustand store
