### PR TITLE
feat(pty): PTY daemon for terminal session persistence

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -10,7 +10,8 @@ export default defineConfig({
         external: ['node-pty'],
         input: {
           index: resolve('src/main/index.ts'),
-          agentProcess: resolve('src/main/services/agentProcess.ts')
+          agentProcess: resolve('src/main/services/agentProcess.ts'),
+          daemonMain: resolve('src/main/services/ptyDaemon/daemonMain.ts')
         },
         output: {
           entryFileNames: '[name].js'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,6 +29,7 @@ import { initAutoUpdater, stopAutoUpdater } from './services/autoUpdate'
 import { waitForEnrichedEnv } from './lib/enrichedEnv'
 import { ensureBraidHooks } from './services/hookInstaller'
 import { startAgentHookServer, stopAgentHookServer } from './services/agentHookServer'
+import { ptyService } from './services/pty'
 
 // Prevent EPIPE errors from crashing the process when stdout/stderr pipes break
 // (common in Electron when the renderer detaches or during hot-reload).
@@ -184,6 +185,13 @@ app.whenReady().then(async () => {
   })
 
   registerIpcHandlers()
+
+  // Ensure the PTY daemon is running (non-blocking)
+  if ('ensureDaemon' in ptyService && typeof ptyService.ensureDaemon === 'function') {
+    ptyService.ensureDaemon().catch((err: unknown) =>
+      console.warn('[pty-daemon] Failed to start daemon:', err)
+    )
+  }
 
   // Start the agent hook HTTP server, then install Claude Code hooks.
   // The server must be running before hooks are installed so the port is known.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -175,6 +175,18 @@ export function registerIpcHandlers(): void {
     ptyService.registerBigTerminal(ptyId, terminalId))
   ipcMain.handle('pty:readScrollback', (_e, terminalId: string) => ptyService.readScrollback(terminalId))
   ipcMain.on('pty:deleteScrollback', (_e, terminalId: string) => ptyService.deleteScrollback(terminalId))
+  ipcMain.handle('pty:reattach', (_e, sessionId: string) => {
+    if ('reattach' in ptyService && typeof ptyService.reattach === 'function') {
+      return ptyService.reattach(sessionId)
+    }
+    return null
+  })
+  ipcMain.handle('pty:listSessions', () => {
+    if ('listSessions' in ptyService && typeof ptyService.listSessions === 'function') {
+      return ptyService.listSessions()
+    }
+    return []
+  })
 
   // GitHub
   ipcMain.handle('github:getPrStatus', (_e, worktreePath: string, forceRefresh?: boolean) =>

--- a/src/main/services/__tests__/agentProcess.test.ts
+++ b/src/main/services/__tests__/agentProcess.test.ts
@@ -216,6 +216,7 @@ describe('agentProcess entry point', () => {
         sendCommand({
           type: 'startSession', sessionId: 's-epipe', worktreeId: 'wt-epipe', projectName: 'test',
           worktreePath: '/tmp', prompt: 'hello', model: 'claude-sonnet-4-6', thinking: false,
+          extendedContext: false, effortLevel: 'high',
           planMode: false, sessionName: 'Test', settings: defaultSettings
         })
         setTimeout(resolve, 200)

--- a/src/main/services/agentHookServer.ts
+++ b/src/main/services/agentHookServer.ts
@@ -13,7 +13,13 @@
 
 import http from 'http'
 import { randomUUID } from 'crypto'
+import { mkdirSync, writeFileSync, unlinkSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
 import { BrowserWindow } from 'electron'
+
+/** Well-known config file path. Hook scripts read this to get the current port/token. */
+const HOOK_CONFIG_PATH = join(homedir(), '.braid', 'hooks', 'hook-server.json')
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -126,6 +132,10 @@ export async function startAgentHookServer(): Promise<{ port: number; token: str
       if (typeof addr === 'object' && addr) {
         serverPort = addr.port
         server = srv
+        // Write port/token to a well-known config file so hook scripts in
+        // surviving daemon PTY sessions can discover the new server after
+        // Electron restarts (env vars in those sessions are stale).
+        writeHookConfig(serverPort, serverToken)
         console.log(`[agentHookServer] Listening on 127.0.0.1:${serverPort}`)
         resolve({ port: serverPort, token: serverToken })
       } else {
@@ -142,7 +152,24 @@ export function stopAgentHookServer(): void {
     server = null
     serverPort = 0
     serverToken = ''
+    removeHookConfig()
   }
+}
+
+/** Write port/token to a well-known file so hook scripts can read the current values. */
+function writeHookConfig(port: number, token: string): void {
+  try {
+    const dir = join(homedir(), '.braid', 'hooks')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(HOOK_CONFIG_PATH, JSON.stringify({ port, token }), { mode: 0o600 })
+  } catch {
+    // Non-fatal - hooks may fail for surviving daemon sessions but fresh spawns still work via env vars
+  }
+}
+
+/** Remove the hook config file on server stop. */
+function removeHookConfig(): void {
+  try { unlinkSync(HOOK_CONFIG_PATH) } catch { /* may not exist */ }
 }
 
 /** Get the current server port (0 if not started). */

--- a/src/main/services/hookInstaller.ts
+++ b/src/main/services/hookInstaller.ts
@@ -16,7 +16,7 @@ import type { ClaudeHookConfig } from './claudeConfig'
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-const HOOK_VERSION = 3
+const HOOK_VERSION = 4
 const HOOK_DIR = join(homedir(), '.braid', 'hooks')
 const HOOK_PATH = join(HOOK_DIR, 'agent-status.sh')
 const HOOK_COMMAND = '~/.braid/hooks/agent-status.sh'
@@ -43,6 +43,16 @@ const HOOK_SCRIPT = `#!/bin/bash
 # Braid agent status hook - POSTs status to Braid's loopback HTTP server.
 # Managed by Braid. Do not edit - changes will be overwritten on next launch.
 # BRAID_HOOK_VERSION=${HOOK_VERSION}
+
+# Resolve hook server port and token.
+# Prefer the config file (survives Electron restart for daemon PTY sessions)
+# over env vars (which become stale after restart).
+HOOK_CONFIG=~/.braid/hooks/hook-server.json
+if [ -f "$HOOK_CONFIG" ]; then
+  cfg=$(cat "$HOOK_CONFIG" 2>/dev/null)
+  [[ "$cfg" =~ \\"port\\"[[:space:]]*:[[:space:]]*([0-9]+) ]] && BRAID_HOOK_PORT="\${BASH_REMATCH[1]}"
+  [[ "$cfg" =~ \\"token\\"[[:space:]]*:[[:space:]]*\\"([^\\"]+)\\" ]] && BRAID_HOOK_TOKEN="\${BASH_REMATCH[1]}"
+fi
 
 # Guard: only run inside Braid big terminals
 [ -z "$BRAID_HOOK_PORT" ] && exit 0

--- a/src/main/services/pty.ts
+++ b/src/main/services/pty.ts
@@ -87,12 +87,12 @@ export interface IPtyService {
   dumpAllScrollbacks(): void
 }
 
-// ── Service ──────────────────────────────────────────────────────────────────
+// ── Legacy in-process service ────────────────────────────────────────────────
 
 class PtyService implements IPtyService {
   private instances = new Map<string, PtyInstance>()
   private counter = 0
-  /** Mapping ptyId → terminalId for big terminal PTYs (for scrollback persistence). */
+  /** Mapping ptyId -> terminalId for big terminal PTYs (for scrollback persistence). */
   private bigTerminalByPty = new Map<string, string>()
 
   private getWindow(): BrowserWindow | null {
@@ -251,7 +251,7 @@ class PtyService implements IPtyService {
     try {
       unlinkSync(scrollbackPath(terminalId))
     } catch {
-      // File may not exist — ignore
+      // File may not exist - ignore
     }
   }
 
@@ -307,9 +307,33 @@ class PtyService implements IPtyService {
   }
 }
 
-export const ptyService = new PtyService()
+// ── Service creation with daemon fallback ────────────────────────────────────
+
+import { PtyDaemonAdapter } from './ptyDaemon'
+
+/**
+ * Create the PTY service. Uses PtyDaemonAdapter by default, which spawns
+ * a standalone daemon process so terminals survive app restarts.
+ * Falls back to in-process PtyService if the daemon fails to initialize.
+ */
+function createPtyService(): IPtyService & { reattach?: (sessionId: string) => Promise<import('./ptyDaemon').ReattachResult | null>; listSessions?: () => Promise<import('./ptyDaemon').SessionInfo[]>; disconnectFromDaemon?: () => void; ensureDaemon?: () => Promise<void> } {
+  try {
+    const adapter = new PtyDaemonAdapter()
+    console.log('[pty] Using daemon adapter')
+    return adapter
+  } catch (err) {
+    console.warn('[pty] Failed to create daemon adapter, falling back to in-process:', err)
+    return new PtyService()
+  }
+}
+
+export const ptyService = createPtyService()
 
 // Flush all big-terminal scrollbacks on graceful app quit so next launch can replay.
 app.on('before-quit', () => {
   ptyService.dumpAllScrollbacks()
+  // Disconnect from daemon (don't kill it - it should outlive us)
+  if ('disconnectFromDaemon' in ptyService && typeof ptyService.disconnectFromDaemon === 'function') {
+    ptyService.disconnectFromDaemon()
+  }
 })

--- a/src/main/services/ptyDaemon/__tests__/checkpoint.test.ts
+++ b/src/main/services/ptyDaemon/__tests__/checkpoint.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { CheckpointData } from '../types'
+
+// Redirect CHECKPOINT_DIR to a temp directory for testing
+const TEST_DIR = join(tmpdir(), `braid-checkpoint-test-${process.pid}`)
+
+vi.mock('../protocol', async () => {
+  const actual = await vi.importActual<typeof import('../protocol')>('../protocol')
+  return {
+    ...actual,
+    CHECKPOINT_DIR: TEST_DIR,
+    CHECKPOINT_INTERVAL_MS: 100,
+  }
+})
+
+// Must import AFTER the mock is set up
+const { flushCheckpoints, loadCheckpoints, deleteCheckpoint } = await import('../checkpoint')
+
+// Minimal mock SessionHost
+function createMockHost(checkpoints: CheckpointData[]) {
+  return { getCheckpoints: () => checkpoints } as unknown as import('../sessionHost').SessionHost
+}
+
+describe('checkpoint', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true })
+  })
+
+  afterEach(() => {
+    try { rmSync(TEST_DIR, { recursive: true, force: true }) } catch { /* */ }
+  })
+
+  it('writes checkpoint files', () => {
+    const host = createMockHost([
+      { sessionId: 's1', cwd: '/tmp', cols: 80, rows: 24, scrollback: 'data1', createdAt: 1000, checkpointedAt: 2000 },
+    ])
+
+    flushCheckpoints(host)
+
+    const files = readdirSync(TEST_DIR).filter((f) => f.endsWith('.json'))
+    expect(files).toEqual(['s1.json'])
+
+    const content = JSON.parse(readFileSync(join(TEST_DIR, 's1.json'), 'utf8')) as CheckpointData
+    expect(content.sessionId).toBe('s1')
+    expect(content.scrollback).toBe('data1')
+  })
+
+  it('cleans up stale checkpoint files', () => {
+    // Create an initial checkpoint
+    const host1 = createMockHost([
+      { sessionId: 's1', cwd: '/tmp', cols: 80, rows: 24, scrollback: 'data1', createdAt: 1000, checkpointedAt: 2000 },
+    ])
+    flushCheckpoints(host1)
+
+    // Now s1 is gone
+    const host2 = createMockHost([])
+    flushCheckpoints(host2)
+
+    const files = readdirSync(TEST_DIR).filter((f) => f.endsWith('.json'))
+    expect(files).toEqual([])
+  })
+
+  it('loads checkpoints from disk', () => {
+    const host = createMockHost([
+      { sessionId: 's1', cwd: '/tmp', cols: 80, rows: 24, scrollback: 'hello', createdAt: 1000, checkpointedAt: 2000 },
+      { sessionId: 's2', cwd: '/home', cols: 120, rows: 40, scrollback: 'world', createdAt: 3000, checkpointedAt: 4000 },
+    ])
+    flushCheckpoints(host)
+
+    const loaded = loadCheckpoints()
+    expect(loaded).toHaveLength(2)
+    const ids = loaded.map((c) => c.sessionId).sort()
+    expect(ids).toEqual(['s1', 's2'])
+  })
+
+  it('returns empty array when checkpoint dir does not exist', () => {
+    rmSync(TEST_DIR, { recursive: true, force: true })
+    const loaded = loadCheckpoints()
+    expect(loaded).toEqual([])
+  })
+
+  it('skips corrupt checkpoint files', () => {
+    mkdirSync(TEST_DIR, { recursive: true })
+    const { writeFileSync } = require('fs')
+    writeFileSync(join(TEST_DIR, 'good.json'), JSON.stringify({
+      sessionId: 'good', cwd: '/tmp', cols: 80, rows: 24, scrollback: '', createdAt: 1, checkpointedAt: 1,
+    }))
+    writeFileSync(join(TEST_DIR, 'bad.json'), 'not valid json')
+
+    const loaded = loadCheckpoints()
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0].sessionId).toBe('good')
+  })
+
+  it('deletes a specific checkpoint', () => {
+    const host = createMockHost([
+      { sessionId: 's1', cwd: '/tmp', cols: 80, rows: 24, scrollback: 'x', createdAt: 1, checkpointedAt: 1 },
+    ])
+    flushCheckpoints(host)
+    expect(existsSync(join(TEST_DIR, 's1.json'))).toBe(true)
+
+    deleteCheckpoint('s1')
+    expect(existsSync(join(TEST_DIR, 's1.json'))).toBe(false)
+  })
+
+  it('deleteCheckpoint does not throw for missing file', () => {
+    expect(() => deleteCheckpoint('nonexistent')).not.toThrow()
+  })
+})

--- a/src/main/services/ptyDaemon/__tests__/lifecycle.test.ts
+++ b/src/main/services/ptyDaemon/__tests__/lifecycle.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const TEST_DIR = join(tmpdir(), `braid-lifecycle-test-${process.pid}`)
+const TEST_PID_FILE = join(TEST_DIR, 'pty-daemon.pid')
+const TEST_SOCKET = join(TEST_DIR, 'pty-v1.sock')
+
+vi.mock('../protocol', async () => {
+  const actual = await vi.importActual<typeof import('../protocol')>('../protocol')
+  return {
+    ...actual,
+    DAEMON_DIR: TEST_DIR,
+    PID_FILE_PATH: TEST_PID_FILE,
+    SOCKET_PATH: TEST_SOCKET,
+  }
+})
+
+const {
+  writePidFile, removePidFile, removeSocketFile,
+  readPidFile, isProcessRunning, isDaemonRunning,
+} = await import('../lifecycle')
+
+describe('lifecycle', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true })
+  })
+
+  afterEach(() => {
+    try { rmSync(TEST_DIR, { recursive: true, force: true }) } catch { /* */ }
+  })
+
+  describe('PID file', () => {
+    it('writes and reads current PID', () => {
+      writePidFile()
+      expect(existsSync(TEST_PID_FILE)).toBe(true)
+      const pid = readPidFile()
+      expect(pid).toBe(process.pid)
+    })
+
+    it('removes PID file', () => {
+      writePidFile()
+      removePidFile()
+      expect(existsSync(TEST_PID_FILE)).toBe(false)
+    })
+
+    it('returns null for missing PID file', () => {
+      expect(readPidFile()).toBeNull()
+    })
+
+    it('returns null for invalid PID content', () => {
+      writeFileSync(TEST_PID_FILE, 'not-a-number')
+      expect(readPidFile()).toBeNull()
+    })
+  })
+
+  describe('isProcessRunning', () => {
+    it('returns true for current process', () => {
+      expect(isProcessRunning(process.pid)).toBe(true)
+    })
+
+    it('returns false for non-existent process', () => {
+      // PID 99999999 is unlikely to exist
+      expect(isProcessRunning(99_999_999)).toBe(false)
+    })
+  })
+
+  describe('isDaemonRunning', () => {
+    it('returns current PID when process is alive', () => {
+      writePidFile()
+      const result = isDaemonRunning()
+      expect(result).toBe(process.pid)
+    })
+
+    it('returns null when no PID file exists', () => {
+      expect(isDaemonRunning()).toBeNull()
+    })
+
+    it('cleans up stale PID file when process is dead', () => {
+      writeFileSync(TEST_PID_FILE, '99999999')
+      // Also create a stale socket file
+      writeFileSync(TEST_SOCKET, '')
+
+      const result = isDaemonRunning()
+      expect(result).toBeNull()
+      // Stale files should be cleaned up
+      expect(existsSync(TEST_PID_FILE)).toBe(false)
+      expect(existsSync(TEST_SOCKET)).toBe(false)
+    })
+  })
+
+  describe('removeSocketFile', () => {
+    it('removes socket file', () => {
+      writeFileSync(TEST_SOCKET, '')
+      removeSocketFile()
+      expect(existsSync(TEST_SOCKET)).toBe(false)
+    })
+
+    it('does not throw for missing file', () => {
+      expect(() => removeSocketFile()).not.toThrow()
+    })
+  })
+})

--- a/src/main/services/ptyDaemon/__tests__/protocol.test.ts
+++ b/src/main/services/ptyDaemon/__tests__/protocol.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { encode, decode, PROTOCOL_VERSION, SOCKET_PATH, PID_FILE_PATH, CHECKPOINT_DIR, IDLE_SHUTDOWN_MS, CHECKPOINT_INTERVAL_MS, BUFFER_MAX_LENGTH } from '../protocol'
+
+describe('protocol constants', () => {
+  it('has expected version', () => {
+    expect(PROTOCOL_VERSION).toBe(1)
+  })
+
+  it('socket path includes version', () => {
+    expect(SOCKET_PATH).toContain('pty-v1.sock')
+  })
+
+  it('paths are under ~/Braid/daemon/', () => {
+    expect(SOCKET_PATH).toContain('Braid/daemon/')
+    expect(PID_FILE_PATH).toContain('Braid/daemon/')
+    expect(CHECKPOINT_DIR).toContain('Braid/daemon/')
+  })
+
+  it('has reasonable timeout and buffer values', () => {
+    expect(IDLE_SHUTDOWN_MS).toBe(600_000) // 10 minutes
+    expect(CHECKPOINT_INTERVAL_MS).toBe(5_000)
+    expect(BUFFER_MAX_LENGTH).toBe(50_000)
+  })
+})
+
+describe('encode', () => {
+  it('serializes a message to NDJSON (trailing newline)', () => {
+    const msg = { id: '1', type: 'ping' as const }
+    const result = encode(msg)
+    expect(result).toBe('{"id":"1","type":"ping"}\n')
+  })
+
+  it('handles complex messages with nested data', () => {
+    const msg = { id: '2', type: 'ok' as const, data: { snapshot: 'hello\nworld' } }
+    const result = encode(msg)
+    expect(result.endsWith('\n')).toBe(true)
+    const parsed = JSON.parse(result.trim())
+    expect(parsed.data.snapshot).toBe('hello\nworld')
+  })
+})
+
+describe('decode', () => {
+  it('parses a valid NDJSON line', () => {
+    const result = decode('{"id":"1","type":"ping"}')
+    expect(result).toEqual({ id: '1', type: 'ping' })
+  })
+
+  it('handles trailing whitespace', () => {
+    const result = decode('  {"type":"data","sessionId":"s1","data":"x"}  ')
+    expect(result).toEqual({ type: 'data', sessionId: 's1', data: 'x' })
+  })
+
+  it('returns null for empty input', () => {
+    expect(decode('')).toBeNull()
+    expect(decode('   ')).toBeNull()
+  })
+
+  it('returns null for invalid JSON', () => {
+    expect(decode('not json')).toBeNull()
+    expect(decode('{broken')).toBeNull()
+  })
+
+  it('roundtrips with encode', () => {
+    const msg = { id: 'req-42', type: 'ok' as const, data: { sessions: [] } }
+    const encoded = encode(msg)
+    const decoded = decode(encoded)
+    expect(decoded).toEqual(msg)
+  })
+})

--- a/src/main/services/ptyDaemon/__tests__/sessionHost.test.ts
+++ b/src/main/services/ptyDaemon/__tests__/sessionHost.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RingBuffer, SessionHost } from '../sessionHost'
+
+// ── RingBuffer tests ──────────────────────────────────────────────────────────
+
+describe('RingBuffer', () => {
+  it('stores and reads data', () => {
+    const buf = new RingBuffer()
+    buf.push('hello')
+    buf.push(' world')
+    expect(buf.read()).toBe('hello world')
+  })
+
+  it('evicts old chunks when exceeding max length', () => {
+    const buf = new RingBuffer()
+    // Push 60KB of data (exceeds 50KB limit)
+    const chunk = 'x'.repeat(10_000)
+    for (let i = 0; i < 6; i++) buf.push(chunk)
+    const result = buf.read()
+    expect(result.length).toBeLessThanOrEqual(50_000)
+  })
+
+  it('trims a single large chunk', () => {
+    const buf = new RingBuffer()
+    buf.push('x'.repeat(100_000))
+    expect(buf.read().length).toBe(50_000)
+  })
+
+  it('clears data', () => {
+    const buf = new RingBuffer()
+    buf.push('data')
+    buf.clear()
+    expect(buf.read()).toBe('')
+  })
+
+  it('handles empty pushes', () => {
+    const buf = new RingBuffer()
+    buf.push('')
+    buf.push('')
+    expect(buf.read()).toBe('')
+  })
+})
+
+// ── SessionHost tests ─────────────────────────────────────────────────────────
+
+// Mock node-pty
+function createMockPty() {
+  const dataCallbacks: Array<(data: string) => void> = []
+  const exitCallbacks: Array<(info: { exitCode: number }) => void> = []
+
+  return {
+    onData: vi.fn((cb: (data: string) => void) => { dataCallbacks.push(cb) }),
+    onExit: vi.fn((cb: (info: { exitCode: number }) => void) => { exitCallbacks.push(cb) }),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(() => {
+      // Simulate exit on kill
+      for (const cb of exitCallbacks) cb({ exitCode: 0 })
+    }),
+    _emitData: (data: string) => { for (const cb of dataCallbacks) cb(data) },
+    _emitExit: (exitCode: number) => { for (const cb of exitCallbacks) cb({ exitCode }) },
+  }
+}
+
+vi.mock('node-pty', () => {
+  let mockPty: ReturnType<typeof createMockPty> | null = null
+  return {
+    spawn: vi.fn(() => {
+      mockPty = createMockPty()
+      return mockPty
+    }),
+    __getMockPty: () => mockPty,
+  }
+})
+
+describe('SessionHost', () => {
+  let host: SessionHost
+
+  beforeEach(() => {
+    host = new SessionHost()
+    vi.clearAllMocks()
+  })
+
+  it('spawns a session', async () => {
+    await host.spawn('s1', '/tmp', 80, 24, '/bin/zsh')
+    expect(host.has('s1')).toBe(true)
+    expect(host.size).toBe(1)
+  })
+
+  it('throws on duplicate sessionId', async () => {
+    await host.spawn('s1', '/tmp', 80, 24, '/bin/zsh')
+    await expect(host.spawn('s1', '/tmp', 80, 24, '/bin/zsh')).rejects.toThrow('Session already exists')
+  })
+
+  it('lists sessions', async () => {
+    await host.spawn('s1', '/home', 80, 24, '/bin/zsh')
+    const list = host.list()
+    expect(list).toHaveLength(1)
+    expect(list[0].sessionId).toBe('s1')
+    expect(list[0].cwd).toBe('/home')
+  })
+
+  it('emits data events', async () => {
+    const dataSpy = vi.fn()
+    host.on('data', dataSpy)
+
+    await host.spawn('s1', '/tmp', 80, 24, '/bin/zsh')
+    const nodePty = await import('node-pty')
+    const mockPty = (nodePty as unknown as { __getMockPty: () => ReturnType<typeof createMockPty> }).__getMockPty()
+    mockPty._emitData('hello')
+
+    expect(dataSpy).toHaveBeenCalledWith('s1', 'hello')
+  })
+
+  it('writes data to session', async () => {
+    await host.spawn('s1', '/tmp', 80, 24, '/bin/zsh')
+    const nodePty = await import('node-pty')
+    const mockPty = (nodePty as unknown as { __getMockPty: () => ReturnType<typeof createMockPty> }).__getMockPty()
+
+    host.write('s1', 'input')
+    expect(mockPty.write).toHaveBeenCalledWith('input')
+  })
+
+  it('resizes session', async () => {
+    await host.spawn('s1', '/tmp', 80, 24, '/bin/zsh')
+    const nodePty = await import('node-pty')
+    const mockPty = (nodePty as unknown as { __getMockPty: () => ReturnType<typeof createMockPty> }).__getMockPty()
+
+    host.resize('s1', 120, 40)
+    expect(mockPty.resize).toHaveBeenCalledWith(120, 40)
+  })
+
+  it('attaches to session and returns snapshot', async () => {
+    await host.spawn('s1', '/tmp', 80, 24, '/bin/zsh')
+    const nodePty = await import('node-pty')
+    const mockPty = (nodePty as unknown as { __getMockPty: () => ReturnType<typeof createMockPty> }).__getMockPty()
+
+    mockPty._emitData('buffered data')
+    const snapshot = host.attach('s1')
+    expect(snapshot).toBe('buffered data')
+  })
+
+  it('returns null for attaching to non-existent session', () => {
+    expect(host.attach('nonexistent')).toBeNull()
+  })
+
+  it('removes session on exit', async () => {
+    const exitSpy = vi.fn()
+    host.on('exit', exitSpy)
+
+    await host.spawn('s1', '/tmp', 80, 24, '/bin/zsh')
+    const nodePty = await import('node-pty')
+    const mockPty = (nodePty as unknown as { __getMockPty: () => ReturnType<typeof createMockPty> }).__getMockPty()
+
+    mockPty._emitExit(0)
+    expect(host.has('s1')).toBe(false)
+    expect(exitSpy).toHaveBeenCalledWith('s1', 0)
+  })
+
+  it('generates checkpoint data', async () => {
+    await host.spawn('s1', '/tmp', 80, 24, '/bin/zsh')
+    const nodePty = await import('node-pty')
+    const mockPty = (nodePty as unknown as { __getMockPty: () => ReturnType<typeof createMockPty> }).__getMockPty()
+
+    mockPty._emitData('checkpoint data')
+
+    const checkpoints = host.getCheckpoints()
+    expect(checkpoints).toHaveLength(1)
+    expect(checkpoints[0].sessionId).toBe('s1')
+    expect(checkpoints[0].scrollback).toBe('checkpoint data')
+    expect(checkpoints[0].cwd).toBe('/tmp')
+  })
+
+  it('kills all sessions', async () => {
+    await host.spawn('s1', '/tmp', 80, 24, '/bin/zsh')
+    await host.spawn('s2', '/tmp', 80, 24, '/bin/zsh')
+    expect(host.size).toBe(2)
+    host.killAll()
+    expect(host.size).toBe(0)
+  })
+
+  it('ignores write/resize to non-existent sessions', () => {
+    // Should not throw
+    host.write('nope', 'data')
+    host.resize('nope', 80, 24)
+  })
+})

--- a/src/main/services/ptyDaemon/adapter.ts
+++ b/src/main/services/ptyDaemon/adapter.ts
@@ -1,0 +1,352 @@
+/**
+ * PtyDaemonAdapter - implements IPtyService by proxying to the daemon.
+ *
+ * This replaces the in-process PtyService when the daemon is available.
+ * The renderer is completely unaware of the daemon - it uses the same
+ * IPC protocol (pty:spawn, pty:write, pty:data, etc.).
+ */
+import { BrowserWindow, app } from 'electron'
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import { fork, execFileSync } from 'child_process'
+import { mainSettings } from '../../ipc'
+import { getHookServerPort, getHookServerToken } from '../agentHookServer'
+import { DaemonClient } from './client'
+import { isDaemonRunning, removeSocketFile } from './lifecycle'
+import { SOCKET_PATH, BUFFER_MAX_LENGTH } from './protocol'
+import { RingBuffer } from './sessionHost'
+import type { IPtyService, TerminalOutput } from '../pty'
+import type { ReattachResult, SessionInfo } from './types'
+
+// ── Scrollback helpers (same as PtyService) ──────────────────────────────────
+
+function scrollbackDir(): string {
+  return join(homedir(), 'Braid', 'bigTerminals')
+}
+
+function scrollbackPath(terminalId: string): string {
+  if (!/^bt-\d+-\d+$/.test(terminalId)) {
+    throw new Error(`Invalid terminal id: ${terminalId}`)
+  }
+  return join(scrollbackDir(), `${terminalId}.scrollback`)
+}
+
+// ── Shell resolution (same as PtyService) ────────────────────────────────────
+
+function isExecutable(path: string): boolean {
+  try {
+    const { lstatSync, accessSync, constants } = require('fs')
+    const stat = lstatSync(path)
+    if (stat.isSymbolicLink()) {
+      if (!existsSync(path)) return false
+    }
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function resolveShell(): string {
+  const configured = mainSettings.terminalShell
+  if (configured && isExecutable(configured)) return configured
+  if (process.env.SHELL && isExecutable(process.env.SHELL)) return process.env.SHELL
+  try {
+    const result = execFileSync('dscl', ['.', '-read', `/Users/${process.env.USER ?? 'root'}`, 'UserShell'], { encoding: 'utf8', timeout: 2000 })
+    const match = result.match(/UserShell:\s*(\S+)/)
+    if (match && isExecutable(match[1])) return match[1]
+  } catch { /* ignore */ }
+  return '/bin/zsh'
+}
+
+// ── Adapter ──────────────────────────────────────────────────────────────────
+
+export class PtyDaemonAdapter implements IPtyService {
+  private client: DaemonClient
+  /** Mapping daemon sessionId to the cwd it was spawned with. */
+  private cwdBySession = new Map<string, string>()
+  /** Mapping daemon sessionId to big-terminal id (for scrollback). */
+  private bigTerminalBySession = new Map<string, string>()
+  /** Local RingBuffer mirror per session - keeps readTerminalOutput() working synchronously. */
+  private buffers = new Map<string, RingBuffer>()
+
+  constructor() {
+    this.client = new DaemonClient()
+
+    // Forward daemon data/exit events to the renderer via IPC,
+    // and mirror output into local RingBuffers for readTerminalOutput().
+    this.client.on('data', (sessionId, data) => {
+      this.buffers.get(sessionId)?.push(data)
+      const win = this.getWindow()
+      if (win && !win.isDestroyed()) {
+        win.webContents.send('pty:data', sessionId, data)
+      }
+    })
+
+    this.client.on('exit', (sessionId, exitCode) => {
+      // Persist scrollback for big terminals before cleaning up (matches legacy behavior)
+      const terminalId = this.bigTerminalBySession.get(sessionId)
+      const buffer = this.buffers.get(sessionId)
+      if (terminalId && buffer) {
+        this.writeScrollbackFile(terminalId, buffer.read())
+      }
+      this.cwdBySession.delete(sessionId)
+      this.bigTerminalBySession.delete(sessionId)
+      this.buffers.delete(sessionId)
+      const win = this.getWindow()
+      if (win && !win.isDestroyed()) {
+        win.webContents.send('pty:exit', sessionId, exitCode)
+      }
+    })
+  }
+
+  private getWindow(): BrowserWindow | null {
+    const windows = BrowserWindow.getAllWindows()
+    return windows[0] ?? null
+  }
+
+  // ── Daemon lifecycle ───────────────────────────────────────────────────
+
+  /** Ensure the daemon is running and the client is connected. */
+  async ensureDaemon(): Promise<void> {
+    if (this.client.connected) return
+
+    const pid = isDaemonRunning()
+    if (!pid) {
+      await this.spawnDaemon()
+    }
+
+    try {
+      await this.client.connect()
+    } catch {
+      // Socket may be stale, try spawning a fresh daemon
+      removeSocketFile()
+      await this.spawnDaemon()
+      await this.client.connect()
+    }
+  }
+
+  private async spawnDaemon(): Promise<void> {
+    // Find the daemon entry point - adjacent to this file in the build output
+    const daemonPath = join(__dirname, 'daemonMain.js')
+
+    const child = fork(daemonPath, [], {
+      detached: true,
+      stdio: 'ignore',
+      env: {
+        ...process.env,
+        // Pass through the shell so the daemon uses the same shell
+        SHELL: resolveShell(),
+      },
+    })
+    child.unref()
+
+    // Wait for the socket to appear (daemon needs a moment to start)
+    await this.waitForSocket(5_000)
+  }
+
+  private waitForSocket(timeoutMs: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const start = Date.now()
+      const check = (): void => {
+        if (existsSync(SOCKET_PATH)) {
+          resolve()
+          return
+        }
+        if (Date.now() - start > timeoutMs) {
+          reject(new Error('Timed out waiting for daemon socket'))
+          return
+        }
+        setTimeout(check, 100)
+      }
+      check()
+    })
+  }
+
+  /** Disconnect from the daemon (don't kill it). Called on app quit. */
+  disconnectFromDaemon(): void {
+    this.client.disconnect()
+  }
+
+  // ── IPtyService implementation ─────────────────────────────────────────
+
+  async spawn(cwd: string, envOverrides?: Record<string, string>): Promise<string> {
+    await this.ensureDaemon()
+
+    const shell = resolveShell()
+    const safeCwd = existsSync(cwd) ? cwd : homedir()
+
+    // Generate a session ID that matches the format the renderer expects
+    const sessionId = `pty-d-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
+    const hookPort = getHookServerPort()
+    const hookToken = getHookServerToken()
+    const env: Record<string, string> = {
+      TERM: 'xterm-256color',
+      BRAID_TERMINAL: '1',
+      ...(hookPort > 0 ? { BRAID_HOOK_PORT: String(hookPort), BRAID_HOOK_TOKEN: hookToken } : {}),
+      ...envOverrides,
+    }
+
+    await this.client.spawn(sessionId, safeCwd, 80, 24, shell, env)
+    this.cwdBySession.set(sessionId, safeCwd)
+    this.buffers.set(sessionId, new RingBuffer())
+    return sessionId
+  }
+
+  write(id: string, data: string): void {
+    this.client.write(id, data)
+  }
+
+  resize(id: string, cols: number, rows: number): void {
+    this.client.resize(id, cols, rows)
+  }
+
+  kill(id: string): void {
+    // Persist scrollback for big terminals before killing (onExit may not fire reliably)
+    const terminalId = this.bigTerminalBySession.get(id)
+    const buffer = this.buffers.get(id)
+    if (terminalId && buffer) {
+      this.writeScrollbackFile(terminalId, buffer.read())
+    }
+    this.client.kill(id).catch(() => {
+      // Session may already be dead
+    })
+    this.cwdBySession.delete(id)
+    this.bigTerminalBySession.delete(id)
+    this.buffers.delete(id)
+  }
+
+  killAll(): void {
+    // Persist scrollback for all big terminals before killing
+    for (const [sessionId, terminalId] of this.bigTerminalBySession) {
+      const buffer = this.buffers.get(sessionId)
+      if (buffer) this.writeScrollbackFile(terminalId, buffer.read())
+    }
+    for (const sessionId of this.cwdBySession.keys()) {
+      this.client.kill(sessionId).catch(() => {})
+    }
+    this.cwdBySession.clear()
+    this.bigTerminalBySession.clear()
+    this.buffers.clear()
+  }
+
+  readTerminalOutput(worktreePath: string): TerminalOutput[] {
+    const results: TerminalOutput[] = []
+    for (const [sessionId, cwd] of this.cwdBySession) {
+      if (cwd === worktreePath) {
+        const buffer = this.buffers.get(sessionId)
+        results.push({ ptyId: sessionId, output: buffer?.read() ?? '' })
+      }
+    }
+    return results
+  }
+
+  // ── Big Terminal scrollback persistence ────────────────────────────────
+
+  registerBigTerminal(ptyId: string, terminalId: string): void {
+    this.bigTerminalBySession.set(ptyId, terminalId)
+  }
+
+  readScrollback(terminalId: string): string {
+    try {
+      return readFileSync(scrollbackPath(terminalId), { encoding: 'utf8' })
+    } catch {
+      return ''
+    }
+  }
+
+  deleteScrollback(terminalId: string): void {
+    try {
+      unlinkSync(scrollbackPath(terminalId))
+    } catch {
+      // File may not exist
+    }
+  }
+
+  dumpAllScrollbacks(): void {
+    for (const [sessionId, terminalId] of this.bigTerminalBySession) {
+      const buffer = this.buffers.get(sessionId)
+      if (buffer) this.writeScrollbackFile(terminalId, buffer.read())
+    }
+  }
+
+  private writeScrollbackFile(terminalId: string, data: string): void {
+    try {
+      mkdirSync(scrollbackDir(), { recursive: true })
+      writeFileSync(scrollbackPath(terminalId), data, { encoding: 'utf8', mode: 0o600 })
+    } catch (err) {
+      console.warn('[pty-daemon] Failed to persist scrollback for', terminalId, err)
+    }
+  }
+
+  /** Run a command non-interactively. This stays in-process (ephemeral, no persistence needed). */
+  async runScript(cwd: string, command: string, timeoutMs = 30_000): Promise<{ exitCode: number }> {
+    // runScript is ephemeral - use in-process node-pty directly
+    const nodePty = await import('node-pty')
+    const shell = resolveShell()
+    const safeCwd = existsSync(cwd) ? cwd : homedir()
+
+    return new Promise((resolve, reject) => {
+      let ptyProcess: import('node-pty').IPty
+      try {
+        ptyProcess = nodePty.spawn(shell, ['-l', '-c', command], {
+          name: 'xterm-256color',
+          cols: 80,
+          rows: 24,
+          cwd: safeCwd,
+          env: { ...process.env, TERM: 'xterm-256color' } as Record<string, string>,
+        })
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        reject(new Error(`Failed to spawn script (shell: ${shell}, cwd: ${safeCwd}): ${msg}`))
+        return
+      }
+
+      let settled = false
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true
+          ptyProcess.kill()
+          resolve({ exitCode: -1 })
+        }
+      }, timeoutMs)
+
+      ptyProcess.onExit(({ exitCode }: { exitCode: number }) => {
+        if (!settled) {
+          settled = true
+          clearTimeout(timer)
+          resolve({ exitCode })
+        }
+      })
+    })
+  }
+
+  // ── Daemon-specific operations ─────────────────────────────────────────
+
+  /** Reattach to an existing daemon session. Returns snapshot or null. */
+  async reattach(sessionId: string): Promise<ReattachResult | null> {
+    try {
+      await this.ensureDaemon()
+      const result = await this.client.attach(sessionId)
+      // Initialize local buffer with snapshot so readTerminalOutput works
+      const buffer = new RingBuffer()
+      buffer.push(result.snapshot)
+      this.buffers.set(sessionId, buffer)
+      return { sessionId, snapshot: result.snapshot }
+    } catch {
+      return null
+    }
+  }
+
+  /** List all active sessions in the daemon. */
+  async listSessions(): Promise<SessionInfo[]> {
+    try {
+      await this.ensureDaemon()
+      return await this.client.list()
+    } catch {
+      return []
+    }
+  }
+}

--- a/src/main/services/ptyDaemon/adapter.ts
+++ b/src/main/services/ptyDaemon/adapter.ts
@@ -190,8 +190,10 @@ export class PtyDaemonAdapter implements IPtyService {
     const shell = resolveShell()
     const safeCwd = existsSync(cwd) ? cwd : homedir()
 
-    // Generate a session ID that matches the format the renderer expects
-    const sessionId = `pty-d-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    // Use the renderer's stable terminal ID as the daemon session key when provided.
+    // This makes reattach work: the renderer calls reattach(terminalId) and the daemon
+    // can find the session because it was keyed by the same ID.
+    const sessionId = envOverrides?.BRAID_TERMINAL_ID ?? `pty-d-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
     const hookPort = getHookServerPort()
     const hookToken = getHookServerToken()

--- a/src/main/services/ptyDaemon/adapter.ts
+++ b/src/main/services/ptyDaemon/adapter.ts
@@ -6,7 +6,7 @@
  * IPC protocol (pty:spawn, pty:write, pty:data, etc.).
  */
 import { BrowserWindow, app } from 'electron'
-import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'fs'
+import { existsSync, lstatSync, accessSync, constants as fsConstants, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
 import { fork, execFileSync } from 'child_process'
@@ -14,7 +14,7 @@ import { mainSettings } from '../../ipc'
 import { getHookServerPort, getHookServerToken } from '../agentHookServer'
 import { DaemonClient } from './client'
 import { isDaemonRunning, removeSocketFile } from './lifecycle'
-import { SOCKET_PATH, BUFFER_MAX_LENGTH } from './protocol'
+import { SOCKET_PATH } from './protocol'
 import { RingBuffer } from './sessionHost'
 import type { IPtyService, TerminalOutput } from '../pty'
 import type { ReattachResult, SessionInfo } from './types'
@@ -36,12 +36,11 @@ function scrollbackPath(terminalId: string): string {
 
 function isExecutable(path: string): boolean {
   try {
-    const { lstatSync, accessSync, constants } = require('fs')
     const stat = lstatSync(path)
     if (stat.isSymbolicLink()) {
       if (!existsSync(path)) return false
     }
-    accessSync(path, constants.X_OK)
+    accessSync(path, fsConstants.X_OK)
     return true
   } catch {
     return false
@@ -70,6 +69,8 @@ export class PtyDaemonAdapter implements IPtyService {
   private bigTerminalBySession = new Map<string, string>()
   /** Local RingBuffer mirror per session - keeps readTerminalOutput() working synchronously. */
   private buffers = new Map<string, RingBuffer>()
+  /** Serializes concurrent ensureDaemon() calls to prevent spawning duplicate daemons. */
+  private pendingEnsure: Promise<void> | null = null
 
   constructor() {
     this.client = new DaemonClient()
@@ -110,6 +111,18 @@ export class PtyDaemonAdapter implements IPtyService {
 
   /** Ensure the daemon is running and the client is connected. */
   async ensureDaemon(): Promise<void> {
+    if (this.client.connected) return
+
+    // Serialize concurrent calls so we don't spawn duplicate daemons
+    if (this.pendingEnsure) return this.pendingEnsure
+
+    this.pendingEnsure = this.doEnsureDaemon().finally(() => {
+      this.pendingEnsure = null
+    })
+    return this.pendingEnsure
+  }
+
+  private async doEnsureDaemon(): Promise<void> {
     if (this.client.connected) return
 
     const pid = isDaemonRunning()
@@ -334,6 +347,16 @@ export class PtyDaemonAdapter implements IPtyService {
       const buffer = new RingBuffer()
       buffer.push(result.snapshot)
       this.buffers.set(sessionId, buffer)
+      // Populate cwdBySession from the daemon's session list if we don't have it
+      if (!this.cwdBySession.has(sessionId)) {
+        try {
+          const sessions = await this.client.list()
+          const info = sessions.find((s) => s.sessionId === sessionId)
+          if (info) this.cwdBySession.set(sessionId, info.cwd)
+        } catch {
+          // Non-fatal - readTerminalOutput() just won't match this session
+        }
+      }
       return { sessionId, snapshot: result.snapshot }
     } catch {
       return null

--- a/src/main/services/ptyDaemon/checkpoint.ts
+++ b/src/main/services/ptyDaemon/checkpoint.ts
@@ -1,0 +1,115 @@
+/**
+ * Periodic checkpointing of PTY sessions to disk.
+ *
+ * Checkpoints are written atomically (write to .tmp, rename) every 5 seconds.
+ * Used for cold restore when the daemon dies and a new one starts.
+ */
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'fs'
+import { join } from 'path'
+import { CHECKPOINT_DIR, CHECKPOINT_INTERVAL_MS } from './protocol'
+import type { SessionHost } from './sessionHost'
+import type { CheckpointData } from './types'
+
+let intervalHandle: ReturnType<typeof setInterval> | null = null
+
+/** Start periodic checkpointing. */
+export function startCheckpointing(host: SessionHost): void {
+  if (intervalHandle) return
+
+  mkdirSync(CHECKPOINT_DIR, { recursive: true })
+
+  intervalHandle = setInterval(() => {
+    flushCheckpoints(host)
+  }, CHECKPOINT_INTERVAL_MS)
+
+  // Don't keep the process alive just for checkpointing
+  if (intervalHandle && typeof intervalHandle === 'object' && 'unref' in intervalHandle) {
+    intervalHandle.unref()
+  }
+}
+
+/** Stop periodic checkpointing. */
+export function stopCheckpointing(): void {
+  if (intervalHandle) {
+    clearInterval(intervalHandle)
+    intervalHandle = null
+  }
+}
+
+/** Write all session checkpoints to disk atomically. */
+export function flushCheckpoints(host: SessionHost): void {
+  const checkpoints = host.getCheckpoints()
+  const activeIds = new Set(checkpoints.map((cp) => cp.sessionId))
+
+  mkdirSync(CHECKPOINT_DIR, { recursive: true })
+
+  // Write active session checkpoints
+  for (const cp of checkpoints) {
+    writeCheckpoint(cp)
+  }
+
+  // Remove checkpoints for sessions that no longer exist
+  try {
+    const files = readdirSync(CHECKPOINT_DIR)
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue
+      const sessionId = file.replace(/\.json$/, '')
+      if (!activeIds.has(sessionId)) {
+        try {
+          unlinkSync(join(CHECKPOINT_DIR, file))
+        } catch {
+          // Best effort
+        }
+      }
+    }
+  } catch {
+    // CHECKPOINT_DIR might not exist yet
+  }
+}
+
+/** Write a single checkpoint atomically. */
+function writeCheckpoint(data: CheckpointData): void {
+  const filePath = join(CHECKPOINT_DIR, `${data.sessionId}.json`)
+  const tmpPath = filePath + '.tmp'
+  try {
+    writeFileSync(tmpPath, JSON.stringify(data), { mode: 0o600 })
+    renameSync(tmpPath, filePath)
+  } catch {
+    // Best effort - don't crash the daemon over a checkpoint failure
+    try { unlinkSync(tmpPath) } catch { /* ignore */ }
+  }
+}
+
+/** Load all checkpoint files from disk. */
+export function loadCheckpoints(): CheckpointData[] {
+  if (!existsSync(CHECKPOINT_DIR)) return []
+
+  const results: CheckpointData[] = []
+  try {
+    const files = readdirSync(CHECKPOINT_DIR)
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue
+      try {
+        const content = readFileSync(join(CHECKPOINT_DIR, file), 'utf8')
+        const data = JSON.parse(content) as CheckpointData
+        if (data.sessionId && data.cwd) {
+          results.push(data)
+        }
+      } catch {
+        // Skip corrupt checkpoint files
+      }
+    }
+  } catch {
+    // Directory read failed
+  }
+  return results
+}
+
+/** Delete a specific checkpoint file. */
+export function deleteCheckpoint(sessionId: string): void {
+  try {
+    unlinkSync(join(CHECKPOINT_DIR, `${sessionId}.json`))
+  } catch {
+    // May not exist
+  }
+}

--- a/src/main/services/ptyDaemon/checkpoint.ts
+++ b/src/main/services/ptyDaemon/checkpoint.ts
@@ -16,7 +16,7 @@ let intervalHandle: ReturnType<typeof setInterval> | null = null
 export function startCheckpointing(host: SessionHost): void {
   if (intervalHandle) return
 
-  mkdirSync(CHECKPOINT_DIR, { recursive: true })
+  mkdirSync(CHECKPOINT_DIR, { recursive: true, mode: 0o700 })
 
   intervalHandle = setInterval(() => {
     flushCheckpoints(host)
@@ -41,7 +41,7 @@ export function flushCheckpoints(host: SessionHost): void {
   const checkpoints = host.getCheckpoints()
   const activeIds = new Set(checkpoints.map((cp) => cp.sessionId))
 
-  mkdirSync(CHECKPOINT_DIR, { recursive: true })
+  mkdirSync(CHECKPOINT_DIR, { recursive: true, mode: 0o700 })
 
   // Write active session checkpoints
   for (const cp of checkpoints) {
@@ -67,9 +67,14 @@ export function flushCheckpoints(host: SessionHost): void {
   }
 }
 
+/** Sanitize a session ID for safe use in file paths. */
+function safeFileName(sessionId: string): string {
+  return sessionId.replace(/[^a-zA-Z0-9-]/g, '_')
+}
+
 /** Write a single checkpoint atomically. */
 function writeCheckpoint(data: CheckpointData): void {
-  const filePath = join(CHECKPOINT_DIR, `${data.sessionId}.json`)
+  const filePath = join(CHECKPOINT_DIR, `${safeFileName(data.sessionId)}.json`)
   const tmpPath = filePath + '.tmp'
   try {
     writeFileSync(tmpPath, JSON.stringify(data), { mode: 0o600 })
@@ -108,7 +113,7 @@ export function loadCheckpoints(): CheckpointData[] {
 /** Delete a specific checkpoint file. */
 export function deleteCheckpoint(sessionId: string): void {
   try {
-    unlinkSync(join(CHECKPOINT_DIR, `${sessionId}.json`))
+    unlinkSync(join(CHECKPOINT_DIR, `${safeFileName(sessionId)}.json`))
   } catch {
     // May not exist
   }

--- a/src/main/services/ptyDaemon/client.ts
+++ b/src/main/services/ptyDaemon/client.ts
@@ -34,6 +34,8 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private _connected = false
   private _closed = false
+  /** Session IDs this client is attached to. Re-attached on reconnect. */
+  private attachedSessions = new Set<string>()
 
   get connected(): boolean {
     return this._connected
@@ -48,6 +50,8 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       this.socket.on('connect', () => {
         this._connected = true
         this.reconnectAttempts = 0
+        // Re-attach to all previously attached sessions so data events resume
+        this.reattachAll()
         this.emit('connected')
         resolve()
       })
@@ -96,10 +100,12 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
 
   async spawn(sessionId: string, cwd: string, cols: number, rows: number, shell: string, env?: Record<string, string>): Promise<void> {
     await this.request({ type: 'spawn', sessionId, cwd, cols, rows, shell, env } as Omit<DaemonRequest, 'id'> & { type: 'spawn' })
+    this.attachedSessions.add(sessionId)
   }
 
   async attach(sessionId: string): Promise<{ snapshot: string }> {
     const result = await this.request({ type: 'attach', sessionId } as Omit<DaemonRequest, 'id'> & { type: 'attach' })
+    this.attachedSessions.add(sessionId)
     return result as { snapshot: string }
   }
 
@@ -114,6 +120,7 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
   }
 
   async kill(sessionId: string): Promise<void> {
+    this.attachedSessions.delete(sessionId)
     await this.request({ type: 'kill', sessionId } as Omit<DaemonRequest, 'id'> & { type: 'kill' })
   }
 
@@ -196,6 +203,7 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
         this.emit('data', event.sessionId, event.data)
       } else if (msg.type === 'exit') {
         const event = msg as ExitEvent
+        this.attachedSessions.delete(event.sessionId)
         this.emit('exit', event.sessionId, event.exitCode)
       }
     }
@@ -206,6 +214,14 @@ export class DaemonClient extends EventEmitter<DaemonClientEvents> {
       clearTimeout(pending.timer)
       pending.reject(new Error(reason))
       this.pending.delete(id)
+    }
+  }
+
+  /** Re-attach to all tracked sessions after a reconnect. */
+  private reattachAll(): void {
+    for (const sessionId of this.attachedSessions) {
+      // Fire-and-forget: we don't need the snapshot here, just re-subscribe to data events
+      this.send({ type: 'attach', sessionId })
     }
   }
 

--- a/src/main/services/ptyDaemon/client.ts
+++ b/src/main/services/ptyDaemon/client.ts
@@ -1,0 +1,225 @@
+/**
+ * DaemonClient - connects to the PTY daemon via Unix domain socket.
+ *
+ * Used by the Electron main process to communicate with the daemon.
+ * Handles request-response correlation, event routing, and auto-reconnect.
+ */
+import { connect, type Socket } from 'net'
+import { EventEmitter } from 'events'
+import { SOCKET_PATH, encode, decode, type DaemonMessage, type DaemonRequest, type DaemonResponse, type DataEvent, type ExitEvent } from './protocol'
+
+const REQUEST_TIMEOUT_MS = 10_000
+const RECONNECT_DELAY_MS = 1_000
+const MAX_RECONNECT_ATTEMPTS = 5
+
+interface PendingRequest {
+  resolve: (data?: unknown) => void
+  reject: (err: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+export interface DaemonClientEvents {
+  data: [sessionId: string, data: string]
+  exit: [sessionId: string, exitCode: number]
+  connected: []
+  disconnected: []
+}
+
+export class DaemonClient extends EventEmitter<DaemonClientEvents> {
+  private socket: Socket | null = null
+  private lineBuffer = ''
+  private pending = new Map<string, PendingRequest>()
+  private requestCounter = 0
+  private reconnectAttempts = 0
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private _connected = false
+  private _closed = false
+
+  get connected(): boolean {
+    return this._connected
+  }
+
+  /** Connect to the daemon socket. */
+  async connect(): Promise<void> {
+    if (this._closed) return
+    return new Promise<void>((resolve, reject) => {
+      this.socket = connect(SOCKET_PATH)
+
+      this.socket.on('connect', () => {
+        this._connected = true
+        this.reconnectAttempts = 0
+        this.emit('connected')
+        resolve()
+      })
+
+      this.socket.on('data', (chunk: Buffer) => {
+        this.lineBuffer += chunk.toString()
+        this.processLines()
+      })
+
+      this.socket.on('close', () => {
+        this._connected = false
+        this.rejectAllPending('Connection closed')
+        this.emit('disconnected')
+        this.scheduleReconnect()
+      })
+
+      this.socket.on('error', (err) => {
+        if (!this._connected) {
+          reject(err)
+          return
+        }
+        this._connected = false
+        this.rejectAllPending('Connection error')
+        this.emit('disconnected')
+        this.scheduleReconnect()
+      })
+    })
+  }
+
+  /** Disconnect from the daemon (without killing it). */
+  disconnect(): void {
+    this._closed = true
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+    this.rejectAllPending('Client disconnected')
+    if (this.socket) {
+      this.socket.destroy()
+      this.socket = null
+    }
+    this._connected = false
+  }
+
+  // ── High-level operations ──────────────────────────────────────────────
+
+  async spawn(sessionId: string, cwd: string, cols: number, rows: number, shell: string, env?: Record<string, string>): Promise<void> {
+    await this.request({ type: 'spawn', sessionId, cwd, cols, rows, shell, env } as Omit<DaemonRequest, 'id'> & { type: 'spawn' })
+  }
+
+  async attach(sessionId: string): Promise<{ snapshot: string }> {
+    const result = await this.request({ type: 'attach', sessionId } as Omit<DaemonRequest, 'id'> & { type: 'attach' })
+    return result as { snapshot: string }
+  }
+
+  write(sessionId: string, data: string): void {
+    // Fire-and-forget
+    this.send({ type: 'write', sessionId, data } as Omit<DaemonRequest, 'id'> & { type: 'write' })
+  }
+
+  resize(sessionId: string, cols: number, rows: number): void {
+    // Fire-and-forget
+    this.send({ type: 'resize', sessionId, cols, rows } as Omit<DaemonRequest, 'id'> & { type: 'resize' })
+  }
+
+  async kill(sessionId: string): Promise<void> {
+    await this.request({ type: 'kill', sessionId } as Omit<DaemonRequest, 'id'> & { type: 'kill' })
+  }
+
+  async snapshot(sessionId: string): Promise<string> {
+    const result = await this.request({ type: 'snapshot', sessionId } as Omit<DaemonRequest, 'id'> & { type: 'snapshot' })
+    return (result as { snapshot: string }).snapshot
+  }
+
+  async list(): Promise<Array<{ sessionId: string; cwd: string; cols: number; rows: number; createdAt: number }>> {
+    const result = await this.request({ type: 'list' } as Omit<DaemonRequest, 'id'> & { type: 'list' })
+    return (result as { sessions: Array<{ sessionId: string; cwd: string; cols: number; rows: number; createdAt: number }> }).sessions
+  }
+
+  async ping(): Promise<void> {
+    await this.request({ type: 'ping' } as Omit<DaemonRequest, 'id'> & { type: 'ping' })
+  }
+
+  async shutdown(): Promise<void> {
+    await this.request({ type: 'shutdown' } as Omit<DaemonRequest, 'id'> & { type: 'shutdown' })
+  }
+
+  // ── Internal ───────────────────────────────────────────────────────────
+
+  private nextId(): string {
+    return `req-${++this.requestCounter}`
+  }
+
+  /** Send a fire-and-forget message. */
+  private send(msg: Record<string, unknown>): void {
+    if (!this.socket?.writable) return
+    const id = this.nextId()
+    const full = { ...msg, id }
+    this.socket.write(encode(full as DaemonMessage))
+  }
+
+  /** Send a request and await the correlated response. */
+  private request(msg: Record<string, unknown>): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket?.writable) {
+        reject(new Error('Not connected to daemon'))
+        return
+      }
+
+      const id = this.nextId()
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`Request timed out: ${msg.type}`))
+      }, REQUEST_TIMEOUT_MS)
+
+      this.pending.set(id, { resolve, reject, timer })
+      const full = { ...msg, id }
+      this.socket.write(encode(full as DaemonMessage))
+    })
+  }
+
+  private processLines(): void {
+    let idx: number
+    while ((idx = this.lineBuffer.indexOf('\n')) !== -1) {
+      const line = this.lineBuffer.slice(0, idx)
+      this.lineBuffer = this.lineBuffer.slice(idx + 1)
+
+      const msg = decode(line)
+      if (!msg) continue
+
+      if ('id' in msg && (msg.type === 'ok' || msg.type === 'error')) {
+        // This is a response to a request
+        const resp = msg as DaemonResponse
+        const pending = this.pending.get(resp.id)
+        if (pending) {
+          this.pending.delete(resp.id)
+          clearTimeout(pending.timer)
+          if (resp.type === 'error') {
+            pending.reject(new Error(resp.message))
+          } else {
+            pending.resolve(resp.data)
+          }
+        }
+      } else if (msg.type === 'data') {
+        const event = msg as DataEvent
+        this.emit('data', event.sessionId, event.data)
+      } else if (msg.type === 'exit') {
+        const event = msg as ExitEvent
+        this.emit('exit', event.sessionId, event.exitCode)
+      }
+    }
+  }
+
+  private rejectAllPending(reason: string): void {
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer)
+      pending.reject(new Error(reason))
+      this.pending.delete(id)
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this._closed) return
+    if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) return
+
+    this.reconnectTimer = setTimeout(async () => {
+      this.reconnectAttempts++
+      try {
+        await this.connect()
+      } catch {
+        // Will retry via the close/error handler
+      }
+    }, RECONNECT_DELAY_MS)
+  }
+}

--- a/src/main/services/ptyDaemon/daemonMain.ts
+++ b/src/main/services/ptyDaemon/daemonMain.ts
@@ -5,13 +5,19 @@
  * the Electron main process via child_process.fork(). It runs
  * independently and survives Electron restarts.
  */
+import { createWriteStream, mkdirSync } from 'fs'
+import { join } from 'path'
 import { SessionHost } from './sessionHost'
 import { SocketServer } from './socketServer'
 import { writePidFile, removePidFile } from './lifecycle'
 import { startCheckpointing, stopCheckpointing, loadCheckpoints } from './checkpoint'
-import { IDLE_SHUTDOWN_MS, SOCKET_PATH } from './protocol'
+import { IDLE_SHUTDOWN_MS, SOCKET_PATH, DAEMON_DIR } from './protocol'
 
 let shuttingDown = false
+
+// Redirect daemon logs to a file for troubleshooting
+mkdirSync(DAEMON_DIR, { recursive: true, mode: 0o700 })
+const logStream = createWriteStream(join(DAEMON_DIR, 'daemon.log'), { flags: 'a', mode: 0o600 })
 
 async function main(): Promise<void> {
   const host = new SessionHost()
@@ -96,11 +102,12 @@ async function main(): Promise<void> {
 
 function log(msg: string): void {
   const ts = new Date().toISOString()
-  // Write to stderr so stdout stays clean for potential future use
-  process.stderr.write(`[pty-daemon ${ts}] ${msg}\n`)
+  const line = `[pty-daemon ${ts}] ${msg}\n`
+  logStream.write(line)
 }
 
 main().catch((err) => {
-  process.stderr.write(`[pty-daemon] Fatal: ${err}\n`)
+  const line = `[pty-daemon] Fatal: ${err}\n`
+  logStream.write(line)
   process.exit(1)
 })

--- a/src/main/services/ptyDaemon/daemonMain.ts
+++ b/src/main/services/ptyDaemon/daemonMain.ts
@@ -1,0 +1,106 @@
+/**
+ * PTY Daemon entry point - standalone Node.js process.
+ *
+ * This file is built as a separate Rollup entry and spawned by
+ * the Electron main process via child_process.fork(). It runs
+ * independently and survives Electron restarts.
+ */
+import { SessionHost } from './sessionHost'
+import { SocketServer } from './socketServer'
+import { writePidFile, removePidFile } from './lifecycle'
+import { startCheckpointing, stopCheckpointing, loadCheckpoints } from './checkpoint'
+import { IDLE_SHUTDOWN_MS, SOCKET_PATH } from './protocol'
+
+let shuttingDown = false
+
+async function main(): Promise<void> {
+  const host = new SessionHost()
+
+  let idleTimer: ReturnType<typeof setTimeout> | null = null
+
+  function resetIdleTimer(): void {
+    if (idleTimer) clearTimeout(idleTimer)
+    idleTimer = setTimeout(() => {
+      log('Idle timeout reached, shutting down')
+      shutdown()
+    }, IDLE_SHUTDOWN_MS)
+  }
+
+  async function shutdown(): Promise<void> {
+    if (shuttingDown) return
+    shuttingDown = true
+
+    log('Shutting down...')
+    stopCheckpointing()
+
+    // Flush final checkpoints before killing PTYs
+    const { flushCheckpoints } = await import('./checkpoint')
+    flushCheckpoints(host)
+
+    host.killAll()
+    await server.close()
+    removePidFile()
+    log('Shutdown complete')
+    process.exit(0)
+  }
+
+  const server = new SocketServer(host, shutdown)
+
+  // Track client connections for idle auto-shutdown
+  server.setClientCallbacks(
+    () => {
+      // Client connected - cancel idle timer
+      if (idleTimer) {
+        clearTimeout(idleTimer)
+        idleTimer = null
+      }
+    },
+    () => {
+      // Client disconnected - restart idle timer if no clients left
+      if (server.clientCount === 0) {
+        resetIdleTimer()
+      }
+    },
+  )
+
+  // Write PID file
+  writePidFile()
+
+  // Restore sessions from checkpoints (cold restore)
+  const shell = process.env.SHELL || '/bin/zsh'
+  const checkpoints = loadCheckpoints()
+  for (const cp of checkpoints) {
+    try {
+      await host.restore(cp, shell)
+      log(`Restored session: ${cp.sessionId}`)
+    } catch (err) {
+      log(`Failed to restore session ${cp.sessionId}: ${err}`)
+    }
+  }
+
+  // Start socket server
+  await server.start()
+  log(`Listening on ${SOCKET_PATH} (pid: ${process.pid})`)
+
+  // Start periodic checkpointing
+  startCheckpointing(host)
+
+  // Start idle timer (will be cancelled on first client connect)
+  resetIdleTimer()
+
+  // Signal handlers
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+  process.on('SIGHUP', shutdown)
+}
+
+function log(msg: string): void {
+  const ts = new Date().toISOString()
+  // Write to stderr so stdout stays clean for potential future use
+  process.stderr.write(`[pty-daemon ${ts}] ${msg}\n`)
+}
+
+main().catch((err) => {
+  process.stderr.write(`[pty-daemon] Fatal: ${err}\n`)
+  process.exit(1)
+})

--- a/src/main/services/ptyDaemon/index.ts
+++ b/src/main/services/ptyDaemon/index.ts
@@ -1,0 +1,4 @@
+export { PtyDaemonAdapter } from './adapter'
+export { DaemonClient } from './client'
+export { isDaemonRunning, stopDaemon } from './lifecycle'
+export type { ReattachResult, SessionInfo } from './types'

--- a/src/main/services/ptyDaemon/lifecycle.ts
+++ b/src/main/services/ptyDaemon/lifecycle.ts
@@ -7,7 +7,7 @@ import { PID_FILE_PATH, SOCKET_PATH } from './protocol'
 
 /** Write the current process PID to the PID file. */
 export function writePidFile(): void {
-  mkdirSync(dirname(PID_FILE_PATH), { recursive: true })
+  mkdirSync(dirname(PID_FILE_PATH), { recursive: true, mode: 0o700 })
   writeFileSync(PID_FILE_PATH, String(process.pid), { mode: 0o600 })
 }
 

--- a/src/main/services/ptyDaemon/lifecycle.ts
+++ b/src/main/services/ptyDaemon/lifecycle.ts
@@ -1,0 +1,88 @@
+/**
+ * Daemon lifecycle helpers - PID file, stale socket detection, running checks.
+ */
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'fs'
+import { dirname } from 'path'
+import { PID_FILE_PATH, SOCKET_PATH } from './protocol'
+
+/** Write the current process PID to the PID file. */
+export function writePidFile(): void {
+  mkdirSync(dirname(PID_FILE_PATH), { recursive: true })
+  writeFileSync(PID_FILE_PATH, String(process.pid), { mode: 0o600 })
+}
+
+/** Remove the PID file. */
+export function removePidFile(): void {
+  try {
+    unlinkSync(PID_FILE_PATH)
+  } catch {
+    // May not exist
+  }
+}
+
+/** Remove the socket file. */
+export function removeSocketFile(): void {
+  try {
+    unlinkSync(SOCKET_PATH)
+  } catch {
+    // May not exist
+  }
+}
+
+/** Read the PID from the PID file. Returns null if not found. */
+export function readPidFile(): number | null {
+  try {
+    const content = readFileSync(PID_FILE_PATH, 'utf8').trim()
+    const pid = parseInt(content, 10)
+    return isNaN(pid) ? null : pid
+  } catch {
+    return null
+  }
+}
+
+/** Check if a process with the given PID is running. */
+export function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Check if the daemon is currently running.
+ * Returns the PID if running, null otherwise.
+ * Cleans up stale PID file and socket if the process is dead.
+ */
+export function isDaemonRunning(): number | null {
+  const pid = readPidFile()
+  if (pid === null) return null
+
+  if (isProcessRunning(pid)) {
+    return pid
+  }
+
+  // Process is dead - clean up stale files
+  removePidFile()
+  if (existsSync(SOCKET_PATH)) {
+    removeSocketFile()
+  }
+  return null
+}
+
+/**
+ * Send SIGTERM to the daemon process if it's running.
+ * Returns true if a signal was sent.
+ */
+export function stopDaemon(): boolean {
+  const pid = isDaemonRunning()
+  if (pid === null) return false
+
+  try {
+    process.kill(pid, 'SIGTERM')
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/main/services/ptyDaemon/protocol.ts
+++ b/src/main/services/ptyDaemon/protocol.ts
@@ -1,0 +1,150 @@
+/**
+ * NDJSON protocol definitions for PTY daemon communication.
+ *
+ * Socket path: ~/Braid/daemon/pty-v1.sock
+ * Messages are newline-delimited JSON (one JSON object per line).
+ */
+import { join } from 'path'
+import { homedir } from 'os'
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+export const PROTOCOL_VERSION = 1
+export const DAEMON_DIR = join(homedir(), 'Braid', 'daemon')
+export const SOCKET_PATH = join(DAEMON_DIR, `pty-v${PROTOCOL_VERSION}.sock`)
+export const PID_FILE_PATH = join(DAEMON_DIR, `pty-daemon.pid`)
+export const CHECKPOINT_DIR = join(DAEMON_DIR, 'checkpoints')
+
+/** Auto-shutdown after 10 minutes with no connected clients. */
+export const IDLE_SHUTDOWN_MS = 10 * 60 * 1000
+
+/** Checkpoint interval in milliseconds. */
+export const CHECKPOINT_INTERVAL_MS = 5_000
+
+/** Maximum RingBuffer size per session. */
+export const BUFFER_MAX_LENGTH = 50_000
+
+// ── Client -> Daemon Requests ────────────────────────────────────────────────
+
+export interface SpawnRequest {
+  id: string
+  type: 'spawn'
+  sessionId: string
+  cwd: string
+  cols: number
+  rows: number
+  env?: Record<string, string>
+  shell?: string
+}
+
+export interface AttachRequest {
+  id: string
+  type: 'attach'
+  sessionId: string
+}
+
+export interface WriteRequest {
+  id: string
+  type: 'write'
+  sessionId: string
+  data: string
+}
+
+export interface ResizeRequest {
+  id: string
+  type: 'resize'
+  sessionId: string
+  cols: number
+  rows: number
+}
+
+export interface KillRequest {
+  id: string
+  type: 'kill'
+  sessionId: string
+}
+
+export interface SnapshotRequest {
+  id: string
+  type: 'snapshot'
+  sessionId: string
+}
+
+export interface ListRequest {
+  id: string
+  type: 'list'
+}
+
+export interface PingRequest {
+  id: string
+  type: 'ping'
+}
+
+export interface ShutdownRequest {
+  id: string
+  type: 'shutdown'
+}
+
+export type DaemonRequest =
+  | SpawnRequest
+  | AttachRequest
+  | WriteRequest
+  | ResizeRequest
+  | KillRequest
+  | SnapshotRequest
+  | ListRequest
+  | PingRequest
+  | ShutdownRequest
+
+// ── Daemon -> Client Events (no id, pushed) ─────────────────────────────────
+
+export interface DataEvent {
+  type: 'data'
+  sessionId: string
+  data: string
+}
+
+export interface ExitEvent {
+  type: 'exit'
+  sessionId: string
+  exitCode: number
+}
+
+export type DaemonEvent = DataEvent | ExitEvent
+
+// ── Daemon -> Client Responses (correlated by id) ───────────────────────────
+
+export interface OkResponse {
+  id: string
+  type: 'ok'
+  data?: unknown
+}
+
+export interface ErrorResponse {
+  id: string
+  type: 'error'
+  message: string
+}
+
+export type DaemonResponse = OkResponse | ErrorResponse
+
+/** Any message that can flow over the socket. */
+export type DaemonMessage = DaemonRequest | DaemonEvent | DaemonResponse
+
+// ── Framing helpers ──────────────────────────────────────────────────────────
+
+/** Encode a message to an NDJSON line (with trailing newline). */
+export function encode(msg: DaemonMessage): string {
+  return JSON.stringify(msg) + '\n'
+}
+
+/** Parse a single NDJSON line. Returns null on invalid JSON. */
+export function decode(line: string): DaemonMessage | null {
+  const trimmed = line.trim()
+  if (!trimmed) return null
+  try {
+    return JSON.parse(trimmed) as DaemonMessage
+  } catch {
+    return null
+  }
+}

--- a/src/main/services/ptyDaemon/sessionHost.ts
+++ b/src/main/services/ptyDaemon/sessionHost.ts
@@ -1,0 +1,277 @@
+/**
+ * Manages all PTY sessions inside the daemon process.
+ *
+ * Each session has a node-pty instance and a RingBuffer holding
+ * the last N characters of output for snapshot/reattach.
+ */
+import { BUFFER_MAX_LENGTH } from './protocol'
+import type { DaemonSession, CheckpointData, SessionInfo } from './types'
+
+// ── RingBuffer ───────────────────────────────────────────────────────────────
+
+export class RingBuffer {
+  private chunks: string[] = []
+  private totalLength = 0
+
+  push(data: string): void {
+    this.chunks.push(data)
+    this.totalLength += data.length
+    while (this.totalLength > BUFFER_MAX_LENGTH && this.chunks.length > 1) {
+      const evicted = this.chunks.shift()!
+      this.totalLength -= evicted.length
+    }
+    if (this.totalLength > BUFFER_MAX_LENGTH && this.chunks.length === 1) {
+      this.chunks[0] = this.chunks[0].slice(this.chunks[0].length - BUFFER_MAX_LENGTH)
+      this.totalLength = this.chunks[0].length
+    }
+  }
+
+  read(): string {
+    return this.chunks.join('')
+  }
+
+  clear(): void {
+    this.chunks = []
+    this.totalLength = 0
+  }
+}
+
+// ── Session entry ────────────────────────────────────────────────────────────
+
+interface SessionEntry {
+  sessionId: string
+  cwd: string
+  cols: number
+  rows: number
+  createdAt: number
+  pty: import('node-pty').IPty
+  buffer: RingBuffer
+  attachedClients: number
+}
+
+// ── Events ───────────────────────────────────────────────────────────────────
+
+export interface SessionHostEvents {
+  data: (sessionId: string, data: string) => void
+  exit: (sessionId: string, exitCode: number) => void
+}
+
+type EventKey = keyof SessionHostEvents
+
+// ── SessionHost ──────────────────────────────────────────────────────────────
+
+export class SessionHost {
+  private sessions = new Map<string, SessionEntry>()
+  private listeners = new Map<EventKey, Set<(...args: unknown[]) => void>>()
+
+  on<K extends EventKey>(event: K, fn: SessionHostEvents[K]): void {
+    let set = this.listeners.get(event)
+    if (!set) {
+      set = new Set()
+      this.listeners.set(event, set)
+    }
+    set.add(fn as (...args: unknown[]) => void)
+  }
+
+  private emit<K extends EventKey>(event: K, ...args: Parameters<SessionHostEvents[K]>): void {
+    const set = this.listeners.get(event)
+    if (set) {
+      for (const fn of set) fn(...args)
+    }
+  }
+
+  /** Spawn a new PTY session. Throws if sessionId already exists. */
+  async spawn(
+    sessionId: string,
+    cwd: string,
+    cols: number,
+    rows: number,
+    shell: string,
+    env?: Record<string, string>,
+  ): Promise<void> {
+    if (this.sessions.has(sessionId)) {
+      throw new Error(`Session already exists: ${sessionId}`)
+    }
+
+    const nodePty = await import('node-pty')
+    const ptyProcess = nodePty.spawn(shell, ['-l'], {
+      name: 'xterm-256color',
+      cols,
+      rows,
+      cwd,
+      env: {
+        ...process.env as Record<string, string>,
+        TERM: 'xterm-256color',
+        ...env,
+      },
+    })
+
+    const buffer = new RingBuffer()
+    const entry: SessionEntry = {
+      sessionId,
+      cwd,
+      cols,
+      rows,
+      createdAt: Date.now(),
+      pty: ptyProcess,
+      buffer,
+      attachedClients: 0,
+    }
+
+    ptyProcess.onData((data: string) => {
+      buffer.push(data)
+      this.emit('data', sessionId, data)
+    })
+
+    ptyProcess.onExit(({ exitCode }: { exitCode: number }) => {
+      this.sessions.delete(sessionId)
+      this.emit('exit', sessionId, exitCode)
+    })
+
+    this.sessions.set(sessionId, entry)
+  }
+
+  /**
+   * Restore a session from checkpoint data by spawning a fresh PTY
+   * and pre-filling the RingBuffer with the checkpointed scrollback.
+   */
+  async restore(checkpoint: CheckpointData, shell: string): Promise<void> {
+    if (this.sessions.has(checkpoint.sessionId)) return
+
+    const nodePty = await import('node-pty')
+    const ptyProcess = nodePty.spawn(shell, ['-l'], {
+      name: 'xterm-256color',
+      cols: checkpoint.cols,
+      rows: checkpoint.rows,
+      cwd: checkpoint.cwd,
+      env: {
+        ...process.env as Record<string, string>,
+        TERM: 'xterm-256color',
+      },
+    })
+
+    const buffer = new RingBuffer()
+    buffer.push(checkpoint.scrollback)
+
+    const entry: SessionEntry = {
+      sessionId: checkpoint.sessionId,
+      cwd: checkpoint.cwd,
+      cols: checkpoint.cols,
+      rows: checkpoint.rows,
+      createdAt: checkpoint.createdAt,
+      pty: ptyProcess,
+      buffer,
+      attachedClients: 0,
+    }
+
+    ptyProcess.onData((data: string) => {
+      buffer.push(data)
+      this.emit('data', checkpoint.sessionId, data)
+    })
+
+    ptyProcess.onExit(({ exitCode }: { exitCode: number }) => {
+      this.sessions.delete(checkpoint.sessionId)
+      this.emit('exit', checkpoint.sessionId, exitCode)
+    })
+
+    this.sessions.set(checkpoint.sessionId, entry)
+  }
+
+  /** Write data to a session's PTY stdin. */
+  write(sessionId: string, data: string): void {
+    this.sessions.get(sessionId)?.pty.write(data)
+  }
+
+  /** Resize a session's PTY. */
+  resize(sessionId: string, cols: number, rows: number): void {
+    const entry = this.sessions.get(sessionId)
+    if (entry) {
+      entry.pty.resize(cols, rows)
+      entry.cols = cols
+      entry.rows = rows
+    }
+  }
+
+  /** Kill a session's PTY. The 'exit' event fires when it dies. */
+  kill(sessionId: string): void {
+    this.sessions.get(sessionId)?.pty.kill()
+  }
+
+  /** Kill all sessions (on daemon shutdown). */
+  killAll(): void {
+    for (const entry of this.sessions.values()) {
+      entry.pty.kill()
+    }
+  }
+
+  /** Mark a client as attached to a session. Returns the snapshot. */
+  attach(sessionId: string): string | null {
+    const entry = this.sessions.get(sessionId)
+    if (!entry) return null
+    entry.attachedClients++
+    return entry.buffer.read()
+  }
+
+  /** Mark a client as detached from a session. */
+  detach(sessionId: string): void {
+    const entry = this.sessions.get(sessionId)
+    if (entry && entry.attachedClients > 0) {
+      entry.attachedClients--
+    }
+  }
+
+  /** Detach from all sessions (when a client disconnects). */
+  detachAll(sessionIds: Set<string>): void {
+    for (const id of sessionIds) {
+      this.detach(id)
+    }
+  }
+
+  /** Get the current snapshot (RingBuffer contents) for a session. */
+  snapshot(sessionId: string): string | null {
+    return this.sessions.get(sessionId)?.buffer.read() ?? null
+  }
+
+  /** Check if a session exists. */
+  has(sessionId: string): boolean {
+    return this.sessions.has(sessionId)
+  }
+
+  /** List all active sessions. */
+  list(): SessionInfo[] {
+    const result: SessionInfo[] = []
+    for (const entry of this.sessions.values()) {
+      result.push({
+        sessionId: entry.sessionId,
+        cwd: entry.cwd,
+        cols: entry.cols,
+        rows: entry.rows,
+        createdAt: entry.createdAt,
+      })
+    }
+    return result
+  }
+
+  /** Get checkpoint data for all sessions (for periodic persistence). */
+  getCheckpoints(): CheckpointData[] {
+    const now = Date.now()
+    const result: CheckpointData[] = []
+    for (const entry of this.sessions.values()) {
+      result.push({
+        sessionId: entry.sessionId,
+        cwd: entry.cwd,
+        cols: entry.cols,
+        rows: entry.rows,
+        scrollback: entry.buffer.read(),
+        createdAt: entry.createdAt,
+        checkpointedAt: now,
+      })
+    }
+    return result
+  }
+
+  /** Number of active sessions. */
+  get size(): number {
+    return this.sessions.size
+  }
+}

--- a/src/main/services/ptyDaemon/socketServer.ts
+++ b/src/main/services/ptyDaemon/socketServer.ts
@@ -11,6 +11,9 @@ import { dirname } from 'path'
 import { SOCKET_PATH, encode, decode, type DaemonRequest, type DaemonEvent } from './protocol'
 import type { SessionHost } from './sessionHost'
 
+/** Maximum NDJSON line length (1 MB). Prevents memory exhaustion from malformed input. */
+const MAX_LINE_LENGTH = 1_024 * 1_024
+
 // ── Client tracking ──────────────────────────────────────────────────────────
 
 interface ClientState {
@@ -42,7 +45,7 @@ export class SocketServer {
 
   /** Start listening on the Unix domain socket. */
   async start(): Promise<void> {
-    mkdirSync(dirname(SOCKET_PATH), { recursive: true })
+    mkdirSync(dirname(SOCKET_PATH), { recursive: true, mode: 0o700 })
 
     // Remove stale socket file if present
     if (existsSync(SOCKET_PATH)) {
@@ -102,6 +105,11 @@ export class SocketServer {
 
     socket.on('data', (chunk: Buffer) => {
       client.lineBuffer += chunk.toString()
+      // Guard against memory exhaustion from missing newlines
+      if (client.lineBuffer.length > MAX_LINE_LENGTH && !client.lineBuffer.includes('\n')) {
+        client.lineBuffer = ''
+        return
+      }
       this.processLines(client)
     })
 

--- a/src/main/services/ptyDaemon/socketServer.ts
+++ b/src/main/services/ptyDaemon/socketServer.ts
@@ -1,0 +1,229 @@
+/**
+ * Unix domain socket server for the PTY daemon.
+ *
+ * Accepts multiple client connections. Each connection speaks NDJSON.
+ * Data events are broadcast to all connected clients that are attached
+ * to the emitting session.
+ */
+import { createServer, type Server, type Socket } from 'net'
+import { existsSync, unlinkSync, mkdirSync } from 'fs'
+import { dirname } from 'path'
+import { SOCKET_PATH, encode, decode, type DaemonRequest, type DaemonEvent } from './protocol'
+import type { SessionHost } from './sessionHost'
+
+// ── Client tracking ──────────────────────────────────────────────────────────
+
+interface ClientState {
+  socket: Socket
+  /** Incomplete NDJSON line buffer for this connection. */
+  lineBuffer: string
+  /** Session IDs this client is attached to (for routing data events). */
+  attachedSessions: Set<string>
+}
+
+// ── SocketServer ─────────────────────────────────────────────────────────────
+
+export class SocketServer {
+  private server: Server | null = null
+  private clients = new Set<ClientState>()
+  private onClientConnect?: () => void
+  private onClientDisconnect?: () => void
+
+  constructor(
+    private host: SessionHost,
+    private onShutdownRequested: () => void,
+  ) {}
+
+  /** Set callbacks for client connect/disconnect (used by lifecycle auto-shutdown timer). */
+  setClientCallbacks(onConnect: () => void, onDisconnect: () => void): void {
+    this.onClientConnect = onConnect
+    this.onClientDisconnect = onDisconnect
+  }
+
+  /** Start listening on the Unix domain socket. */
+  async start(): Promise<void> {
+    mkdirSync(dirname(SOCKET_PATH), { recursive: true })
+
+    // Remove stale socket file if present
+    if (existsSync(SOCKET_PATH)) {
+      unlinkSync(SOCKET_PATH)
+    }
+
+    // Wire up session host events to broadcast to attached clients
+    this.host.on('data', (sessionId, data) => {
+      this.broadcast({ type: 'data', sessionId, data })
+    })
+    this.host.on('exit', (sessionId, exitCode) => {
+      this.broadcast({ type: 'exit', sessionId, exitCode })
+      // Remove session from all clients' attached sets
+      for (const client of this.clients) {
+        client.attachedSessions.delete(sessionId)
+      }
+    })
+
+    return new Promise<void>((resolve, reject) => {
+      this.server = createServer((socket) => this.handleConnection(socket))
+      this.server.on('error', reject)
+      this.server.listen(SOCKET_PATH, () => {
+        this.server!.removeListener('error', reject)
+        resolve()
+      })
+    })
+  }
+
+  /** Stop accepting connections, close all clients. */
+  async close(): Promise<void> {
+    for (const client of this.clients) {
+      client.socket.destroy()
+    }
+    this.clients.clear()
+
+    return new Promise<void>((resolve) => {
+      if (!this.server) return resolve()
+      this.server.close(() => resolve())
+    })
+  }
+
+  get clientCount(): number {
+    return this.clients.size
+  }
+
+  // ── Connection handling ──────────────────────────────────────────────────
+
+  private handleConnection(socket: Socket): void {
+    const client: ClientState = {
+      socket,
+      lineBuffer: '',
+      attachedSessions: new Set(),
+    }
+
+    this.clients.add(client)
+    this.onClientConnect?.()
+
+    socket.on('data', (chunk: Buffer) => {
+      client.lineBuffer += chunk.toString()
+      this.processLines(client)
+    })
+
+    socket.on('close', () => {
+      // Detach from all sessions this client was attached to
+      this.host.detachAll(client.attachedSessions)
+      this.clients.delete(client)
+      this.onClientDisconnect?.()
+    })
+
+    socket.on('error', () => {
+      this.host.detachAll(client.attachedSessions)
+      this.clients.delete(client)
+      this.onClientDisconnect?.()
+    })
+  }
+
+  private processLines(client: ClientState): void {
+    let newlineIdx: number
+    while ((newlineIdx = client.lineBuffer.indexOf('\n')) !== -1) {
+      const line = client.lineBuffer.slice(0, newlineIdx)
+      client.lineBuffer = client.lineBuffer.slice(newlineIdx + 1)
+
+      const msg = decode(line)
+      if (msg && 'id' in msg) {
+        this.handleRequest(client, msg as DaemonRequest)
+      }
+    }
+  }
+
+  // ── Request dispatch ───────────────────────────────────────────────────
+
+  private async handleRequest(client: ClientState, req: DaemonRequest): Promise<void> {
+    try {
+      switch (req.type) {
+        case 'spawn':
+          await this.host.spawn(
+            req.sessionId, req.cwd, req.cols, req.rows,
+            req.shell || process.env.SHELL || '/bin/zsh',
+            req.env,
+          )
+          client.attachedSessions.add(req.sessionId)
+          this.sendResponse(client, { id: req.id, type: 'ok' })
+          break
+
+        case 'attach': {
+          const snapshot = this.host.attach(req.sessionId)
+          if (snapshot === null) {
+            this.sendResponse(client, { id: req.id, type: 'error', message: `Session not found: ${req.sessionId}` })
+          } else {
+            client.attachedSessions.add(req.sessionId)
+            this.sendResponse(client, { id: req.id, type: 'ok', data: { snapshot } })
+          }
+          break
+        }
+
+        case 'write':
+          this.host.write(req.sessionId, req.data)
+          // Fire-and-forget: no response
+          break
+
+        case 'resize':
+          this.host.resize(req.sessionId, req.cols, req.rows)
+          // Fire-and-forget: no response
+          break
+
+        case 'kill':
+          this.host.kill(req.sessionId)
+          client.attachedSessions.delete(req.sessionId)
+          this.sendResponse(client, { id: req.id, type: 'ok' })
+          break
+
+        case 'snapshot': {
+          const data = this.host.snapshot(req.sessionId)
+          if (data === null) {
+            this.sendResponse(client, { id: req.id, type: 'error', message: `Session not found: ${req.sessionId}` })
+          } else {
+            this.sendResponse(client, { id: req.id, type: 'ok', data: { snapshot: data } })
+          }
+          break
+        }
+
+        case 'list': {
+          const sessions = this.host.list()
+          this.sendResponse(client, { id: req.id, type: 'ok', data: { sessions } })
+          break
+        }
+
+        case 'ping':
+          this.sendResponse(client, { id: req.id, type: 'ok' })
+          break
+
+        case 'shutdown':
+          this.sendResponse(client, { id: req.id, type: 'ok' })
+          this.onShutdownRequested()
+          break
+
+        default: {
+          const exhaustive: never = req
+          this.sendResponse(client, { id: (exhaustive as DaemonRequest).id, type: 'error', message: `Unknown request type` })
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      this.sendResponse(client, { id: req.id, type: 'error', message })
+    }
+  }
+
+  // ── I/O helpers ────────────────────────────────────────────────────────
+
+  private sendResponse(client: ClientState, msg: { id: string; type: 'ok' | 'error'; data?: unknown; message?: string }): void {
+    if (!client.socket.writable) return
+    client.socket.write(encode(msg as import('./protocol').DaemonMessage))
+  }
+
+  /** Broadcast an event to all clients attached to the relevant session. */
+  private broadcast(event: DaemonEvent): void {
+    const line = encode(event)
+    for (const client of this.clients) {
+      if (client.attachedSessions.has(event.sessionId) && client.socket.writable) {
+        client.socket.write(line)
+      }
+    }
+  }
+}

--- a/src/main/services/ptyDaemon/types.ts
+++ b/src/main/services/ptyDaemon/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared types for the PTY daemon module.
+ */
+
+/** Information about an active PTY session in the daemon. */
+export interface DaemonSession {
+  sessionId: string
+  cwd: string
+  cols: number
+  rows: number
+  createdAt: number
+  /** Whether at least one client is currently attached to this session. */
+  attached: boolean
+}
+
+/** Checkpoint data persisted to disk for cold restore. */
+export interface CheckpointData {
+  sessionId: string
+  cwd: string
+  cols: number
+  rows: number
+  scrollback: string
+  createdAt: number
+  checkpointedAt: number
+}
+
+/** Result of a reattach operation returned to the renderer. */
+export interface ReattachResult {
+  sessionId: string
+  snapshot: string
+}
+
+/** Information about a session returned by list(). */
+export interface SessionInfo {
+  sessionId: string
+  cwd: string
+  cols: number
+  rows: number
+  createdAt: number
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -131,6 +131,10 @@ const api = {
       ipcRenderer.invoke('pty:readScrollback', terminalId) as Promise<string>,
     deleteScrollback: (terminalId: string) =>
       ipcRenderer.send('pty:deleteScrollback', terminalId),
+    reattach: (sessionId: string) =>
+      ipcRenderer.invoke('pty:reattach', sessionId) as Promise<{ sessionId: string; snapshot: string } | null>,
+    listSessions: () =>
+      ipcRenderer.invoke('pty:listSessions') as Promise<Array<{ sessionId: string; cwd: string; cols: number; rows: number; createdAt: number }>>,
     onAgentHookStatus: (callback: (status: { terminalId: string; state: string; agentType: string; toolName?: string; interrupted?: boolean }) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, status: { terminalId: string; state: string; agentType: string; toolName?: string; interrupted?: boolean }) => callback(status)
       ipcRenderer.on('agent-hook:status', handler)

--- a/src/renderer/components/Center/bigTerminalCache.ts
+++ b/src/renderer/components/Center/bigTerminalCache.ts
@@ -151,6 +151,31 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
 
   entry.spawnPromise = (async () => {
     let hasScrollback = false
+
+    // Attempt warm reattach to daemon session first
+    let reattached = false
+    try {
+      const result = await ipc.pty.reattach(terminalId)
+      if (result && result.snapshot) {
+        reattached = true
+        hasScrollback = true
+        entry.ptyId = result.sessionId
+        replayIntoTerminal(terminalId, term, result.snapshot)
+        replayIntoTerminal(terminalId, term, '\r\n\x1b[2m[session reconnected]\x1b[0m\r\n')
+        replayIntoTerminal(terminalId, term, POST_REPLAY_MODE_RESET)
+        ipc.pty.registerBigTerminal(result.sessionId, terminalId)
+        term.onData((d) => {
+          if (isReplaying(terminalId)) return
+          if (entry.ptyId && !entry.disposed) ipc.pty.write(entry.ptyId, d)
+        })
+      }
+    } catch {
+      // Reattach not available or failed - fall through to normal spawn
+    }
+
+    if (reattached || entry.disposed) return
+
+    // Fall back to scrollback file replay + fresh spawn
     try {
       const scrollback = await ipc.pty.readScrollback(terminalId)
       if (scrollback && scrollback.length > 0) {

--- a/src/renderer/components/Right/TabbedTerminal.tsx
+++ b/src/renderer/components/Right/TabbedTerminal.tsx
@@ -207,7 +207,7 @@ export function TabbedTerminal({ worktreePath, projectId, projectPath, hidden, c
     }
 
     try {
-      const id = await ipc.pty.spawn(worktreePathRef.current)
+      const id = await ipc.pty.spawn(worktreePathRef.current, { BRAID_TERMINAL_ID: tab.id })
       tab.ptyId = id
       tab.term.onData((data: string) => ipc.pty.write(id, data))
       requestAnimationFrame(() => {

--- a/src/renderer/components/Right/TabbedTerminal.tsx
+++ b/src/renderer/components/Right/TabbedTerminal.tsx
@@ -189,6 +189,23 @@ export function TabbedTerminal({ worktreePath, projectId, projectPath, hidden, c
   }, [])
 
   const spawnTab = useCallback(async (tab: TermTab) => {
+    // Attempt warm reattach to daemon session first
+    try {
+      const result = await ipc.pty.reattach(tab.id)
+      if (result && result.snapshot) {
+        tab.ptyId = result.sessionId
+        tab.term.write(result.snapshot)
+        tab.term.write('\r\n\x1b[2m[session reconnected]\x1b[0m\r\n')
+        tab.term.onData((data: string) => ipc.pty.write(result.sessionId, data))
+        requestAnimationFrame(() => {
+          try { tab.fitAddon.fit(); ipc.pty.resize(result.sessionId, tab.term.cols, tab.term.rows) } catch { /* ignore */ }
+        })
+        return
+      }
+    } catch {
+      // Reattach not available - fall through to fresh spawn
+    }
+
     try {
       const id = await ipc.pty.spawn(worktreePathRef.current)
       tab.ptyId = id

--- a/src/renderer/components/Right/terminalCache.ts
+++ b/src/renderer/components/Right/terminalCache.ts
@@ -8,6 +8,7 @@ import { LigaturesAddon } from '@xterm/addon-ligatures'
 import * as ipc from '@/lib/ipc'
 import { getTerminalTheme } from '@/themes/terminal'
 import { useUIStore } from '@/store/ui'
+import { SK } from '@/lib/storageKeys'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -151,6 +152,39 @@ export function activateWebgl(term: Terminal, onContextLoss?: () => void): Webgl
 export function disposeWebgl(addon: WebglAddon | null): void {
   if (!addon) return
   try { addon.dispose() } catch { /* ignore */ }
+}
+
+// ── Right-panel tab ID persistence (for daemon reattach across reloads) ──────
+
+interface PersistedTabInfo {
+  id: string
+  label: string
+}
+
+/** Save right-panel tab metadata for a worktree to localStorage. */
+export function saveRightTerminalTabs(worktreePath: string, tabs: TermTab[]): void {
+  try {
+    const data: PersistedTabInfo[] = tabs
+      .filter((t) => t.id !== SETUP_TAB_ID && t.id !== RUN_TAB_ID)
+      .map((t) => ({ id: t.id, label: t.label }))
+    localStorage.setItem(SK.rightTerminalTabsPrefix + worktreePath, JSON.stringify(data))
+  } catch { /* ignore */ }
+}
+
+/** Load persisted right-panel tab metadata for a worktree. */
+export function loadRightTerminalTabs(worktreePath: string): PersistedTabInfo[] {
+  try {
+    const raw = localStorage.getItem(SK.rightTerminalTabsPrefix + worktreePath)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .filter((x): x is { id: unknown; label: unknown } =>
+        typeof x === 'object' && x !== null && 'id' in x && 'label' in x)
+      .map((x) => ({ id: String(x.id), label: String(x.label) }))
+  } catch {
+    return []
+  }
 }
 
 /** Re-theme all cached terminals when the app theme changes */

--- a/src/renderer/components/Right/terminalCache.ts
+++ b/src/renderer/components/Right/terminalCache.ts
@@ -42,7 +42,7 @@ export const terminalCache = new Map<string, CachedTerminals>()
 let _tabCounter = 0
 export function nextTabId(): string {
   _tabCounter++
-  return `tab-${_tabCounter}`
+  return `rt-${Date.now()}-${_tabCounter}`
 }
 
 

--- a/src/renderer/components/Right/useTerminalLifecycle.ts
+++ b/src/renderer/components/Right/useTerminalLifecycle.ts
@@ -4,6 +4,7 @@ import { useUIStore } from '@/store/ui'
 import {
   SETUP_TAB_ID,
   terminalCache, nextTabId, createTerminal, initGlobalPtyRouting, reThemeAllTerminals,
+  saveRightTerminalTabs, loadRightTerminalTabs,
   type TermTab,
 } from './terminalCache'
 
@@ -116,6 +117,8 @@ export function useTerminalLifecycle({
       tab.resizeObserver = null
     }
     terminalCache.set(path, { tabs: currentTabs, activeTabId: activeTabIdRef.current })
+    // Persist tab IDs to localStorage so daemon sessions can be reattached after app restart
+    saveRightTerminalTabs(path, currentTabs)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Lifecycle: worktree switch ───────────────────────────────────────────
@@ -147,11 +150,29 @@ export function useTerminalLifecycle({
         }
       })
     } else {
-      setTabs([])
-      tabsRef.current = []
-      setActiveTabId(null)
-      activeTabIdRef.current = null
-      addTab()
+      // No in-memory cache - try restoring from localStorage (app restart with daemon alive)
+      const persisted = loadRightTerminalTabs(worktreePath)
+      if (persisted.length > 0) {
+        const restoredTabs: TermTab[] = persisted.map((p) => {
+          const { term, fitAddon } = createTerminal()
+          return { id: p.id, label: p.label, ptyId: null, term, fitAddon, resizeObserver: null }
+        })
+        setTabs(restoredTabs)
+        tabsRef.current = restoredTabs
+        const firstId = restoredTabs[0]?.id ?? null
+        setActiveTabId(firstId)
+        activeTabIdRef.current = firstId
+        // Mark all as pending attach so they get spawned/reattached when the DOM ref fires
+        for (const tab of restoredTabs) {
+          pendingAttach.current.set(tab.id, tab)
+        }
+      } else {
+        setTabs([])
+        tabsRef.current = []
+        setActiveTabId(null)
+        activeTabIdRef.current = null
+        addTab()
+      }
     }
     // Capture worktreePath in closure — cleanup runs after the next render
     // has already updated worktreePathRef, so we need the closed-over value

--- a/src/renderer/lib/ipc.ts
+++ b/src/renderer/lib/ipc.ts
@@ -116,6 +116,8 @@ export const pty = {
   registerBigTerminal: (ptyId: string, terminalId: string) => api().pty.registerBigTerminal(ptyId, terminalId),
   readScrollback: (terminalId: string) => api().pty.readScrollback(terminalId) as Promise<string>,
   deleteScrollback: (terminalId: string) => api().pty.deleteScrollback(terminalId),
+  reattach: (sessionId: string) => api().pty.reattach(sessionId) as Promise<{ sessionId: string; snapshot: string } | null>,
+  listSessions: () => api().pty.listSessions() as Promise<Array<{ sessionId: string; cwd: string; cols: number; rows: number; createdAt: number }>>,
   onAgentHookStatus: (callback: (status: { terminalId: string; state: string; agentType: string; toolName?: string; interrupted?: boolean }) => void) =>
     api().pty.onAgentHookStatus(callback),
 }

--- a/src/renderer/lib/storageKeys.ts
+++ b/src/renderer/lib/storageKeys.ts
@@ -118,8 +118,10 @@ export const SK = {
   noVirtualization:           `${prefix}:noVirtualization`,
   magicTrackpad:              `${prefix}:magicTrackpad`,
   bigTerminalEnabled:         `${prefix}:bigTerminalEnabled`,
-  /** Prefix — append worktreeId to get the full key, e.g. SK.bigTerminalTabsPrefix + worktreeId */
+  /** Prefix - append worktreeId to get the full key, e.g. SK.bigTerminalTabsPrefix + worktreeId */
   bigTerminalTabsPrefix:      `${prefix}:bigTerminalTabs:`,
+  /** Prefix - append worktreeId for right-panel terminal tab IDs (daemon reattach). */
+  rightTerminalTabsPrefix:    `${prefix}:rightTerminalTabs:`,
   rollbackHistory:            `${prefix}:rollbackHistory`,
   lastNewTabAction:           `${prefix}:lastNewTabAction`,
   webAppsEnabled:             `${prefix}:webAppsEnabled`,

--- a/src/renderer/store/sessions/__tests__/rollbackActions.test.ts
+++ b/src/renderer/store/sessions/__tests__/rollbackActions.test.ts
@@ -31,10 +31,10 @@ vi.mock('@/store/ui', () => ({
 // useSessionsStore with a ref that we patch per-test to point at the test store.
 const storeRef = { current: null as unknown }
 vi.mock('../store', () => ({
-  useSessionsStore: new Proxy({} as Record<string, unknown>, {
-    get(_target, prop) {
-      const s = storeRef.current as Record<string, unknown>
-      return s?.[prop]
+  useSessionsStore: new Proxy({} as Record<string | symbol, unknown>, {
+    get(_target, prop: string | symbol) {
+      const s = storeRef.current as Record<string | symbol, unknown>
+      return s?.[prop as string]
     }
   })
 }))
@@ -254,8 +254,8 @@ describe('rollbackToUserMessage', () => {
       const msg = makeMsg({ id: 'msg-1', role: 'user', snapshotSha: 'snap1' })
       const { actions, getSession: get } = createActions({
         messages: [msg],
-        pendingQuestion: { question: 'test' } as AgentSession['pendingQuestion'],
-        pendingPlanApproval: { planContent: 'test' } as AgentSession['pendingPlanApproval'],
+        pendingQuestion: { toolUseId: 'tu-1', questions: [{ question: 'test', header: '', options: [], multiSelect: false }] } as AgentSession['pendingQuestion'],
+        pendingPlanApproval: { toolUseId: 'tu-2' } as AgentSession['pendingPlanApproval'],
       })
       await actions.rollbackToUserMessage('sess-1', 'msg-1')
       expect(get().pendingQuestion).toBeUndefined()


### PR DESCRIPTION
## Summary

- Add a standalone PTY daemon process that keeps terminal sessions alive across Electron app restarts
- Daemon communicates via Unix domain socket (`~/Braid/daemon/pty-v1.sock`) using NDJSON protocol
- Renderer seamlessly reattaches to surviving sessions on reload, falling back to fresh spawn if unavailable

## Layers touched

- [x] **Main process** (`src/main/`) — services, IPC handlers
- [x] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib

## Changes

**Services** (`ptyDaemon/`):
- `daemonMain.ts` - standalone Node entry point (forked, detached), auto-shuts down after 10min idle
- `sessionHost.ts` - manages PTY sessions with 50KB RingBuffer for snapshots
- `socketServer.ts` - multi-client Unix socket server routing data/exit events to attached clients
- `client.ts` - request-response client with request correlation, timeouts, and auto-reconnect
- `adapter.ts` - implements `IPtyService`, transparently proxies all operations to the daemon
- `checkpoint.ts` - periodic atomic writes (every 5s) for cold restore after daemon crash
- `protocol.ts` - NDJSON message types (spawn/attach/write/resize/kill/snapshot/list/ping/shutdown)
- `lifecycle.ts` - PID file management, stale socket cleanup
- `types.ts` - shared type definitions

**IPC** (`main/ipc.ts` -> `preload/index.ts` -> `lib/ipc.ts`):
- New `pty:reattach` handler - returns session snapshot for warm reconnect
- New `pty:listSessions` handler - lists active daemon sessions

**Renderer** (`Center/bigTerminalCache.ts`, `Right/TabbedTerminal.tsx`):
- Both attempt warm reattach before spawning a fresh PTY
- Shows "[session reconnected]" indicator on successful reattach
- Tab IDs now include timestamps (`rt-{ts}-{counter}`) for stable daemon session mapping

**Build** (`electron.vite.config.ts`):
- Added `daemonMain` as a separate Rollup entry point

## How to test

1. `yarn dev`
2. Open a terminal in the right panel, run a command (e.g., `ls`)
3. Cmd+R to reload the window - terminal should reattach with scrollback preserved and "[session reconnected]" message
4. Quit the app entirely, relaunch - daemon restores sessions from checkpoint files
5. Check `~/Braid/daemon/` for `pty-v1.sock` and `pty-daemon.pid`
6. After 10 minutes with no Braid windows, daemon auto-shuts down

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [ ] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [x] IPC changes are threaded through all 3 layers (main -> preload -> renderer)
- [x] New state is added to the correct Zustand store