### PR TITLE
feat: default new tab action to Claude Code terminal

### DIFF
--- a/src/renderer/store/ui/settings.ts
+++ b/src/renderer/store/ui/settings.ts
@@ -192,8 +192,8 @@ export const createSettingsSlice: StateCreator<UIState, [], [], SettingsSlice> =
   })(),
 
   lastNewTabAction: (() => {
-    const v = loadStr(SK.lastNewTabAction, 'chat')
-    return VALID_NEW_TAB_ACTIONS.has(v) ? v as NewTabAction : 'chat'
+    const v = loadStr(SK.lastNewTabAction, 'claudeCode')
+    return VALID_NEW_TAB_ACTIONS.has(v) ? v as NewTabAction : 'claudeCode'
   })(),
   streamingAnimation: loadBool(SK.streamingAnimation, true),
 


### PR DESCRIPTION
## Summary

- Change the default `lastNewTabAction` from `chat` to `claudeCode` so new users (or users without saved preferences) get a Claude Code terminal when clicking "+"

## Layers touched

- [x] **Renderer** (`src/renderer/`) — components, stores, lib

## Changes

**Stores** (`projects.ts` / `sessions.ts` / `ui.ts`):
- `src/renderer/store/ui/settings.ts` — changed default fallback for `lastNewTabAction` from `'chat'` to `'claudeCode'`

## How to test

1. `yarn dev`
2. Clear `braid:lastNewTabAction` from localStorage (or use a fresh profile)
3. Click the "+" button in the tab bar - should open a Claude Code terminal instead of a new chat
4. Existing users with a saved preference are unaffected

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store