### PR TITLE
feat(themes): add per-theme terminal ANSI colors for all 29 builtin themes

### DIFF
--- a/src/renderer/themes/__tests__/builtinTerminal.test.ts
+++ b/src/renderer/themes/__tests__/builtinTerminal.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { builtinThemes } from '../palettes'
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/
+const TERMINAL_FIELDS = [
+  'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white',
+  'brightBlack', 'brightRed', 'brightGreen', 'brightYellow',
+  'brightBlue', 'brightMagenta', 'brightCyan', 'brightWhite'
+] as const
+
+describe('builtin theme terminal colors', () => {
+  it('has at least 29 builtin themes', () => {
+    expect(builtinThemes.length).toBeGreaterThanOrEqual(29)
+  })
+
+  for (const theme of builtinThemes) {
+    describe(theme.name, () => {
+      it('has a terminal color block', () => {
+        expect(theme.terminal).toBeDefined()
+      })
+
+      it('has all 16 valid hex ANSI colors', () => {
+        expect(theme.terminal).toBeDefined()
+        for (const field of TERMINAL_FIELDS) {
+          expect(theme.terminal![field]).toMatch(HEX_RE)
+        }
+      })
+    })
+  }
+})

--- a/src/renderer/themes/__tests__/deriveTerminal.test.ts
+++ b/src/renderer/themes/__tests__/deriveTerminal.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest'
+import { deriveTerminalColors } from '../deriveTerminal'
+import type { ThemePalette } from '../palettes'
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/
+
+const darkPalette: ThemePalette = {
+  id: 'test-dark',
+  name: 'Test Dark',
+  type: 'dark',
+  source: 'custom',
+  colors: {
+    bgPrimary: '#1e1e1e',
+    bgSecondary: '#252526',
+    bgTertiary: '#2d2d2d',
+    bgHover: '#3a3a3a',
+    border: '#404040',
+    textPrimary: '#d4d4d4',
+    textSecondary: '#9a9a9a',
+    textMuted: '#666666',
+    accent: '#569cd6',
+    accentHover: '#6bb3f0',
+    green: '#6a9955',
+    red: '#f44747',
+    amber: '#dcdcaa',
+    olive: '#808080',
+    hlBase: '#d4d4d4',
+    hlComment: '#6a9955',
+    hlKeyword: '#c586c0',
+    hlAttrName: '#9cdcfe',
+    hlString: '#ce9178',
+    hlTitle: '#dcdcaa',
+    hlType: '#4ec9b0',
+    hlNumber: '#b5cea8',
+    hlMeta: '#569cd6',
+    hlVariable: '#9cdcfe',
+    hlTag: '#569cd6',
+    hlAttr: '#9cdcfe'
+  }
+}
+
+const lightPalette: ThemePalette = {
+  ...darkPalette,
+  id: 'test-light',
+  name: 'Test Light',
+  type: 'light',
+  colors: {
+    ...darkPalette.colors,
+    bgPrimary: '#ffffff',
+    textPrimary: '#333333',
+    textMuted: '#aaaaaa',
+    accent: '#0969da',
+    hlTitle: '#8250df',
+    hlMeta: '#0550ae'
+  }
+}
+
+const TERMINAL_FIELDS = [
+  'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white',
+  'brightBlack', 'brightRed', 'brightGreen', 'brightYellow',
+  'brightBlue', 'brightMagenta', 'brightCyan', 'brightWhite'
+] as const
+
+describe('deriveTerminalColors', () => {
+  it('produces 16 valid hex colors for a dark palette', () => {
+    const result = deriveTerminalColors(darkPalette)
+    for (const field of TERMINAL_FIELDS) {
+      expect(result[field]).toMatch(HEX_RE)
+    }
+  })
+
+  it('produces 16 valid hex colors for a light palette', () => {
+    const result = deriveTerminalColors(lightPalette)
+    for (const field of TERMINAL_FIELDS) {
+      expect(result[field]).toMatch(HEX_RE)
+    }
+  })
+
+  it('maps palette.red to terminal red', () => {
+    const result = deriveTerminalColors(darkPalette)
+    expect(result.red).toBe(darkPalette.colors.red)
+  })
+
+  it('maps palette.green to terminal green', () => {
+    const result = deriveTerminalColors(darkPalette)
+    expect(result.green).toBe(darkPalette.colors.green)
+  })
+
+  it('maps palette.amber to terminal yellow', () => {
+    const result = deriveTerminalColors(darkPalette)
+    expect(result.yellow).toBe(darkPalette.colors.amber)
+  })
+
+  it('maps palette.accent to terminal blue', () => {
+    const result = deriveTerminalColors(darkPalette)
+    expect(result.blue).toBe(darkPalette.colors.accent)
+  })
+
+  it('uses bgPrimary for black on dark themes', () => {
+    const result = deriveTerminalColors(darkPalette)
+    expect(result.black).toBe(darkPalette.colors.bgPrimary)
+  })
+
+  it('uses textPrimary for white on dark themes', () => {
+    const result = deriveTerminalColors(darkPalette)
+    expect(result.white).toBe(darkPalette.colors.textPrimary)
+  })
+
+  it('uses a dark black for light themes (not the light bgPrimary)', () => {
+    const result = deriveTerminalColors(lightPalette)
+    expect(result.black).not.toBe(lightPalette.colors.bgPrimary)
+    expect(result.black).toBe('#2e3440')
+  })
+
+  it('bright variants differ from base variants', () => {
+    const result = deriveTerminalColors(darkPalette)
+    expect(result.brightRed).not.toBe(result.red)
+    expect(result.brightGreen).not.toBe(result.green)
+    expect(result.brightBlue).not.toBe(result.blue)
+  })
+})

--- a/src/renderer/themes/__tests__/terminal.test.ts
+++ b/src/renderer/themes/__tests__/terminal.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { getTerminalTheme } from '../terminal'
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/
+
+// Simulate CSS custom properties on document.documentElement
+beforeEach(() => {
+  const vars: Record<string, string> = {
+    '--bg-primary': '#0d1117',
+    '--text-primary': '#e6edf3',
+    '--accent': '#58a6ff',
+    '--accent-tint-30': '#58a6ff4d',
+    '--term-black': '#0d1117',
+    '--term-red': '#f85149',
+    '--term-green': '#3fb950',
+    '--term-yellow': '#d29922',
+    '--term-blue': '#58a6ff',
+    '--term-magenta': '#d2a8ff',
+    '--term-cyan': '#79c0ff',
+    '--term-white': '#e6edf3',
+    '--term-bright-black': '#6e7681',
+    '--term-bright-red': '#ffa198',
+    '--term-bright-green': '#56d364',
+    '--term-bright-yellow': '#e3b341',
+    '--term-bright-blue': '#79c0ff',
+    '--term-bright-magenta': '#d2a8ff',
+    '--term-bright-cyan': '#a5d6ff',
+    '--term-bright-white': '#f0f6fc'
+  }
+
+  // Mock getComputedStyle to return our vars
+  const original = window.getComputedStyle
+  vi.spyOn(window, 'getComputedStyle').mockImplementation((elt: Element) => {
+    if (elt === document.documentElement) {
+      return {
+        getPropertyValue: (name: string) => vars[name] ?? ''
+      } as CSSStyleDeclaration
+    }
+    return original(elt)
+  })
+})
+
+describe('getTerminalTheme', () => {
+  it('returns an object with all 16 ANSI color fields', () => {
+    const theme = getTerminalTheme()
+    const fields = [
+      'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white',
+      'brightBlack', 'brightRed', 'brightGreen', 'brightYellow',
+      'brightBlue', 'brightMagenta', 'brightCyan', 'brightWhite'
+    ] as const
+    for (const field of fields) {
+      expect(theme[field]).toMatch(HEX_RE)
+    }
+  })
+
+  it('reads --term-* CSS vars for base colors', () => {
+    const theme = getTerminalTheme()
+    expect(theme.red).toBe('#f85149')
+    expect(theme.green).toBe('#3fb950')
+    expect(theme.magenta).toBe('#d2a8ff')
+    expect(theme.cyan).toBe('#79c0ff')
+  })
+
+  it('reads --term-bright-* CSS vars for bright colors', () => {
+    const theme = getTerminalTheme()
+    expect(theme.brightRed).toBe('#ffa198')
+    expect(theme.brightGreen).toBe('#56d364')
+    expect(theme.brightMagenta).toBe('#d2a8ff')
+    expect(theme.brightCyan).toBe('#a5d6ff')
+  })
+
+  it('includes background, foreground, and cursor', () => {
+    const theme = getTerminalTheme()
+    expect(theme.background).toBe('#0d1117')
+    expect(theme.foreground).toBe('#e6edf3')
+    expect(theme.cursor).toBe('#58a6ff')
+  })
+
+  it('includes selectionBackground', () => {
+    const theme = getTerminalTheme()
+    expect(theme.selectionBackground).toBeTruthy()
+  })
+})

--- a/src/renderer/themes/apply.ts
+++ b/src/renderer/themes/apply.ts
@@ -1,4 +1,5 @@
 import type { ThemePalette } from './palettes'
+import { deriveTerminalColors } from './deriveTerminal'
 
 /** Convert hex color + opacity (0-100) to hex with alpha channel */
 export function hexAlpha(hex: string, opacity: number): string {
@@ -140,6 +141,27 @@ export function applyTheme(palette: ThemePalette): void {
     '--hljs-variable': c.hlVariable,
     '--hljs-tag': c.hlTag,
     '--hljs-attr': c.hlAttr
+  })
+
+  // Terminal ANSI colors
+  const term = palette.terminal ?? deriveTerminalColors(palette)
+  setVars({
+    '--term-black': term.black,
+    '--term-red': term.red,
+    '--term-green': term.green,
+    '--term-yellow': term.yellow,
+    '--term-blue': term.blue,
+    '--term-magenta': term.magenta,
+    '--term-cyan': term.cyan,
+    '--term-white': term.white,
+    '--term-bright-black': term.brightBlack,
+    '--term-bright-red': term.brightRed,
+    '--term-bright-green': term.brightGreen,
+    '--term-bright-yellow': term.brightYellow,
+    '--term-bright-blue': term.brightBlue,
+    '--term-bright-magenta': term.brightMagenta,
+    '--term-bright-cyan': term.brightCyan,
+    '--term-bright-white': term.brightWhite
   })
 
   // Set data-theme attribute for any CSS-only selectors

--- a/src/renderer/themes/deriveTerminal.ts
+++ b/src/renderer/themes/deriveTerminal.ts
@@ -1,0 +1,62 @@
+import type { TerminalColors, ThemePalette } from './palettes'
+
+/** Parse a hex color into [r, g, b] */
+function parseHex(hex: string): [number, number, number] {
+  return [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16)
+  ]
+}
+
+/** Convert [r, g, b] back to hex */
+function toHex(r: number, g: number, b: number): string {
+  const clamp = (v: number) => Math.min(255, Math.max(0, Math.round(v)))
+  return (
+    '#' +
+    clamp(r).toString(16).padStart(2, '0') +
+    clamp(g).toString(16).padStart(2, '0') +
+    clamp(b).toString(16).padStart(2, '0')
+  )
+}
+
+/** Lighten a hex color by a factor (0-1) */
+function lighten(hex: string, amount: number): string {
+  const [r, g, b] = parseHex(hex)
+  return toHex(r + (255 - r) * amount, g + (255 - g) * amount, b + (255 - b) * amount)
+}
+
+/** Darken a hex color by a factor (0-1) */
+function darken(hex: string, amount: number): string {
+  const [r, g, b] = parseHex(hex)
+  return toHex(r * (1 - amount), g * (1 - amount), b * (1 - amount))
+}
+
+/**
+ * Derive terminal ANSI colors from a theme palette.
+ * Used as a fallback for custom/VSCode themes that don't provide explicit terminal colors.
+ */
+export function deriveTerminalColors(palette: ThemePalette): TerminalColors {
+  const c = palette.colors
+  const isDark = palette.type === 'dark'
+  const brighten = isDark ? lighten : darken
+
+  return {
+    black: isDark ? c.bgPrimary : '#2e3440',
+    red: c.red,
+    green: c.green,
+    yellow: c.amber,
+    blue: c.accent,
+    magenta: c.hlTitle,
+    cyan: c.hlMeta,
+    white: isDark ? c.textPrimary : '#d8dee9',
+    brightBlack: isDark ? c.textMuted : '#4c566a',
+    brightRed: brighten(c.red, 0.15),
+    brightGreen: brighten(c.green, 0.15),
+    brightYellow: brighten(c.amber, 0.15),
+    brightBlue: brighten(c.accent, 0.15),
+    brightMagenta: brighten(c.hlTitle, 0.15),
+    brightCyan: brighten(c.hlMeta, 0.15),
+    brightWhite: isDark ? lighten(c.textPrimary, 0.1) : '#eceff4'
+  }
+}

--- a/src/renderer/themes/palettes/accessibility/deuteranopia-dark.ts
+++ b/src/renderer/themes/palettes/accessibility/deuteranopia-dark.ts
@@ -33,5 +33,23 @@ export const deuteranopiaDark: ThemePalette = {
     hlVariable: '#e89a3c',
     hlTag: '#4a9eff',
     hlAttr: '#c49aff'
+  },
+  terminal: {
+    black: '#1a1d24',
+    red: '#5b9fff',
+    green: '#e89a3c',
+    yellow: '#d4a340',
+    blue: '#4a9eff',
+    magenta: '#c49aff',
+    cyan: '#6db3ff',
+    white: '#e2e6ed',
+    brightBlack: '#6b7380',
+    brightRed: '#7ab4ff',
+    brightGreen: '#f0b05c',
+    brightYellow: '#e0b75c',
+    brightBlue: '#6db3ff',
+    brightMagenta: '#d4b2ff',
+    brightCyan: '#8ac4ff',
+    brightWhite: '#f0f3f8'
   }
 }

--- a/src/renderer/themes/palettes/accessibility/protanopia-light.ts
+++ b/src/renderer/themes/palettes/accessibility/protanopia-light.ts
@@ -33,5 +33,23 @@ export const protanopiaLight: ThemePalette = {
     hlVariable: '#b35d00',
     hlTag: '#0860bf',
     hlAttr: '#7b40c0'
+  },
+  terminal: {
+    black: '#2c3240',
+    red: '#0860bf',
+    green: '#b35d00',
+    yellow: '#8a6d00',
+    blue: '#0860bf',
+    magenta: '#7b40c0',
+    cyan: '#0550a0',
+    white: '#8690a0',
+    brightBlack: '#5a6170',
+    brightRed: '#1a78d4',
+    brightGreen: '#c87218',
+    brightYellow: '#a08218',
+    brightBlue: '#1a78d4',
+    brightMagenta: '#9058d0',
+    brightCyan: '#1668b8',
+    brightWhite: '#fafbfc'
   }
 }

--- a/src/renderer/themes/palettes/accessibility/tritanopia-dark.ts
+++ b/src/renderer/themes/palettes/accessibility/tritanopia-dark.ts
@@ -33,5 +33,23 @@ export const tritanopiaDark: ThemePalette = {
     hlVariable: '#d46b6b',
     hlTag: '#e85d75',
     hlAttr: '#c49aff'
+  },
+  terminal: {
+    black: '#1c1a20',
+    red: '#e85d75',
+    green: '#5bc8af',
+    yellow: '#d46b6b',
+    blue: '#e85d75',
+    magenta: '#c49aff',
+    cyan: '#5bc8af',
+    white: '#e4e0ed',
+    brightBlack: '#706b80',
+    brightRed: '#f07a90',
+    brightGreen: '#72d4bf',
+    brightYellow: '#df8585',
+    brightBlue: '#f07a90',
+    brightMagenta: '#d4b2ff',
+    brightCyan: '#72d4bf',
+    brightWhite: '#f0ecf5'
   }
 }

--- a/src/renderer/themes/palettes/dark/amethyst.ts
+++ b/src/renderer/themes/palettes/dark/amethyst.ts
@@ -33,5 +33,23 @@ export const amethyst: ThemePalette = {
     hlVariable: '#ffb86c',
     hlTag: '#ff79c6',
     hlAttr: '#50fa7b'
+  },
+  terminal: {
+    black: '#21222c',
+    red: '#ff5555',
+    green: '#50fa7b',
+    yellow: '#f1fa8c',
+    blue: '#bd93f9',
+    magenta: '#ff79c6',
+    cyan: '#8be9fd',
+    white: '#f8f8f2',
+    brightBlack: '#6272a4',
+    brightRed: '#ff6e6e',
+    brightGreen: '#69ff94',
+    brightYellow: '#ffffa5',
+    brightBlue: '#d6acff',
+    brightMagenta: '#ff92df',
+    brightCyan: '#a4ffff',
+    brightWhite: '#ffffff'
   }
 }

--- a/src/renderer/themes/palettes/dark/arctic.ts
+++ b/src/renderer/themes/palettes/dark/arctic.ts
@@ -33,5 +33,23 @@ export const arctic: ThemePalette = {
     hlVariable: '#bf616a',
     hlTag: '#81a1c1',
     hlAttr: '#8fbcbb'
+  },
+  terminal: {
+    black: '#3b4252',
+    red: '#bf616a',
+    green: '#a3be8c',
+    yellow: '#ebcb8b',
+    blue: '#81a1c1',
+    magenta: '#b48ead',
+    cyan: '#88c0d0',
+    white: '#e5e9f0',
+    brightBlack: '#4c566a',
+    brightRed: '#d08770',
+    brightGreen: '#a3be8c',
+    brightYellow: '#ebcb8b',
+    brightBlue: '#81a1c1',
+    brightMagenta: '#b48ead',
+    brightCyan: '#8fbcbb',
+    brightWhite: '#eceff4'
   }
 }

--- a/src/renderer/themes/palettes/dark/bourbon.ts
+++ b/src/renderer/themes/palettes/dark/bourbon.ts
@@ -33,5 +33,23 @@ export const bourbon: ThemePalette = {
     hlVariable: '#fe8019',
     hlTag: '#fb4934',
     hlAttr: '#8ec07c'
+  },
+  terminal: {
+    black: '#282828',
+    red: '#cc241d',
+    green: '#98971a',
+    yellow: '#d79921',
+    blue: '#458588',
+    magenta: '#b16286',
+    cyan: '#689d6a',
+    white: '#a89984',
+    brightBlack: '#928374',
+    brightRed: '#fb4934',
+    brightGreen: '#b8bb26',
+    brightYellow: '#fabd2f',
+    brightBlue: '#83a598',
+    brightMagenta: '#d3869b',
+    brightCyan: '#8ec07c',
+    brightWhite: '#ebdbb2'
   }
 }

--- a/src/renderer/themes/palettes/dark/bronze.ts
+++ b/src/renderer/themes/palettes/dark/bronze.ts
@@ -33,5 +33,23 @@ export const bronze: ThemePalette = {
     hlVariable: '#cb4b16',
     hlTag: '#268bd2',
     hlAttr: '#657b83'
+  },
+  terminal: {
+    black: '#073642',
+    red: '#dc322f',
+    green: '#859900',
+    yellow: '#b58900',
+    blue: '#268bd2',
+    magenta: '#d33682',
+    cyan: '#2aa198',
+    white: '#eee8d5',
+    brightBlack: '#002b36',
+    brightRed: '#cb4b16',
+    brightGreen: '#586e75',
+    brightYellow: '#657b83',
+    brightBlue: '#839496',
+    brightMagenta: '#6c71c4',
+    brightCyan: '#93a1a1',
+    brightWhite: '#fdf6e3'
   }
 }

--- a/src/renderer/themes/palettes/dark/canyon-dark.ts
+++ b/src/renderer/themes/palettes/dark/canyon-dark.ts
@@ -33,5 +33,23 @@ export const canyonDark: ThemePalette = {
     hlVariable: '#e6e1cf',
     hlTag: '#59c2ff',
     hlAttr: '#ffb454'
+  },
+  terminal: {
+    black: '#0f1419',
+    red: '#f07178',
+    green: '#aad94c',
+    yellow: '#ffb454',
+    blue: '#39bae6',
+    magenta: '#d2a6ff',
+    cyan: '#95e6cb',
+    white: '#e6e1cf',
+    brightBlack: '#5c6773',
+    brightRed: '#ff8f89',
+    brightGreen: '#bae66c',
+    brightYellow: '#ffc46b',
+    brightBlue: '#59c2ff',
+    brightMagenta: '#dcb8ff',
+    brightCyan: '#a8edda',
+    brightWhite: '#f0ede4'
   }
 }

--- a/src/renderer/themes/palettes/dark/cocoa.ts
+++ b/src/renderer/themes/palettes/dark/cocoa.ts
@@ -33,5 +33,23 @@ export const cocoa: ThemePalette = {
     hlVariable: '#f38ba8',
     hlTag: '#f38ba8',
     hlAttr: '#b4befe'
+  },
+  terminal: {
+    black: '#45475a',
+    red: '#f38ba8',
+    green: '#a6e3a1',
+    yellow: '#f9e2af',
+    blue: '#89b4fa',
+    magenta: '#f5c2e7',
+    cyan: '#94e2d5',
+    white: '#bac2de',
+    brightBlack: '#585b70',
+    brightRed: '#f5a0b8',
+    brightGreen: '#b5e8b5',
+    brightYellow: '#fae8bd',
+    brightBlue: '#a0c4fb',
+    brightMagenta: '#f7ceec',
+    brightCyan: '#a8e8de',
+    brightWhite: '#a6adc8'
   }
 }

--- a/src/renderer/themes/palettes/dark/dusk-rose.ts
+++ b/src/renderer/themes/palettes/dark/dusk-rose.ts
@@ -33,5 +33,23 @@ export const duskRose: ThemePalette = {
     hlVariable: '#e0def4',
     hlTag: '#eb6f92',
     hlAttr: '#ebbcba'
+  },
+  terminal: {
+    black: '#26233a',
+    red: '#eb6f92',
+    green: '#31748f',
+    yellow: '#f6c177',
+    blue: '#9ccfd8',
+    magenta: '#c4a7e7',
+    cyan: '#ebbcba',
+    white: '#e0def4',
+    brightBlack: '#6e6a86',
+    brightRed: '#f083a2',
+    brightGreen: '#3d8fa8',
+    brightYellow: '#f8cc8b',
+    brightBlue: '#aed8e0',
+    brightMagenta: '#d0b8ec',
+    brightCyan: '#f0c9c7',
+    brightWhite: '#e8e6f8'
   }
 }

--- a/src/renderer/themes/palettes/dark/ember.ts
+++ b/src/renderer/themes/palettes/dark/ember.ts
@@ -33,5 +33,23 @@ export const ember: ThemePalette = {
     hlVariable: '#fc9867',
     hlTag: '#ff6188',
     hlAttr: '#a9dc76'
+  },
+  terminal: {
+    black: '#2d2a2e',
+    red: '#ff6188',
+    green: '#a9dc76',
+    yellow: '#ffd866',
+    blue: '#78dce8',
+    magenta: '#ab9df2',
+    cyan: '#78dce8',
+    white: '#fcfcfa',
+    brightBlack: '#727072',
+    brightRed: '#ff7999',
+    brightGreen: '#b8e38a',
+    brightYellow: '#ffde7a',
+    brightBlue: '#8fe4ee',
+    brightMagenta: '#baaef5',
+    brightCyan: '#8fe4ee',
+    brightWhite: '#ffffff'
   }
 }

--- a/src/renderer/themes/palettes/dark/high-contrast.ts
+++ b/src/renderer/themes/palettes/dark/high-contrast.ts
@@ -33,5 +33,23 @@ export const highContrast: ThemePalette = {
     hlVariable: '#ffa657',
     hlTag: '#7ee787',
     hlAttr: '#79c0ff'
+  },
+  terminal: {
+    black: '#000000',
+    red: '#ff6a69',
+    green: '#3fb950',
+    yellow: '#f0b72f',
+    blue: '#409eff',
+    magenta: '#d2a8ff',
+    cyan: '#76e3ea',
+    white: '#ffffff',
+    brightBlack: '#6e7681',
+    brightRed: '#ff9492',
+    brightGreen: '#56d364',
+    brightYellow: '#f4c753',
+    brightBlue: '#58b4ff',
+    brightMagenta: '#dcb8ff',
+    brightCyan: '#8ff0f5',
+    brightWhite: '#ffffff'
   }
 }

--- a/src/renderer/themes/palettes/dark/neon-dusk.ts
+++ b/src/renderer/themes/palettes/dark/neon-dusk.ts
@@ -33,5 +33,23 @@ export const neonDusk: ThemePalette = {
     hlVariable: '#f7768e',
     hlTag: '#f7768e',
     hlAttr: '#73daca'
+  },
+  terminal: {
+    black: '#15161e',
+    red: '#f7768e',
+    green: '#9ece6a',
+    yellow: '#e0af68',
+    blue: '#7aa2f7',
+    magenta: '#bb9af7',
+    cyan: '#7dcfff',
+    white: '#a9b1d6',
+    brightBlack: '#414868',
+    brightRed: '#f7768e',
+    brightGreen: '#9ece6a',
+    brightYellow: '#e0af68',
+    brightBlue: '#7aa2f7',
+    brightMagenta: '#bb9af7',
+    brightCyan: '#7dcfff',
+    brightWhite: '#c0caf5'
   }
 }

--- a/src/renderer/themes/palettes/dark/obsidian.ts
+++ b/src/renderer/themes/palettes/dark/obsidian.ts
@@ -33,5 +33,23 @@ export const obsidian: ThemePalette = {
     hlVariable: '#e06c75',
     hlTag: '#e06c75',
     hlAttr: '#d19a66'
+  },
+  terminal: {
+    black: '#282c34',
+    red: '#e06c75',
+    green: '#98c379',
+    yellow: '#e5c07b',
+    blue: '#61afef',
+    magenta: '#c678dd',
+    cyan: '#56b6c2',
+    white: '#abb2bf',
+    brightBlack: '#5c6370',
+    brightRed: '#e88388',
+    brightGreen: '#a9d18e',
+    brightYellow: '#ebcc93',
+    brightBlue: '#7cc3f5',
+    brightMagenta: '#d18ee6',
+    brightCyan: '#6fc4ce',
+    brightWhite: '#dcdfe4'
   }
 }

--- a/src/renderer/themes/palettes/dark/ocean-dimmed.ts
+++ b/src/renderer/themes/palettes/dark/ocean-dimmed.ts
@@ -33,5 +33,23 @@ export const oceanDimmed: ThemePalette = {
     hlVariable: '#f69d50',
     hlTag: '#8ddb8c',
     hlAttr: '#6cb6ff'
+  },
+  terminal: {
+    black: '#2d333b',
+    red: '#e5534b',
+    green: '#57ab5a',
+    yellow: '#c69026',
+    blue: '#539bf5',
+    magenta: '#dcbdfb',
+    cyan: '#76e3ea',
+    white: '#adbac7',
+    brightBlack: '#636e7b',
+    brightRed: '#f47067',
+    brightGreen: '#6bc46d',
+    brightYellow: '#daaa3f',
+    brightBlue: '#6cb6ff',
+    brightMagenta: '#dcbdfb',
+    brightCyan: '#96d0ff',
+    brightWhite: '#cdd9e5'
   }
 }

--- a/src/renderer/themes/palettes/dark/sakura-dark.ts
+++ b/src/renderer/themes/palettes/dark/sakura-dark.ts
@@ -33,5 +33,23 @@ export const sakuraDark: ThemePalette = {
     hlVariable: '#e8b88a',
     hlTag: '#7ec89f',
     hlAttr: '#f2a5c0'
+  },
+  terminal: {
+    black: '#1a1520',
+    red: '#e86b7a',
+    green: '#7ec89f',
+    yellow: '#d4a656',
+    blue: '#b8c9e8',
+    magenta: '#d4a0e0',
+    cyan: '#b8a0d4',
+    white: '#e8dfe8',
+    brightBlack: '#7a6d82',
+    brightRed: '#f08090',
+    brightGreen: '#96d4b0',
+    brightYellow: '#e0b86e',
+    brightBlue: '#c6d4ee',
+    brightMagenta: '#dfb4e6',
+    brightCyan: '#c4b0dc',
+    brightWhite: '#f2ecf2'
   }
 }

--- a/src/renderer/themes/palettes/default/ocean-dark.ts
+++ b/src/renderer/themes/palettes/default/ocean-dark.ts
@@ -33,5 +33,23 @@ export const oceanDark: ThemePalette = {
     hlVariable: '#ffa657',
     hlTag: '#7ee787',
     hlAttr: '#79c0ff'
+  },
+  terminal: {
+    black: '#0d1117',
+    red: '#f85149',
+    green: '#3fb950',
+    yellow: '#d29922',
+    blue: '#58a6ff',
+    magenta: '#d2a8ff',
+    cyan: '#79c0ff',
+    white: '#e6edf3',
+    brightBlack: '#6e7681',
+    brightRed: '#ffa198',
+    brightGreen: '#56d364',
+    brightYellow: '#e3b341',
+    brightBlue: '#79c0ff',
+    brightMagenta: '#d2a8ff',
+    brightCyan: '#a5d6ff',
+    brightWhite: '#f0f6fc'
   }
 }

--- a/src/renderer/themes/palettes/default/ocean-light.ts
+++ b/src/renderer/themes/palettes/default/ocean-light.ts
@@ -33,5 +33,23 @@ export const oceanLight: ThemePalette = {
     hlVariable: '#953800',
     hlTag: '#116329',
     hlAttr: '#0550ae'
+  },
+  terminal: {
+    black: '#24292e',
+    red: '#cf222e',
+    green: '#116329',
+    yellow: '#4d2d00',
+    blue: '#0969da',
+    magenta: '#8250df',
+    cyan: '#1b7c83',
+    white: '#6e7781',
+    brightBlack: '#57606a',
+    brightRed: '#a40e26',
+    brightGreen: '#1a7f37',
+    brightYellow: '#633c01',
+    brightBlue: '#218bff',
+    brightMagenta: '#a475f9',
+    brightCyan: '#3192aa',
+    brightWhite: '#8c959f'
   }
 }

--- a/src/renderer/themes/palettes/index.ts
+++ b/src/renderer/themes/palettes/index.ts
@@ -1,4 +1,4 @@
-export type { ThemeGroup, ThemePalette } from './types'
+export type { TerminalColors, ThemeGroup, ThemePalette } from './types'
 
 import { ThemeGroup, ThemePalette } from './types'
 import { defaultThemes } from './default'

--- a/src/renderer/themes/palettes/light/canyon-light.ts
+++ b/src/renderer/themes/palettes/light/canyon-light.ts
@@ -33,5 +33,23 @@ export const canyonLight: ThemePalette = {
     hlVariable: '#5c6773',
     hlTag: '#55b4d4',
     hlAttr: '#f2ae49'
+  },
+  terminal: {
+    black: '#5c6773',
+    red: '#f07171',
+    green: '#86b300',
+    yellow: '#f29718',
+    blue: '#399ee6',
+    magenta: '#a37acc',
+    cyan: '#4cbf99',
+    white: '#abb0b6',
+    brightBlack: '#828c99',
+    brightRed: '#f58c8c',
+    brightGreen: '#99c411',
+    brightYellow: '#f5a832',
+    brightBlue: '#55b4d4',
+    brightMagenta: '#b593d6',
+    brightCyan: '#60ccaa',
+    brightWhite: '#fafafa'
   }
 }

--- a/src/renderer/themes/palettes/light/cream.ts
+++ b/src/renderer/themes/palettes/light/cream.ts
@@ -33,5 +33,23 @@ export const cream: ThemePalette = {
     hlVariable: '#d20f39',
     hlTag: '#d20f39',
     hlAttr: '#1e66f5'
+  },
+  terminal: {
+    black: '#5c5f77',
+    red: '#d20f39',
+    green: '#40a02b',
+    yellow: '#df8e1d',
+    blue: '#1e66f5',
+    magenta: '#8839ef',
+    cyan: '#04a5e5',
+    white: '#acb0be',
+    brightBlack: '#6c6f85',
+    brightRed: '#e03e56',
+    brightGreen: '#50b03b',
+    brightYellow: '#e9a030',
+    brightBlue: '#3578f7',
+    brightMagenta: '#9a4ef2',
+    brightCyan: '#17b2e8',
+    brightWhite: '#dce0e8'
   }
 }

--- a/src/renderer/themes/palettes/light/dawn-rose.ts
+++ b/src/renderer/themes/palettes/light/dawn-rose.ts
@@ -33,5 +33,23 @@ export const dawnRose: ThemePalette = {
     hlVariable: '#575279',
     hlTag: '#b4637a',
     hlAttr: '#d7827a'
+  },
+  terminal: {
+    black: '#575279',
+    red: '#b4637a',
+    green: '#286983',
+    yellow: '#ea9d34',
+    blue: '#56949f',
+    magenta: '#907aa9',
+    cyan: '#d7827a',
+    white: '#9893a5',
+    brightBlack: '#797593',
+    brightRed: '#c47a90',
+    brightGreen: '#3d7f99',
+    brightYellow: '#eead52',
+    brightBlue: '#6da5b0',
+    brightMagenta: '#a38ebb',
+    brightCyan: '#dd948c',
+    brightWhite: '#faf4ed'
   }
 }

--- a/src/renderer/themes/palettes/light/ivory.ts
+++ b/src/renderer/themes/palettes/light/ivory.ts
@@ -33,5 +33,23 @@ export const ivory: ThemePalette = {
     hlVariable: '#e45649',
     hlTag: '#e45649',
     hlAttr: '#986801'
+  },
+  terminal: {
+    black: '#383a42',
+    red: '#e45649',
+    green: '#50a14f',
+    yellow: '#c18401',
+    blue: '#4078f2',
+    magenta: '#a626a4',
+    cyan: '#0184bc',
+    white: '#a0a1a7',
+    brightBlack: '#696c77',
+    brightRed: '#ec6b5e',
+    brightGreen: '#60b25f',
+    brightYellow: '#d49a12',
+    brightBlue: '#5493ff',
+    brightMagenta: '#b740b0',
+    brightCyan: '#1b9fc6',
+    brightWhite: '#f0f0f0'
   }
 }

--- a/src/renderer/themes/palettes/light/lavender.ts
+++ b/src/renderer/themes/palettes/light/lavender.ts
@@ -33,5 +33,23 @@ export const lavender: ThemePalette = {
     hlVariable: '#b85c00',
     hlTag: '#d63384',
     hlAttr: '#228b44'
+  },
+  terminal: {
+    black: '#282a36',
+    red: '#e63535',
+    green: '#228b44',
+    yellow: '#c4960a',
+    blue: '#9b6bdf',
+    magenta: '#d63384',
+    cyan: '#1a8a8a',
+    white: '#6272a4',
+    brightBlack: '#44475a',
+    brightRed: '#f04f4f',
+    brightGreen: '#34a05a',
+    brightYellow: '#d8a91e',
+    brightBlue: '#ae83e6',
+    brightMagenta: '#e24d9a',
+    brightCyan: '#2aa0a0',
+    brightWhite: '#f8f8f2'
   }
 }

--- a/src/renderer/themes/palettes/light/morning-haze.ts
+++ b/src/renderer/themes/palettes/light/morning-haze.ts
@@ -33,5 +33,23 @@ export const morningHaze: ThemePalette = {
     hlVariable: '#8c4351',
     hlTag: '#8c4351',
     hlAttr: '#166775'
+  },
+  terminal: {
+    black: '#343b59',
+    red: '#8c4351',
+    green: '#485e30',
+    yellow: '#8f5e15',
+    blue: '#34548a',
+    magenta: '#5a4a78',
+    cyan: '#166775',
+    white: '#8990b3',
+    brightBlack: '#4c5179',
+    brightRed: '#a4566a',
+    brightGreen: '#5b7342',
+    brightYellow: '#a57228',
+    brightBlue: '#476ba0',
+    brightMagenta: '#6e5e8e',
+    brightCyan: '#287b8a',
+    brightWhite: '#d5d6db'
   }
 }

--- a/src/renderer/themes/palettes/light/polar.ts
+++ b/src/renderer/themes/palettes/light/polar.ts
@@ -33,5 +33,23 @@ export const polar: ThemePalette = {
     hlVariable: '#bf616a',
     hlTag: '#81a1c1',
     hlAttr: '#8fbcbb'
+  },
+  terminal: {
+    black: '#2e3440',
+    red: '#bf616a',
+    green: '#a3be8c',
+    yellow: '#ebcb8b',
+    blue: '#5e81ac',
+    magenta: '#b48ead',
+    cyan: '#88c0d0',
+    white: '#d8dee9',
+    brightBlack: '#4c566a',
+    brightRed: '#d08770',
+    brightGreen: '#a3be8c',
+    brightYellow: '#ebcb8b',
+    brightBlue: '#81a1c1',
+    brightMagenta: '#b48ead',
+    brightCyan: '#8fbcbb',
+    brightWhite: '#eceff4'
   }
 }

--- a/src/renderer/themes/palettes/light/sakura-light.ts
+++ b/src/renderer/themes/palettes/light/sakura-light.ts
@@ -33,5 +33,23 @@ export const sakuraLight: ThemePalette = {
     hlVariable: '#8a5c1a',
     hlTag: '#2d8a56',
     hlAttr: '#c4567a'
+  },
+  terminal: {
+    black: '#2d1f2b',
+    red: '#c93545',
+    green: '#2d8a56',
+    yellow: '#9a6d1a',
+    blue: '#1a5276',
+    magenta: '#7b3fa0',
+    cyan: '#6b3fa0',
+    white: '#9a8696',
+    brightBlack: '#6b5568',
+    brightRed: '#d8505e',
+    brightGreen: '#3e9d69',
+    brightYellow: '#ae7e2a',
+    brightBlue: '#2a6a8e',
+    brightMagenta: '#9254b3',
+    brightCyan: '#8254b3',
+    brightWhite: '#fef7f9'
   }
 }

--- a/src/renderer/themes/palettes/light/sandstone.ts
+++ b/src/renderer/themes/palettes/light/sandstone.ts
@@ -33,5 +33,23 @@ export const sandstone: ThemePalette = {
     hlVariable: '#cb4b16',
     hlTag: '#268bd2',
     hlAttr: '#657b83'
+  },
+  terminal: {
+    black: '#073642',
+    red: '#dc322f',
+    green: '#859900',
+    yellow: '#b58900',
+    blue: '#268bd2',
+    magenta: '#d33682',
+    cyan: '#2aa198',
+    white: '#eee8d5',
+    brightBlack: '#002b36',
+    brightRed: '#cb4b16',
+    brightGreen: '#586e75',
+    brightYellow: '#657b83',
+    brightBlue: '#839496',
+    brightMagenta: '#6c71c4',
+    brightCyan: '#93a1a1',
+    brightWhite: '#fdf6e3'
   }
 }

--- a/src/renderer/themes/palettes/light/sunrise.ts
+++ b/src/renderer/themes/palettes/light/sunrise.ts
@@ -33,5 +33,23 @@ export const sunrise: ThemePalette = {
     hlVariable: '#c05820',
     hlTag: '#d3423e',
     hlAttr: '#679c10'
+  },
+  terminal: {
+    black: '#2d2a2e',
+    red: '#d3423e',
+    green: '#679c10',
+    yellow: '#c89014',
+    blue: '#1691a5',
+    magenta: '#7a57c2',
+    cyan: '#1691a5',
+    white: '#908e92',
+    brightBlack: '#5b585d',
+    brightRed: '#e05753',
+    brightGreen: '#7aaf24',
+    brightYellow: '#daa22c',
+    brightBlue: '#28a3b7',
+    brightMagenta: '#8d6bd0',
+    brightCyan: '#28a3b7',
+    brightWhite: '#fafaf8'
   }
 }

--- a/src/renderer/themes/palettes/light/wheat.ts
+++ b/src/renderer/themes/palettes/light/wheat.ts
@@ -33,5 +33,23 @@ export const wheat: ThemePalette = {
     hlVariable: '#af3a03',
     hlTag: '#cc241d',
     hlAttr: '#427b58'
+  },
+  terminal: {
+    black: '#3c3836',
+    red: '#cc241d',
+    green: '#98971a',
+    yellow: '#d79921',
+    blue: '#458588',
+    magenta: '#b16286',
+    cyan: '#689d6a',
+    white: '#7c6f64',
+    brightBlack: '#928374',
+    brightRed: '#9d0006',
+    brightGreen: '#79740e',
+    brightYellow: '#b57614',
+    brightBlue: '#076678',
+    brightMagenta: '#8f3f71',
+    brightCyan: '#427b58',
+    brightWhite: '#fbf1c7'
   }
 }

--- a/src/renderer/themes/palettes/types.ts
+++ b/src/renderer/themes/palettes/types.ts
@@ -1,5 +1,24 @@
 export type ThemeGroup = 'default' | 'dark' | 'light' | 'accessibility'
 
+export interface TerminalColors {
+  black: string
+  red: string
+  green: string
+  yellow: string
+  blue: string
+  magenta: string
+  cyan: string
+  white: string
+  brightBlack: string
+  brightRed: string
+  brightGreen: string
+  brightYellow: string
+  brightBlue: string
+  brightMagenta: string
+  brightCyan: string
+  brightWhite: string
+}
+
 export interface ThemePalette {
   id: string
   name: string
@@ -35,4 +54,5 @@ export interface ThemePalette {
     hlTag: string // HTML/XML tags
     hlAttr: string // HTML/XML attributes
   }
+  terminal?: TerminalColors
 }

--- a/src/renderer/themes/terminal.ts
+++ b/src/renderer/themes/terminal.ts
@@ -10,22 +10,29 @@ export function getTerminalTheme(): ITheme {
   const bg = cssVar('--bg-primary', '#0d1117')
   const fg = cssVar('--text-primary', '#e6edf3')
   const accent = cssVar('--accent', '#58a6ff')
-  const red = cssVar('--red', '#f85149')
-  const green = cssVar('--green', '#3fb950')
-  const amber = cssVar('--amber', '#d29922')
 
   return {
     background: bg,
     foreground: fg,
     cursor: accent,
     selectionBackground: cssVar('--accent-tint-30', accent + '4d'),
-    black: bg,
-    red,
-    green,
-    yellow: amber,
-    blue: accent,
-    magenta: '#bc8cff',
-    cyan: '#76e3ea',
-    white: fg
+    // Base 8 ANSI colors
+    black: cssVar('--term-black', '#0d1117'),
+    red: cssVar('--term-red', '#f85149'),
+    green: cssVar('--term-green', '#3fb950'),
+    yellow: cssVar('--term-yellow', '#d29922'),
+    blue: cssVar('--term-blue', '#58a6ff'),
+    magenta: cssVar('--term-magenta', '#d2a8ff'),
+    cyan: cssVar('--term-cyan', '#79c0ff'),
+    white: cssVar('--term-white', '#e6edf3'),
+    // Bright 8 ANSI colors
+    brightBlack: cssVar('--term-bright-black', '#6e7681'),
+    brightRed: cssVar('--term-bright-red', '#ffa198'),
+    brightGreen: cssVar('--term-bright-green', '#56d364'),
+    brightYellow: cssVar('--term-bright-yellow', '#e3b341'),
+    brightBlue: cssVar('--term-bright-blue', '#79c0ff'),
+    brightMagenta: cssVar('--term-bright-magenta', '#d2a8ff'),
+    brightCyan: cssVar('--term-bright-cyan', '#a5d6ff'),
+    brightWhite: cssVar('--term-bright-white', '#f0f6fc')
   }
 }

--- a/src/renderer/themes/vscode.ts
+++ b/src/renderer/themes/vscode.ts
@@ -1,4 +1,4 @@
-import type { ThemePalette } from './palettes'
+import type { TerminalColors, ThemePalette } from './palettes'
 
 /** Strip JSONC comments (// and /* ... *​/) to make it valid JSON */
 function stripJsonComments(text: string): string {
@@ -175,6 +175,37 @@ export function importVSCodeTheme(jsonText: string, fileName: string): ThemePale
     tokenColor(tc, ['entity.other.attribute-name']) ??
     accent
 
+  // Terminal ANSI colors from VSCode theme
+  let terminal: TerminalColors | undefined
+  const ansiBlack = colors['terminal.ansiBlack']
+  const ansiRed = colors['terminal.ansiRed']
+  const ansiGreen = colors['terminal.ansiGreen']
+  const ansiYellow = colors['terminal.ansiYellow']
+  const ansiBlue = colors['terminal.ansiBlue']
+  const ansiMagenta = colors['terminal.ansiMagenta']
+  const ansiCyan = colors['terminal.ansiCyan']
+  const ansiWhite = colors['terminal.ansiWhite']
+  if (ansiBlack && ansiRed && ansiGreen && ansiYellow && ansiBlue && ansiMagenta && ansiCyan && ansiWhite) {
+    terminal = {
+      black: normalizeHex(ansiBlack),
+      red: normalizeHex(ansiRed),
+      green: normalizeHex(ansiGreen),
+      yellow: normalizeHex(ansiYellow),
+      blue: normalizeHex(ansiBlue),
+      magenta: normalizeHex(ansiMagenta),
+      cyan: normalizeHex(ansiCyan),
+      white: normalizeHex(ansiWhite),
+      brightBlack: normalizeHex(colors['terminal.ansiBrightBlack'] ?? adjustBrightness(ansiBlack, isDark ? 40 : -40)),
+      brightRed: normalizeHex(colors['terminal.ansiBrightRed'] ?? adjustBrightness(ansiRed, isDark ? 30 : -30)),
+      brightGreen: normalizeHex(colors['terminal.ansiBrightGreen'] ?? adjustBrightness(ansiGreen, isDark ? 30 : -30)),
+      brightYellow: normalizeHex(colors['terminal.ansiBrightYellow'] ?? adjustBrightness(ansiYellow, isDark ? 30 : -30)),
+      brightBlue: normalizeHex(colors['terminal.ansiBrightBlue'] ?? adjustBrightness(ansiBlue, isDark ? 30 : -30)),
+      brightMagenta: normalizeHex(colors['terminal.ansiBrightMagenta'] ?? adjustBrightness(ansiMagenta, isDark ? 30 : -30)),
+      brightCyan: normalizeHex(colors['terminal.ansiBrightCyan'] ?? adjustBrightness(ansiCyan, isDark ? 30 : -30)),
+      brightWhite: normalizeHex(colors['terminal.ansiBrightWhite'] ?? adjustBrightness(ansiWhite, isDark ? 30 : -30))
+    }
+  }
+
   // Generate a stable ID from the file name
   const id = 'vscode-' + fileName
     .replace(/\.jsonc?$/i, '')
@@ -213,6 +244,7 @@ export function importVSCodeTheme(jsonText: string, fileName: string): ThemePale
       hlVariable,
       hlTag,
       hlAttr
-    }
+    },
+    terminal
   }
 }


### PR DESCRIPTION
## Summary

- Add hand-tuned 16-color ANSI terminal palettes to all 29 builtin themes so terminals match each theme's look and feel
- Add `deriveTerminalColors()` fallback that auto-generates ANSI colors from any palette (for custom/VSCode themes without explicit terminal colors)
- Wire terminal colors through `applyTheme()` as `--term-*` CSS custom properties and update `getTerminalTheme()` to read them

## Layers touched

- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Themes** (`src/renderer/themes/`):
- `palettes/types.ts` - new `TerminalColors` interface (16 ANSI fields) and optional `terminal` field on `ThemePalette`
- `palettes/**/*.ts` - added explicit `terminal` color blocks to all 29 builtin theme palettes (dark, light, accessibility)
- `deriveTerminal.ts` - new module that derives 16 ANSI colors from any `ThemePalette` using palette colors + lighten/darken helpers
- `apply.ts` - sets `--term-*` CSS variables from `palette.terminal` or `deriveTerminalColors()` fallback
- `terminal.ts` - updated `getTerminalTheme()` to read `--term-*` CSS vars instead of hardcoded values
- `vscode.ts` - updated VSCode theme import to map `terminal.ansi*` colors into the palette's `terminal` field

**Tests** (`src/renderer/themes/__tests__/`):
- `builtinTerminal.test.ts` - validates all builtin themes have 16 valid hex ANSI colors
- `deriveTerminal.test.ts` - unit tests for `deriveTerminalColors()` (dark/light palettes, color mapping, bright variants)
- `terminal.test.ts` - unit tests for `getTerminalTheme()` reading CSS vars

## How to test

1. `yarn dev`
2. Switch between different themes in Settings > Appearance
3. Open a terminal tab - verify ANSI colors change to match the active theme
4. Import a VSCode theme - verify terminal colors are derived or mapped from the imported theme

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store