### PR TITLE
fix(chat): submit AskUserQuestion answers keyed by question text

### DIFF
--- a/src/renderer/components/Center/AskUserQuestionPrompt.tsx
+++ b/src/renderer/components/Center/AskUserQuestionPrompt.tsx
@@ -42,16 +42,13 @@ export function AskUserQuestionPrompt({ pendingQuestion, onSubmit }: Props) {
 
   const handleSubmit = () => {
     // SDK keys answers by question text, not header (AskUserQuestionOutput in
-    // @anthropic-ai/claude-agent-sdk). Free-text "other" overrides selections.
+    // @anthropic-ai/claude-agent-sdk).
     const final: Record<string, string> = {}
     for (const q of pendingQuestion.questions) {
+      const answers = (selections[q.header] ?? []).filter((l) => l !== '__other__')
       const other = otherValues[q.header]?.trim()
-      if (other) {
-        final[q.question] = other
-        continue
-      }
-      const labels = (selections[q.header] ?? []).filter((l) => l !== '__other__')
-      if (labels.length) final[q.question] = labels.join(', ')
+      if (other) answers.push(other)
+      if (answers.length) final[q.question] = answers.join(', ')
     }
     onSubmit(final)
   }

--- a/src/renderer/components/Center/AskUserQuestionPrompt.tsx
+++ b/src/renderer/components/Center/AskUserQuestionPrompt.tsx
@@ -41,13 +41,17 @@ export function AskUserQuestionPrompt({ pendingQuestion, onSubmit }: Props) {
   }
 
   const handleSubmit = () => {
-    // Convert selections arrays to comma-separated strings; merge "other" free-text
+    // SDK keys answers by question text, not header (AskUserQuestionOutput in
+    // @anthropic-ai/claude-agent-sdk). Free-text "other" overrides selections.
     const final: Record<string, string> = {}
-    for (const [header, labels] of Object.entries(selections)) {
-      final[header] = labels.filter((l) => l !== '__other__').join(', ')
-    }
-    for (const [header, text] of Object.entries(otherValues)) {
-      if (text.trim()) final[header] = text.trim()
+    for (const q of pendingQuestion.questions) {
+      const other = otherValues[q.header]?.trim()
+      if (other) {
+        final[q.question] = other
+        continue
+      }
+      const labels = (selections[q.header] ?? []).filter((l) => l !== '__other__')
+      if (labels.length) final[q.question] = labels.join(', ')
     }
     onSubmit(final)
   }


### PR DESCRIPTION
## Summary
- Braid was sending `AskUserQuestion` answers keyed by `q.header` (the short chip label), but the Claude Agent SDK expects them keyed by `q.question` (the full question text — see `AskUserQuestionOutput` in `@anthropic-ai/claude-agent-sdk`: *"question text -> answer string"*).
- As a result, the SDK couldn't correlate the user's selections with the asked questions, and Claude effectively saw the answers as unreadable.
- Fix: iterate `pendingQuestion.questions` and emit each answer under `q.question`. Drops the now-unnecessary header→question lookup and makes the "other" override precedence explicit.

## Root cause
- Schema (`AskUserQuestionOutput.answers`, `sdk-tools.d.ts:2666`): keys are question text → answer string.
- SDK CLI uses `answers[V.question]` when rendering / formatting the tool result back to the model.
- `AskUserQuestionPrompt.tsx#handleSubmit` previously keyed `final` by `header`, so the lookup failed silently downstream.

## Test plan
- [ ] Run a session and trigger `AskUserQuestion` with a single question — verify Claude correctly reads the chosen option.
- [ ] Trigger `AskUserQuestion` with multiple questions — verify Claude correlates each answer with the right question.
- [ ] Select the "Other" option and submit free-text — verify Claude reads the typed value.
- [ ] Multi-select question: pick several options + Other (no text) — verify Claude reads the joined labels.
- [ ] `yarn test` passes (pre-existing unrelated failures in `lsp/helpers` and `useSwipeNavigation` remain).