### PR TITLE
feat: terminal agent notifications and persist active center view

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -131,8 +131,8 @@ export function registerIpcHandlers(): void {
   ipcMain.handle('agent:updateSessionName', (_e, sessionId: string, name: string) =>
     agentService.updateSessionName(sessionId, name)
   )
-  ipcMain.handle('agent:notify', (_e, sessionId: string, type: 'done' | 'error' | 'waiting_input', sessionName?: string, errorMessage?: string, reason?: 'question' | 'plan_approval') =>
-    agentService.notify(sessionId, type, sessionName, errorMessage, reason)
+  ipcMain.handle('agent:notify', (_e, sessionId: string, type: 'done' | 'error' | 'waiting_input', sessionName?: string, errorMessage?: string, reason?: 'question' | 'plan_approval', branch?: string, projectName?: string) =>
+    agentService.notify(sessionId, type, sessionName, errorMessage, reason, branch, projectName)
   )
   ipcMain.handle('agent:getSlashCommands', (_e, cwd: string) =>
     agentService.getSlashCommands(cwd)

--- a/src/main/services/agent.ts
+++ b/src/main/services/agent.ts
@@ -256,11 +256,23 @@ class AgentCoordinator {
     type: 'done' | 'error' | 'waiting_input',
     sessionName?: string,
     errorMessage?: string,
-    reason?: 'question' | 'plan_approval'
+    reason?: 'question' | 'plan_approval',
+    branch?: string,
+    projectName?: string
   ): void {
     if (sessionName) {
       const meta = this.sessionMeta.get(sessionId)
-      if (meta) meta.sessionName = sessionName
+      if (meta) {
+        meta.sessionName = sessionName
+      } else {
+        // Create ephemeral meta for terminal-originated notifications
+        this.sessionMeta.set(sessionId, {
+          sessionName,
+          cwd: '',
+          branch: branch ?? '',
+          projectName: projectName ?? ''
+        })
+      }
     }
     this.maybeNotify(sessionId, type, errorMessage, reason)
   }

--- a/src/main/services/agent.ts
+++ b/src/main/services/agent.ts
@@ -275,6 +275,11 @@ class AgentCoordinator {
       }
     }
     this.maybeNotify(sessionId, type, errorMessage, reason)
+
+    // Clean up ephemeral meta to avoid polluting uniqueProjects count
+    if (!this.sessionProcesses.has(sessionId)) {
+      this.sessionMeta.delete(sessionId)
+    }
   }
 
   answerToolInput(sessionId: string, result: Record<string, unknown>): void {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -86,8 +86,8 @@ const api = {
       ipcRenderer.invoke('agent:sendMessage', sessionId, message, sdkSessionId, cwd, model, extendedContext, effortLevel, planMode, sessionName, images, additionalDirectories, linkedWorktreeContext, connectedDeviceId, mobileFramework, resumeSessionAt),
     updateSessionName: (sessionId: string, name: string) =>
       ipcRenderer.invoke('agent:updateSessionName', sessionId, name),
-    notify: (sessionId: string, type: 'done' | 'error' | 'waiting_input', sessionName?: string, errorMessage?: string, reason?: 'question' | 'plan_approval') =>
-      ipcRenderer.invoke('agent:notify', sessionId, type, sessionName, errorMessage, reason),
+    notify: (sessionId: string, type: 'done' | 'error' | 'waiting_input', sessionName?: string, errorMessage?: string, reason?: 'question' | 'plan_approval', branch?: string, projectName?: string) =>
+      ipcRenderer.invoke('agent:notify', sessionId, type, sessionName, errorMessage, reason, branch, projectName),
     getSlashCommands: (cwd: string) =>
       ipcRenderer.invoke('agent:getSlashCommands', cwd),
     answerToolInput: (sessionId: string, result: Record<string, unknown>) =>

--- a/src/renderer/components/Center/bigTerminalCache.ts
+++ b/src/renderer/components/Center/bigTerminalCache.ts
@@ -9,7 +9,9 @@ import { registerTitleDetection } from '@/lib/agentTitleDetection'
 import { replayIntoTerminal, isReplaying, POST_REPLAY_MODE_RESET } from '@/lib/replayGuard'
 import type { AgentStatusPayload, AgentStatusState } from '@/lib/agentStatus'
 import { createCompletionCoordinator, type CompletionCoordinator } from '@/lib/agentCompletionCoordinator'
+import { notifyTerminalStateChange, clearTerminalNotificationState } from '@/lib/terminalNotifications'
 import { useUIStore } from '@/store/ui'
+import { useToastsStore } from '@/store/toasts'
 
 export interface BigTermEntry {
   terminalId: string
@@ -73,6 +75,7 @@ function ensureHookListener(): void {
       payload.state,
       interrupted ?? false
     )
+    notifyTerminalStateChange(terminalId, payload.state)
   })
 }
 
@@ -129,11 +132,13 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
   registerAgentStatusOsc(term, (payload) => {
     updateStatus(payload)
     completionCoordinator.observeHookStatus(payload.state, payload.interrupted)
+    notifyTerminalStateChange(terminalId, payload.state)
   })
 
   registerTitleDetection(term, (result) => {
     updateStatus({ state: result.state, agentType: result.agentType ?? undefined })
     completionCoordinator.observeTitleStatus(result.state)
+    notifyTerminalStateChange(terminalId, result.state)
   })
 
   // OSC 9 (Braid hooks): Claude Code hooks return terminalSequence with
@@ -141,6 +146,7 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
   registerBraidOsc9(term, (payload) => {
     updateStatus(payload)
     completionCoordinator.observeHookStatus(payload.state, false)
+    notifyTerminalStateChange(terminalId, payload.state)
   })
 
   entry.spawnPromise = (async () => {
@@ -217,6 +223,9 @@ export function disposeBigTerminal(terminalId: string): void {
   try { ipc.pty.deleteScrollback(terminalId) } catch {}
   // Clear ephemeral agent status from store
   try { useUIStore.getState().clearBigTerminalStatus(terminalId) } catch {}
+  // Dismiss any toasts and clear dedup state for this terminal
+  try { useToastsStore.getState().dismissByTerminal(terminalId) } catch {}
+  clearTerminalNotificationState(terminalId)
 }
 
 /** Dispose many at once (e.g. on worktree removal). */

--- a/src/renderer/components/Center/bigTerminalCache.ts
+++ b/src/renderer/components/Center/bigTerminalCache.ts
@@ -98,7 +98,7 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
   const { term, fitAddon, searchAddon } = createTerminal()
 
   // Completion coordinator fires when an agent finishes a task.
-  // Currently logs - can be wired to toast notifications or dock badge later.
+  // Toast + desktop notifications are handled by notifyTerminalStateChange.
   const completionCoordinator = createCompletionCoordinator({
     onComplete: (source, interrupted) => {
       console.debug(`[terminal:${terminalId}] Agent completed (source=${source}, interrupted=${interrupted})`)

--- a/src/renderer/components/shared/ToastContainer.tsx
+++ b/src/renderer/components/shared/ToastContainer.tsx
@@ -23,8 +23,12 @@ function dismissReducer(state: Set<string>, action: Action): Set<string> {
 
 function navigateToSession(toast: ToastType): void {
   useUIStore.getState().selectWorktree(toast.projectId, toast.worktreeId)
-  useSessionsStore.getState().setActiveSession(toast.sessionId)
-  useUIStore.getState().setActiveCenterView({ type: 'session', sessionId: toast.sessionId })
+  if (toast.terminalId) {
+    useUIStore.getState().setActiveCenterView({ type: 'terminal', terminalId: toast.terminalId })
+  } else {
+    useSessionsStore.getState().setActiveSession(toast.sessionId)
+    useUIStore.getState().setActiveCenterView({ type: 'session', sessionId: toast.sessionId })
+  }
   useUIStore.getState().setMissionControlActive(false)
 }
 

--- a/src/renderer/lib/__tests__/terminalNotifications.test.ts
+++ b/src/renderer/lib/__tests__/terminalNotifications.test.ts
@@ -114,6 +114,12 @@ describe('notifyTerminalStateChange', () => {
     expect(mockAddToast).toHaveBeenCalledOnce()
   })
 
+  it('deduplicates blocked after waiting (same notification type)', () => {
+    notifyTerminalStateChange('bt-1', 'waiting')
+    notifyTerminalStateChange('bt-1', 'blocked')
+    expect(mockAddToast).toHaveBeenCalledOnce()
+  })
+
   it('allows notification after state change', () => {
     notifyTerminalStateChange('bt-1', 'done')
     notifyTerminalStateChange('bt-1', 'working')  // skip (working)

--- a/src/renderer/lib/__tests__/terminalNotifications.test.ts
+++ b/src/renderer/lib/__tests__/terminalNotifications.test.ts
@@ -35,6 +35,7 @@ const DEFAULT_UI_STATE = {
     'wt-2': [{ id: 'bt-2', label: 'Claude Code' }],
   },
   activeCenterViewByWorktree: {},
+  selectedWorktreeId: 'wt-1',
   notifyOnDone: true,
   notifyOnWaitingInput: true,
   inAppNotifications: true,
@@ -58,7 +59,7 @@ beforeEach(() => {
   clearTerminalNotificationState('bt-1')
   clearTerminalNotificationState('bt-2')
   // Restore default mock implementations
-  vi.mocked(useUIStore.getState).mockReturnValue(DEFAULT_UI_STATE as ReturnType<typeof useUIStore.getState>)
+  vi.mocked(useUIStore.getState).mockReturnValue(DEFAULT_UI_STATE as unknown as ReturnType<typeof useUIStore.getState>)
   vi.mocked(useProjectsStore.getState).mockReturnValue(DEFAULT_PROJECTS_STATE as ReturnType<typeof useProjectsStore.getState>)
 })
 
@@ -120,7 +121,7 @@ describe('notifyTerminalStateChange', () => {
     expect(mockAddToast).toHaveBeenCalledTimes(2)
   })
 
-  it('skips done toast when terminal is focused', () => {
+  it('skips done toast and desktop notification when terminal is focused', () => {
     vi.mocked(useUIStore.getState).mockReturnValue({
       bigTerminalsByWorktree: {
         'wt-1': [{ id: 'bt-1', label: 'Terminal 1' }],
@@ -128,13 +129,35 @@ describe('notifyTerminalStateChange', () => {
       activeCenterViewByWorktree: {
         'wt-1': { type: 'terminal', terminalId: 'bt-1' },
       },
+      selectedWorktreeId: 'wt-1',
       notifyOnDone: true,
       notifyOnWaitingInput: true,
       inAppNotifications: true,
-    } as ReturnType<typeof useUIStore.getState>)
+    } as unknown as ReturnType<typeof useUIStore.getState>)
 
     notifyTerminalStateChange('bt-1', 'done')
     expect(mockAddToast).not.toHaveBeenCalled()
+    expect(mockNotify).not.toHaveBeenCalled()
+  })
+
+  it('fires done notification when terminal view is active but different worktree is selected', () => {
+    vi.mocked(useUIStore.getState).mockReturnValue({
+      bigTerminalsByWorktree: {
+        'wt-1': [{ id: 'bt-1', label: 'Terminal 1' }],
+        'wt-2': [{ id: 'bt-2', label: 'Claude Code' }],
+      },
+      activeCenterViewByWorktree: {
+        'wt-1': { type: 'terminal', terminalId: 'bt-1' },
+      },
+      selectedWorktreeId: 'wt-2',
+      notifyOnDone: true,
+      notifyOnWaitingInput: true,
+      inAppNotifications: true,
+    } as unknown as ReturnType<typeof useUIStore.getState>)
+
+    notifyTerminalStateChange('bt-1', 'done')
+    expect(mockAddToast).toHaveBeenCalledOnce()
+    expect(mockNotify).toHaveBeenCalledOnce()
   })
 
   it('still fires waiting_input when terminal is focused', () => {
@@ -145,10 +168,11 @@ describe('notifyTerminalStateChange', () => {
       activeCenterViewByWorktree: {
         'wt-1': { type: 'terminal', terminalId: 'bt-1' },
       },
+      selectedWorktreeId: 'wt-1',
       notifyOnDone: true,
       notifyOnWaitingInput: true,
       inAppNotifications: true,
-    } as ReturnType<typeof useUIStore.getState>)
+    } as unknown as ReturnType<typeof useUIStore.getState>)
 
     notifyTerminalStateChange('bt-1', 'waiting')
     expect(mockAddToast).toHaveBeenCalledOnce()
@@ -160,10 +184,11 @@ describe('notifyTerminalStateChange', () => {
         'wt-1': [{ id: 'bt-1', label: 'Terminal 1' }],
       },
       activeCenterViewByWorktree: {},
+      selectedWorktreeId: 'wt-1',
       notifyOnDone: false,
       notifyOnWaitingInput: true,
       inAppNotifications: true,
-    } as ReturnType<typeof useUIStore.getState>)
+    } as unknown as ReturnType<typeof useUIStore.getState>)
 
     notifyTerminalStateChange('bt-1', 'done')
     expect(mockAddToast).not.toHaveBeenCalled()
@@ -175,10 +200,11 @@ describe('notifyTerminalStateChange', () => {
         'wt-1': [{ id: 'bt-1', label: 'Terminal 1' }],
       },
       activeCenterViewByWorktree: {},
+      selectedWorktreeId: 'wt-1',
       notifyOnDone: true,
       notifyOnWaitingInput: true,
       inAppNotifications: false,
-    } as ReturnType<typeof useUIStore.getState>)
+    } as unknown as ReturnType<typeof useUIStore.getState>)
 
     notifyTerminalStateChange('bt-1', 'done')
     expect(mockAddToast).not.toHaveBeenCalled()

--- a/src/renderer/lib/__tests__/terminalNotifications.test.ts
+++ b/src/renderer/lib/__tests__/terminalNotifications.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockAddToast = vi.fn()
+const mockNotify = vi.fn()
+
+vi.mock('@/store/ui', () => ({
+  useUIStore: { getState: vi.fn() },
+}))
+
+vi.mock('@/store/projects', () => ({
+  useProjectsStore: { getState: vi.fn() },
+}))
+
+vi.mock('@/store/toasts', () => ({
+  useToastsStore: {
+    getState: vi.fn(() => ({ addToast: mockAddToast })),
+  },
+}))
+
+vi.mock('@/lib/ipc', () => ({
+  agent: { notify: (...args: unknown[]) => mockNotify(...args) },
+}))
+
+// ── Import after mocks ──────────────────────────────────────────────────────
+
+import { notifyTerminalStateChange, clearTerminalNotificationState } from '../terminalNotifications'
+import { useUIStore } from '@/store/ui'
+import { useProjectsStore } from '@/store/projects'
+
+const DEFAULT_UI_STATE = {
+  bigTerminalsByWorktree: {
+    'wt-1': [{ id: 'bt-1', label: 'Terminal 1' }],
+    'wt-2': [{ id: 'bt-2', label: 'Claude Code' }],
+  },
+  activeCenterViewByWorktree: {},
+  notifyOnDone: true,
+  notifyOnWaitingInput: true,
+  inAppNotifications: true,
+}
+
+const DEFAULT_PROJECTS_STATE = {
+  projects: [
+    {
+      id: 'proj-1',
+      name: 'my-app',
+      worktrees: [
+        { id: 'wt-1', branch: 'feature/test', path: '/path/wt-1' },
+        { id: 'wt-2', branch: 'main', path: '/path/wt-2' },
+      ],
+    },
+  ],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clearTerminalNotificationState('bt-1')
+  clearTerminalNotificationState('bt-2')
+  // Restore default mock implementations
+  vi.mocked(useUIStore.getState).mockReturnValue(DEFAULT_UI_STATE as ReturnType<typeof useUIStore.getState>)
+  vi.mocked(useProjectsStore.getState).mockReturnValue(DEFAULT_PROJECTS_STATE as ReturnType<typeof useProjectsStore.getState>)
+})
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('notifyTerminalStateChange', () => {
+  it('fires toast and desktop notification on done', () => {
+    notifyTerminalStateChange('bt-1', 'done')
+    expect(mockAddToast).toHaveBeenCalledOnce()
+    expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'done',
+      sessionId: '',
+      sessionName: 'Terminal 1',
+      terminalId: 'bt-1',
+      terminalLabel: 'Terminal 1',
+      worktreeId: 'wt-1',
+      worktreeBranch: 'feature/test',
+      projectId: 'proj-1',
+      projectName: '',  // single project
+    }))
+    expect(mockNotify).toHaveBeenCalledWith(
+      'bt-1', 'done', 'Terminal 1',
+      undefined, undefined,
+      'feature/test', 'my-app'
+    )
+  })
+
+  it('fires waiting_input for waiting state', () => {
+    notifyTerminalStateChange('bt-1', 'waiting')
+    expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'waiting_input',
+      terminalId: 'bt-1',
+    }))
+  })
+
+  it('fires waiting_input for blocked state', () => {
+    notifyTerminalStateChange('bt-1', 'blocked')
+    expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'waiting_input',
+    }))
+  })
+
+  it('skips notification for working state', () => {
+    notifyTerminalStateChange('bt-1', 'working')
+    expect(mockAddToast).not.toHaveBeenCalled()
+    expect(mockNotify).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates same state', () => {
+    notifyTerminalStateChange('bt-1', 'done')
+    notifyTerminalStateChange('bt-1', 'done')
+    expect(mockAddToast).toHaveBeenCalledOnce()
+  })
+
+  it('allows notification after state change', () => {
+    notifyTerminalStateChange('bt-1', 'done')
+    notifyTerminalStateChange('bt-1', 'working')  // skip (working)
+    notifyTerminalStateChange('bt-1', 'done')
+    expect(mockAddToast).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips done toast when terminal is focused', () => {
+    vi.mocked(useUIStore.getState).mockReturnValue({
+      bigTerminalsByWorktree: {
+        'wt-1': [{ id: 'bt-1', label: 'Terminal 1' }],
+      },
+      activeCenterViewByWorktree: {
+        'wt-1': { type: 'terminal', terminalId: 'bt-1' },
+      },
+      notifyOnDone: true,
+      notifyOnWaitingInput: true,
+      inAppNotifications: true,
+    } as ReturnType<typeof useUIStore.getState>)
+
+    notifyTerminalStateChange('bt-1', 'done')
+    expect(mockAddToast).not.toHaveBeenCalled()
+  })
+
+  it('still fires waiting_input when terminal is focused', () => {
+    vi.mocked(useUIStore.getState).mockReturnValue({
+      bigTerminalsByWorktree: {
+        'wt-1': [{ id: 'bt-1', label: 'Terminal 1' }],
+      },
+      activeCenterViewByWorktree: {
+        'wt-1': { type: 'terminal', terminalId: 'bt-1' },
+      },
+      notifyOnDone: true,
+      notifyOnWaitingInput: true,
+      inAppNotifications: true,
+    } as ReturnType<typeof useUIStore.getState>)
+
+    notifyTerminalStateChange('bt-1', 'waiting')
+    expect(mockAddToast).toHaveBeenCalledOnce()
+  })
+
+  it('skips toast when notifyOnDone is false', () => {
+    vi.mocked(useUIStore.getState).mockReturnValue({
+      bigTerminalsByWorktree: {
+        'wt-1': [{ id: 'bt-1', label: 'Terminal 1' }],
+      },
+      activeCenterViewByWorktree: {},
+      notifyOnDone: false,
+      notifyOnWaitingInput: true,
+      inAppNotifications: true,
+    } as ReturnType<typeof useUIStore.getState>)
+
+    notifyTerminalStateChange('bt-1', 'done')
+    expect(mockAddToast).not.toHaveBeenCalled()
+  })
+
+  it('skips toast when inAppNotifications is false but still fires desktop', () => {
+    vi.mocked(useUIStore.getState).mockReturnValue({
+      bigTerminalsByWorktree: {
+        'wt-1': [{ id: 'bt-1', label: 'Terminal 1' }],
+      },
+      activeCenterViewByWorktree: {},
+      notifyOnDone: true,
+      notifyOnWaitingInput: true,
+      inAppNotifications: false,
+    } as ReturnType<typeof useUIStore.getState>)
+
+    notifyTerminalStateChange('bt-1', 'done')
+    expect(mockAddToast).not.toHaveBeenCalled()
+    expect(mockNotify).toHaveBeenCalledOnce()
+  })
+
+  it('skips when terminal not found in any worktree', () => {
+    notifyTerminalStateChange('bt-unknown', 'done')
+    expect(mockAddToast).not.toHaveBeenCalled()
+    expect(mockNotify).not.toHaveBeenCalled()
+  })
+
+  it('includes projectName when 2+ projects exist', () => {
+    vi.mocked(useProjectsStore.getState).mockReturnValue({
+      projects: [
+        {
+          id: 'proj-1', name: 'my-app',
+          worktrees: [{ id: 'wt-1', branch: 'feature/test', path: '/p1' }],
+        },
+        {
+          id: 'proj-2', name: 'other-app',
+          worktrees: [{ id: 'wt-3', branch: 'main', path: '/p2' }],
+        },
+      ],
+    } as ReturnType<typeof useProjectsStore.getState>)
+
+    notifyTerminalStateChange('bt-1', 'done')
+    expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({
+      projectName: 'my-app',
+    }))
+  })
+})

--- a/src/renderer/lib/__tests__/terminalNotifications.test.ts
+++ b/src/renderer/lib/__tests__/terminalNotifications.test.ts
@@ -121,7 +121,7 @@ describe('notifyTerminalStateChange', () => {
     expect(mockAddToast).toHaveBeenCalledTimes(2)
   })
 
-  it('skips done toast and desktop notification when terminal is focused', () => {
+  it('skips done toast but still fires desktop notification when terminal is focused', () => {
     vi.mocked(useUIStore.getState).mockReturnValue({
       bigTerminalsByWorktree: {
         'wt-1': [{ id: 'bt-1', label: 'Terminal 1' }],
@@ -137,7 +137,8 @@ describe('notifyTerminalStateChange', () => {
 
     notifyTerminalStateChange('bt-1', 'done')
     expect(mockAddToast).not.toHaveBeenCalled()
-    expect(mockNotify).not.toHaveBeenCalled()
+    // Desktop notification still fires - maybeNotify has its own window-focus check
+    expect(mockNotify).toHaveBeenCalledOnce()
   })
 
   it('fires done notification when terminal view is active but different worktree is selected', () => {

--- a/src/renderer/lib/ipc.ts
+++ b/src/renderer/lib/ipc.ts
@@ -87,8 +87,8 @@ export const agent = {
   sendMessage: (sessionId: string, message: string, sdkSessionId: string, cwd: string, model: string, extendedContext: boolean, effortLevel: string, planMode: boolean, sessionName: string, images?: string[], additionalDirectories?: string[], linkedWorktreeContext?: string, connectedDeviceId?: string, mobileFramework?: string, resumeSessionAt?: string) =>
     api().agent.sendMessage(sessionId, message, sdkSessionId, cwd, model, extendedContext, effortLevel, planMode, sessionName, images, additionalDirectories, linkedWorktreeContext, connectedDeviceId, mobileFramework, resumeSessionAt),
   updateSessionName: (sessionId: string, name: string) => api().agent.updateSessionName(sessionId, name),
-  notify: (sessionId: string, type: 'done' | 'error' | 'waiting_input', sessionName?: string, errorMessage?: string, reason?: 'question' | 'plan_approval') =>
-    api().agent.notify(sessionId, type, sessionName, errorMessage, reason),
+  notify: (sessionId: string, type: 'done' | 'error' | 'waiting_input', sessionName?: string, errorMessage?: string, reason?: 'question' | 'plan_approval', branch?: string, projectName?: string) =>
+    api().agent.notify(sessionId, type, sessionName, errorMessage, reason, branch, projectName),
   getSlashCommands: (cwd: string) => api().agent.getSlashCommands(cwd),
   answerToolInput: (sessionId: string, result: Record<string, unknown>) =>
     api().agent.answerToolInput(sessionId, result),

--- a/src/renderer/lib/storageKeys.ts
+++ b/src/renderer/lib/storageKeys.ts
@@ -41,6 +41,8 @@ export const SK = {
   openFilePathsPrefix:        `${prefix}:openFilePaths:`,
   /** Prefix — unified tab order (sessions + files interleaved), keyed by worktree ID */
   tabOrderPrefix:             `${prefix}:tabOrder:`,
+  /** Prefix — active center view (session/file/terminal/changes), keyed by worktree ID */
+  activeCenterViewPrefix:     `${prefix}:activeCenterView:`,
 
   // ── Settings — AI ──────────────────────────────────────────────────────
   defaultModel:               `${prefix}:defaultModel`,

--- a/src/renderer/lib/terminalNotifications.ts
+++ b/src/renderer/lib/terminalNotifications.ts
@@ -1,0 +1,104 @@
+// ---------------------------------------------------------------------------
+// Terminal agent notifications - toasts + desktop notifications for big terminals
+// ---------------------------------------------------------------------------
+
+import type { AgentStatusState } from '@/lib/agentStatus'
+import { useUIStore } from '@/store/ui'
+import { useProjectsStore } from '@/store/projects'
+import { useToastsStore } from '@/store/toasts'
+import * as ipc from '@/lib/ipc'
+
+/** Track last notified state per terminal to dedup across detection sources. */
+const lastNotifiedState = new Map<string, AgentStatusState>()
+
+/** Find which worktree owns a given terminalId and return context for notifications. */
+function resolveTerminalContext(terminalId: string): {
+  worktreeId: string
+  branch: string
+  projectId: string
+  projectName: string
+  label: string
+} | null {
+  const ui = useUIStore.getState()
+  for (const [worktreeId, tabs] of Object.entries(ui.bigTerminalsByWorktree)) {
+    const tab = tabs.find((t) => t.id === terminalId)
+    if (!tab) continue
+    const project = useProjectsStore.getState().projects.find((p) =>
+      p.worktrees.some((w) => w.id === worktreeId)
+    )
+    const wt = project?.worktrees.find((w) => w.id === worktreeId)
+    if (!project || !wt) return null
+    return {
+      worktreeId,
+      branch: wt.branch,
+      projectId: project.id,
+      projectName: project.name,
+      label: tab.label,
+    }
+  }
+  return null
+}
+
+/** Check if the user is currently viewing this terminal in the center panel. */
+function isTerminalFocused(terminalId: string, worktreeId: string): boolean {
+  const view = useUIStore.getState().activeCenterViewByWorktree[worktreeId]
+  if (!view || view.type !== 'terminal') return false
+  return (view as { type: 'terminal'; terminalId: string }).terminalId === terminalId
+}
+
+/**
+ * Fire a toast + desktop notification when a terminal agent changes state.
+ * Called from multiple detection sources (hook, OSC, title) - dedup guard
+ * ensures only one notification per state transition.
+ */
+export function notifyTerminalStateChange(terminalId: string, state: AgentStatusState): void {
+  // Dedup: skip if we already saw this exact state (across detection sources)
+  if (lastNotifiedState.get(terminalId) === state) return
+  lastNotifiedState.set(terminalId, state)
+
+  // Only notify for actionable states
+  const type: 'done' | 'waiting_input' | null =
+    state === 'done' ? 'done'
+    : (state === 'waiting' || state === 'blocked') ? 'waiting_input'
+    : null
+  if (!type) return
+
+  // Check user preferences
+  const ui = useUIStore.getState()
+  if (type === 'done' && !ui.notifyOnDone) return
+  if (type === 'waiting_input' && !ui.notifyOnWaitingInput) return
+
+  const ctx = resolveTerminalContext(terminalId)
+  if (!ctx) return
+
+  // Skip if user is actively viewing this terminal (except for waiting_input)
+  if (type !== 'waiting_input' && isTerminalFocused(terminalId, ctx.worktreeId)) return
+
+  // Skip in-app toast if disabled
+  if (ui.inAppNotifications) {
+    const projectCount = useProjectsStore.getState().projects.length
+    useToastsStore.getState().addToast({
+      type,
+      sessionId: '',
+      sessionName: ctx.label,
+      worktreeId: ctx.worktreeId,
+      worktreeBranch: ctx.branch,
+      projectId: ctx.projectId,
+      projectName: projectCount >= 2 ? ctx.projectName : '',
+      terminalId,
+      terminalLabel: ctx.label,
+    })
+  }
+
+  // Desktop notification via existing infrastructure
+  ipc.agent.notify(
+    terminalId, type, ctx.label,
+    undefined, undefined,
+    ctx.branch, ctx.projectName
+  )
+}
+
+/** Clear dedup state when a terminal is disposed. */
+export function clearTerminalNotificationState(terminalId: string): void {
+  lastNotifiedState.delete(terminalId)
+}

--- a/src/renderer/lib/terminalNotifications.ts
+++ b/src/renderer/lib/terminalNotifications.ts
@@ -80,13 +80,14 @@ export function notifyTerminalStateChange(terminalId: string, state: AgentStatus
   const ctx = resolveTerminalContext(terminalId, ui.bigTerminalsByWorktree)
   if (!ctx) return
 
-  // Skip if user is actively viewing this terminal (except for waiting_input)
-  if (type !== 'waiting_input' && isTerminalFocused(
+  // Focus check only suppresses the in-app toast, not the desktop notification.
+  // The desktop path (maybeNotify) has its own window-focus check.
+  const focused = type !== 'waiting_input' && isTerminalFocused(
     terminalId, ctx.worktreeId,
     ui.selectedWorktreeId ?? null, ui.activeCenterViewByWorktree
-  )) return
+  )
 
-  if (ui.inAppNotifications) {
+  if (ui.inAppNotifications && !focused) {
     const projectCount = useProjectsStore.getState().projects.length
     useToastsStore.getState().addToast({
       type,

--- a/src/renderer/lib/terminalNotifications.ts
+++ b/src/renderer/lib/terminalNotifications.ts
@@ -61,14 +61,18 @@ function isTerminalFocused(
  * ensures only one notification per state transition.
  */
 export function notifyTerminalStateChange(terminalId: string, state: AgentStatusState): void {
-  // Dedup: skip if we already saw this exact state (across detection sources)
-  if (lastNotifiedState.get(terminalId) === state) return
-  lastNotifiedState.set(terminalId, state)
+  // Normalize blocked -> waiting for dedup: both map to the same notification
+  // type, and different detection sources can emit either for the same event.
+  const normalized: AgentStatusState = state === 'blocked' ? 'waiting' : state
+
+  // Dedup: skip if we already saw this state (across detection sources)
+  if (lastNotifiedState.get(terminalId) === normalized) return
+  lastNotifiedState.set(terminalId, normalized)
 
   // Only notify for actionable states (done, error, waiting/blocked)
   const type: 'done' | 'error' | 'waiting_input' | null =
-    state === 'done' ? 'done'
-    : (state === 'waiting' || state === 'blocked') ? 'waiting_input'
+    normalized === 'done' ? 'done'
+    : normalized === 'waiting' ? 'waiting_input'
     : null
   if (!type) return
 

--- a/src/renderer/lib/terminalNotifications.ts
+++ b/src/renderer/lib/terminalNotifications.ts
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import type { AgentStatusState } from '@/lib/agentStatus'
+import type { CenterView } from '@/store/ui/layout'
 import { useUIStore } from '@/store/ui'
 import { useProjectsStore } from '@/store/projects'
 import { useToastsStore } from '@/store/toasts'
@@ -12,15 +13,17 @@ import * as ipc from '@/lib/ipc'
 const lastNotifiedState = new Map<string, AgentStatusState>()
 
 /** Find which worktree owns a given terminalId and return context for notifications. */
-function resolveTerminalContext(terminalId: string): {
+function resolveTerminalContext(
+  terminalId: string,
+  bigTerminalsByWorktree: Record<string, { id: string; label: string }[]>
+): {
   worktreeId: string
   branch: string
   projectId: string
   projectName: string
   label: string
 } | null {
-  const ui = useUIStore.getState()
-  for (const [worktreeId, tabs] of Object.entries(ui.bigTerminalsByWorktree)) {
+  for (const [worktreeId, tabs] of Object.entries(bigTerminalsByWorktree)) {
     const tab = tabs.find((t) => t.id === terminalId)
     if (!tab) continue
     const project = useProjectsStore.getState().projects.find((p) =>
@@ -40,10 +43,16 @@ function resolveTerminalContext(terminalId: string): {
 }
 
 /** Check if the user is currently viewing this terminal in the center panel. */
-function isTerminalFocused(terminalId: string, worktreeId: string): boolean {
-  const view = useUIStore.getState().activeCenterViewByWorktree[worktreeId]
+function isTerminalFocused(
+  terminalId: string,
+  worktreeId: string,
+  selectedWorktreeId: string | null,
+  activeCenterViewByWorktree: Record<string, CenterView | null>
+): boolean {
+  if (selectedWorktreeId !== worktreeId) return false
+  const view = activeCenterViewByWorktree[worktreeId]
   if (!view || view.type !== 'terminal') return false
-  return (view as { type: 'terminal'; terminalId: string }).terminalId === terminalId
+  return view.terminalId === terminalId
 }
 
 /**
@@ -56,25 +65,27 @@ export function notifyTerminalStateChange(terminalId: string, state: AgentStatus
   if (lastNotifiedState.get(terminalId) === state) return
   lastNotifiedState.set(terminalId, state)
 
-  // Only notify for actionable states
-  const type: 'done' | 'waiting_input' | null =
+  // Only notify for actionable states (done, error, waiting/blocked)
+  const type: 'done' | 'error' | 'waiting_input' | null =
     state === 'done' ? 'done'
     : (state === 'waiting' || state === 'blocked') ? 'waiting_input'
     : null
   if (!type) return
 
-  // Check user preferences
+  // Read UI state once and thread it through
   const ui = useUIStore.getState()
   if (type === 'done' && !ui.notifyOnDone) return
   if (type === 'waiting_input' && !ui.notifyOnWaitingInput) return
 
-  const ctx = resolveTerminalContext(terminalId)
+  const ctx = resolveTerminalContext(terminalId, ui.bigTerminalsByWorktree)
   if (!ctx) return
 
   // Skip if user is actively viewing this terminal (except for waiting_input)
-  if (type !== 'waiting_input' && isTerminalFocused(terminalId, ctx.worktreeId)) return
+  if (type !== 'waiting_input' && isTerminalFocused(
+    terminalId, ctx.worktreeId,
+    ui.selectedWorktreeId ?? null, ui.activeCenterViewByWorktree
+  )) return
 
-  // Skip in-app toast if disabled
   if (ui.inAppNotifications) {
     const projectCount = useProjectsStore.getState().projects.length
     useToastsStore.getState().addToast({

--- a/src/renderer/store/toasts.ts
+++ b/src/renderer/store/toasts.ts
@@ -51,7 +51,7 @@ export const useToastsStore = create<ToastsState>((set) => ({
       // Prevent duplicate: key by terminalId+type for terminal toasts, sessionId+type otherwise
       const isDupe = data.terminalId
         ? s.toasts.some((t) => t.terminalId === data.terminalId && t.type === data.type)
-        : s.toasts.some((t) => t.sessionId === data.sessionId && t.type === data.type)
+        : s.toasts.some((t) => !t.terminalId && t.sessionId === data.sessionId && t.type === data.type)
       if (isDupe) return s
 
       // Play notification sound (outside state update to avoid side-effect issues)

--- a/src/renderer/store/toasts.ts
+++ b/src/renderer/store/toasts.ts
@@ -20,6 +20,10 @@ export interface Toast {
   projectId: string
   /** Non-empty only when 2+ projects are open (avoids noise for single-project users) */
   projectName: string
+  /** Present when toast is for a big terminal (not a chat session) */
+  terminalId?: string
+  /** Display label for the terminal, e.g. "Terminal 1", "Claude Code" */
+  terminalLabel?: string
   createdAt: number
 }
 
@@ -29,6 +33,7 @@ interface ToastsState {
   dismissToast: (id: string) => void
   dismissByType: (type: Toast['type']) => void
   dismissBySession: (sessionId: string) => void
+  dismissByTerminal: (terminalId: string) => void
 }
 
 let counter = 0
@@ -43,10 +48,11 @@ export const useToastsStore = create<ToastsState>((set) => ({
     const toast: Toast = { ...data, id, createdAt: Date.now() }
 
     set((s) => {
-      // Prevent duplicate: same session + same type already exists
-      if (s.toasts.some((t) => t.sessionId === data.sessionId && t.type === data.type)) {
-        return s
-      }
+      // Prevent duplicate: key by terminalId+type for terminal toasts, sessionId+type otherwise
+      const isDupe = data.terminalId
+        ? s.toasts.some((t) => t.terminalId === data.terminalId && t.type === data.type)
+        : s.toasts.some((t) => t.sessionId === data.sessionId && t.type === data.type)
+      if (isDupe) return s
 
       // Play notification sound (outside state update to avoid side-effect issues)
       if (useUIStore.getState().notificationSound) {
@@ -77,5 +83,9 @@ export const useToastsStore = create<ToastsState>((set) => ({
 
   dismissBySession: (sessionId) => {
     set((s) => ({ toasts: s.toasts.filter((t) => t.sessionId !== sessionId) }))
+  },
+
+  dismissByTerminal: (terminalId) => {
+    set((s) => ({ toasts: s.toasts.filter((t) => t.terminalId !== terminalId) }))
   }
 }))

--- a/src/renderer/store/ui/layout.ts
+++ b/src/renderer/store/ui/layout.ts
@@ -243,6 +243,10 @@ export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (se
       try {
         localStorage.setItem(SK.openFilePathsPrefix + prevWorktreeId, JSON.stringify(get().openFilePaths))
         localStorage.setItem(SK.tabOrderPrefix + prevWorktreeId, JSON.stringify(get().tabOrder))
+        const prevView = get().activeCenterViewByWorktree[prevWorktreeId]
+        if (prevView) {
+          localStorage.setItem(SK.activeCenterViewPrefix + prevWorktreeId, JSON.stringify(prevView))
+        }
       } catch {}
     }
 
@@ -264,10 +268,23 @@ export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (se
       }
     } catch {}
 
+    let restoredCenterView: CenterView | null = null
+    try {
+      const raw = localStorage.getItem(SK.activeCenterViewPrefix + worktreeId)
+      if (raw) {
+        restoredCenterView = JSON.parse(raw) as CenterView
+      }
+    } catch {}
+
     try {
       localStorage.setItem(SK.selectedProjectId, projectId)
       localStorage.setItem(SK.selectedWorktreeId, worktreeId)
     } catch {}
+
+    const nextActiveCenterView = { ...get().activeCenterViewByWorktree }
+    if (restoredCenterView) {
+      nextActiveCenterView[worktreeId] = restoredCenterView
+    }
 
     set({
       selectedProjectId: projectId,
@@ -276,6 +293,7 @@ export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (se
       openFilePaths: restoredFiles,
       tabOrder: restoredTabOrder,
       dirtyFilePaths: new Set(),
+      activeCenterViewByWorktree: nextActiveCenterView,
     })
     // Hydrate persisted big terminal tabs for the target worktree (idempotent)
     get().restoreBigTerminalsForWorktree(worktreeId)
@@ -468,6 +486,9 @@ export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (se
   setActiveCenterView: (view) => {
     const wtId = get().selectedWorktreeId ?? ''
     set({ activeCenterViewByWorktree: { ...get().activeCenterViewByWorktree, [wtId]: view } })
+    if (wtId) {
+      try { localStorage.setItem(SK.activeCenterViewPrefix + wtId, JSON.stringify(view)) } catch {}
+    }
   },
 
   setFileDirty: (path, dirty) => {

--- a/src/renderer/store/ui/layout.ts
+++ b/src/renderer/store/ui/layout.ts
@@ -706,6 +706,7 @@ export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (se
     // Also clear persisted per-worktree localStorage entries
     try { localStorage.removeItem(SK.openFilePathsPrefix + worktreeId) } catch {}
     try { localStorage.removeItem(SK.tabOrderPrefix + worktreeId) } catch {}
+    try { localStorage.removeItem(SK.activeCenterViewPrefix + worktreeId) } catch {}
   },
 })
 

--- a/src/renderer/store/ui/layout.ts
+++ b/src/renderer/store/ui/layout.ts
@@ -217,7 +217,16 @@ export const createLayoutSlice: StateCreator<UIState, [], [], LayoutSlice> = (se
     return []
   })(),
   dirtyFilePaths: new Set(),
-  activeCenterViewByWorktree: {},
+  activeCenterViewByWorktree: (() => {
+    try {
+      const wtId = loadStr(SK.selectedWorktreeId, '')
+      if (wtId) {
+        const raw = localStorage.getItem(SK.activeCenterViewPrefix + wtId)
+        if (raw) return { [wtId]: JSON.parse(raw) as CenterView }
+      }
+    } catch {}
+    return {}
+  })(),
   skipDeleteWorktreeConfirm: localStorage.getItem(SK.skipDeleteWorktreeConfirm) === 'true',
   newlyAddedWorktreeId: null,
   projectAvatarVisible: loadBool(SK.projectAvatarVisible, true),


### PR DESCRIPTION
## Summary

- Add toast + desktop notifications when terminal agents finish or need input, matching the existing session notification system
- Persist the active center view (chat/file/terminal/changes) per worktree across switches, so the user returns to what they were looking at
- Extend the `agent:notify` IPC with `branch` and `projectName` params so terminal notifications show useful context

## Layers touched

- [x] **Main process** (`src/main/`) — services, IPC handlers
- [x] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib

## Changes

**Center:**
- `bigTerminalCache.ts` — hook into `notifyTerminalStateChange` from all three detection sources (hook, OSC, title); clean up notification state on terminal dispose

**Stores** (`toasts.ts` / `ui/layout.ts`):
- `toasts.ts` — add `terminalId`/`terminalLabel` fields to `Toast`, add `dismissByTerminal()`, fix dedup logic to key by terminalId for terminal toasts
- `ui/layout.ts` — persist and restore `activeCenterViewByWorktree` in localStorage on worktree switch; persist on `setActiveCenterView`

**Services** (`agent.ts`):
- `agent.ts` — accept `branch`/`projectName` in `notify()`, create ephemeral session meta for terminal notifications so desktop notifications include branch/project context

**IPC** (`main/ipc.ts` → `preload/index.ts` → `lib/ipc.ts`):
- Thread `branch` and `projectName` params through all 3 IPC layers for `agent:notify`

**New files:**
- `lib/terminalNotifications.ts` — resolves terminal context (worktree, branch, project), dedup guard across detection sources, fires toast + desktop notification
- `lib/__tests__/terminalNotifications.test.ts` — 239-line test suite covering all notification scenarios (done, waiting, dedup, focus suppression, multi-project)

**Shared:**
- `ToastContainer.tsx` — navigate to terminal view (not chat) when clicking a terminal toast
- `storageKeys.ts` — add `activeCenterViewPrefix` key

## How to test

1. `yarn dev`
2. Open a big terminal and run `claude` (or any agent)
3. Switch to a different worktree while the agent is working
4. When the agent finishes, verify a toast appears and clicking it navigates back to the terminal
5. Switch between worktrees and verify the center view (chat vs terminal vs file) is restored correctly
6. Run `yarn test terminalNotifications` to verify unit tests pass

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [x] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store