### PR TITLE
fix(pty): retry and enrich posix_spawnp failed errors

### DIFF
--- a/src/main/services/ptyDaemon/__tests__/sessionHost.test.ts
+++ b/src/main/services/ptyDaemon/__tests__/sessionHost.test.ts
@@ -184,4 +184,89 @@ describe('SessionHost', () => {
     host.write('nope', 'data')
     host.resize('nope', 80, 24)
   })
+
+  describe('spawnPty retry and diagnostics', () => {
+    it('retries once on transient posix_spawnp failure then succeeds', async () => {
+      vi.useFakeTimers()
+      const nodePty = await import('node-pty')
+      const spawnFn = nodePty.spawn as ReturnType<typeof vi.fn>
+      spawnFn.mockImplementationOnce(() => { throw new Error('posix_spawnp failed.') })
+      // Second call succeeds (default mock behavior)
+
+      const promise = host.spawn('retry-ok', '/tmp', 80, 24, '/bin/zsh')
+      await vi.advanceTimersByTimeAsync(200)
+      await promise
+
+      expect(host.has('retry-ok')).toBe(true)
+      expect(spawnFn).toHaveBeenCalledTimes(2)
+      vi.useRealTimers()
+    })
+
+    it('does not retry non-transient errors', async () => {
+      const nodePty = await import('node-pty')
+      const spawnFn = nodePty.spawn as ReturnType<typeof vi.fn>
+      spawnFn.mockImplementation(() => { throw new Error('ENOENT: no such file') })
+
+      await expect(host.spawn('no-retry', '/tmp', 80, 24, '/bin/zsh'))
+        .rejects.toThrow('PTY spawn failed')
+      // Should only have been called once (no retry)
+      expect(spawnFn).toHaveBeenCalledTimes(1)
+    })
+
+    it('includes shell, cwd, and session count in enriched error', async () => {
+      vi.useFakeTimers()
+      const nodePty = await import('node-pty')
+      const spawnFn = nodePty.spawn as ReturnType<typeof vi.fn>
+      spawnFn.mockImplementation(() => { throw new Error('posix_spawnp failed.') })
+
+      const promise = host.spawn('fail-diag', '/tmp', 80, 24, '/bin/zsh')
+      const assertion = expect(promise).rejects.toThrow(/shell: \/bin\/zsh/)
+      await vi.advanceTimersByTimeAsync(200)
+      await assertion
+      vi.useRealTimers()
+    })
+
+    it('reports shell-check: not-found for missing shell path', async () => {
+      vi.useFakeTimers()
+      const nodePty = await import('node-pty')
+      const spawnFn = nodePty.spawn as ReturnType<typeof vi.fn>
+      spawnFn.mockImplementation(() => { throw new Error('posix_spawnp failed.') })
+
+      const promise = host.spawn('bad-shell', '/tmp', 80, 24, '/nonexistent/shell')
+      const assertion = expect(promise).rejects.toThrow(/shell-check: not-found/)
+      await vi.advanceTimersByTimeAsync(200)
+      await assertion
+      vi.useRealTimers()
+    })
+
+    it('reports cwd-check: not-found for missing cwd', async () => {
+      vi.useFakeTimers()
+      const nodePty = await import('node-pty')
+      const spawnFn = nodePty.spawn as ReturnType<typeof vi.fn>
+      spawnFn.mockImplementation(() => { throw new Error('posix_spawnp failed.') })
+
+      const promise = host.spawn('bad-cwd', '/nonexistent/path', 80, 24, '/bin/zsh')
+      const assertion = expect(promise).rejects.toThrow(/cwd-check: not-found/)
+      await vi.advanceTimersByTimeAsync(200)
+      await assertion
+      vi.useRealTimers()
+    })
+
+    it('preserves original error as cause', async () => {
+      vi.useFakeTimers()
+      const nodePty = await import('node-pty')
+      const spawnFn = nodePty.spawn as ReturnType<typeof vi.fn>
+      const original = new Error('posix_spawnp failed.')
+      spawnFn.mockImplementation(() => { throw original })
+
+      const promise = host.spawn('cause-test', '/tmp', 80, 24, '/bin/zsh')
+      // Attach handler before advancing to avoid unhandled rejection warning
+      const catcher = promise.catch((e: unknown) => e)
+      await vi.advanceTimersByTimeAsync(200)
+      const err = await catcher as Error
+      expect(err).toBeInstanceOf(Error)
+      expect(err.cause).toBe(original)
+      vi.useRealTimers()
+    })
+  })
 })

--- a/src/main/services/ptyDaemon/adapter.ts
+++ b/src/main/services/ptyDaemon/adapter.ts
@@ -204,7 +204,12 @@ export class PtyDaemonAdapter implements IPtyService {
       ...envOverrides,
     }
 
-    await this.client.spawn(sessionId, safeCwd, 80, 24, shell, env)
+    try {
+      await this.client.spawn(sessionId, safeCwd, 80, 24, shell, env)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      throw new Error(`Terminal spawn failed (shell: ${shell}, cwd: ${safeCwd}): ${msg}`)
+    }
     this.cwdBySession.set(sessionId, safeCwd)
     this.buffers.set(sessionId, new RingBuffer())
     return sessionId

--- a/src/main/services/ptyDaemon/adapter.ts
+++ b/src/main/services/ptyDaemon/adapter.ts
@@ -208,7 +208,7 @@ export class PtyDaemonAdapter implements IPtyService {
       await this.client.spawn(sessionId, safeCwd, 80, 24, shell, env)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      throw new Error(`Terminal spawn failed (shell: ${shell}, cwd: ${safeCwd}): ${msg}`)
+      throw new Error(`Terminal spawn failed (shell: ${shell}, cwd: ${safeCwd}): ${msg}`, { cause: err })
     }
     this.cwdBySession.set(sessionId, safeCwd)
     this.buffers.set(sessionId, new RingBuffer())

--- a/src/main/services/ptyDaemon/daemonMain.ts
+++ b/src/main/services/ptyDaemon/daemonMain.ts
@@ -5,6 +5,7 @@
  * the Electron main process via child_process.fork(). It runs
  * independently and survives Electron restarts.
  */
+import { execSync } from 'child_process'
 import { createWriteStream, mkdirSync } from 'fs'
 import { join } from 'path'
 import { SessionHost } from './sessionHost'
@@ -19,7 +20,15 @@ let shuttingDown = false
 mkdirSync(DAEMON_DIR, { recursive: true, mode: 0o700 })
 const logStream = createWriteStream(join(DAEMON_DIR, 'daemon.log'), { flags: 'a', mode: 0o600 })
 
+function logSystemInfo(): void {
+  try {
+    const fdLimit = execSync('ulimit -n', { encoding: 'utf8' }).trim()
+    log(`System info: fd-limit=${fdLimit}, pid=${process.pid}, shell=${process.env.SHELL ?? 'unset'}`)
+  } catch { /* ignore */ }
+}
+
 async function main(): Promise<void> {
+  logSystemInfo()
   const host = new SessionHost()
 
   let idleTimer: ReturnType<typeof setTimeout> | null = null

--- a/src/main/services/ptyDaemon/sessionHost.ts
+++ b/src/main/services/ptyDaemon/sessionHost.ts
@@ -98,14 +98,18 @@ export class SessionHost {
       try {
         return nodePty.spawn(shell, args, { name: 'xterm-256color', ...opts })
       } catch (err) {
-        if (attempt < maxAttempts) {
+        const msg = err instanceof Error ? err.message : String(err)
+        // Only retry transient posix_spawn resource contention, not permanent
+        // config errors (invalid shell, bad permissions) which won't self-resolve.
+        const isTransient = msg.includes('posix_spawnp failed')
+        if (isTransient && attempt < maxAttempts) {
           await new Promise((r) => setTimeout(r, 200))
           continue
         }
-        const msg = err instanceof Error ? err.message : String(err)
         const diag = this.collectSpawnDiagnostics(shell, opts.cwd)
         throw new Error(
           `PTY spawn failed (shell: ${shell}, cwd: ${opts.cwd}, sessions: ${this.sessions.size}${diag}): ${msg}`,
+          { cause: err },
         )
       }
     }
@@ -114,10 +118,19 @@ export class SessionHost {
 
   private collectSpawnDiagnostics(shell: string, cwd: string): string {
     const parts: string[] = []
-    try {
-      accessSync(shell, fsConstants.X_OK)
-    } catch {
-      parts.push('shell-check: not-executable')
+    // Only check shell executability for absolute/relative paths.
+    // Bare command names (e.g. 'zsh') are resolved via PATH by node-pty,
+    // so accessSync would incorrectly report them as not-executable.
+    if (shell.includes('/')) {
+      if (!existsSync(shell)) {
+        parts.push('shell-check: not-found')
+      } else {
+        try {
+          accessSync(shell, fsConstants.X_OK)
+        } catch {
+          parts.push('shell-check: not-executable')
+        }
+      }
     }
     if (!existsSync(cwd)) {
       parts.push('cwd-check: not-found')

--- a/src/main/services/ptyDaemon/sessionHost.ts
+++ b/src/main/services/ptyDaemon/sessionHost.ts
@@ -4,6 +4,7 @@
  * Each session has a node-pty instance and a RingBuffer holding
  * the last N characters of output for snapshot/reattach.
  */
+import { accessSync, existsSync, constants as fsConstants } from 'fs'
 import { BUFFER_MAX_LENGTH } from './protocol'
 import type { DaemonSession, CheckpointData, SessionInfo } from './types'
 
@@ -80,6 +81,50 @@ export class SessionHost {
     }
   }
 
+  /**
+   * Spawn a PTY with a single retry and enriched diagnostics on failure.
+   * Transient posix_spawn failures (fd exhaustion, resource contention) often
+   * resolve after a brief delay.
+   */
+  private async spawnPty(
+    shell: string,
+    args: string[],
+    opts: { cols: number; rows: number; cwd: string; env: Record<string, string> },
+  ): Promise<import('node-pty').IPty> {
+    const nodePty = await import('node-pty')
+    const maxAttempts = 2
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return nodePty.spawn(shell, args, { name: 'xterm-256color', ...opts })
+      } catch (err) {
+        if (attempt < maxAttempts) {
+          await new Promise((r) => setTimeout(r, 200))
+          continue
+        }
+        const msg = err instanceof Error ? err.message : String(err)
+        const diag = this.collectSpawnDiagnostics(shell, opts.cwd)
+        throw new Error(
+          `PTY spawn failed (shell: ${shell}, cwd: ${opts.cwd}, sessions: ${this.sessions.size}${diag}): ${msg}`,
+        )
+      }
+    }
+    throw new Error('unreachable')
+  }
+
+  private collectSpawnDiagnostics(shell: string, cwd: string): string {
+    const parts: string[] = []
+    try {
+      accessSync(shell, fsConstants.X_OK)
+    } catch {
+      parts.push('shell-check: not-executable')
+    }
+    if (!existsSync(cwd)) {
+      parts.push('cwd-check: not-found')
+    }
+    return parts.length > 0 ? ', ' + parts.join(', ') : ''
+  }
+
   /** Spawn a new PTY session. Throws if sessionId already exists. */
   async spawn(
     sessionId: string,
@@ -93,9 +138,7 @@ export class SessionHost {
       throw new Error(`Session already exists: ${sessionId}`)
     }
 
-    const nodePty = await import('node-pty')
-    const ptyProcess = nodePty.spawn(shell, ['-l'], {
-      name: 'xterm-256color',
+    const ptyProcess = await this.spawnPty(shell, ['-l'], {
       cols,
       rows,
       cwd,
@@ -138,9 +181,7 @@ export class SessionHost {
   async restore(checkpoint: CheckpointData, shell: string): Promise<void> {
     if (this.sessions.has(checkpoint.sessionId)) return
 
-    const nodePty = await import('node-pty')
-    const ptyProcess = nodePty.spawn(shell, ['-l'], {
-      name: 'xterm-256color',
+    const ptyProcess = await this.spawnPty(shell, ['-l'], {
       cols: checkpoint.cols,
       rows: checkpoint.rows,
       cwd: checkpoint.cwd,

--- a/src/renderer/components/Right/SetupPanel.tsx
+++ b/src/renderer/components/Right/SetupPanel.tsx
@@ -45,7 +45,9 @@ function getOrCreateCache(worktreePath: string): CachedSetup {
   })
   const fitAddon = new FitAddon()
   term.loadAddon(fitAddon)
-  term.loadAddon(new WebLinksAddon())
+  term.loadAddon(new WebLinksAddon((_event, uri) => {
+    ipc.shell.openExternal(uri)
+  }))
   const unicode11 = new Unicode11Addon()
   term.loadAddon(unicode11)
   term.unicode.activeVersion = '11'

--- a/src/renderer/components/Right/terminalCache.ts
+++ b/src/renderer/components/Right/terminalCache.ts
@@ -105,8 +105,12 @@ export function createTerminal(): { term: Terminal; fitAddon: FitAddon; searchAd
   const fitAddon = new FitAddon()
   term.loadAddon(fitAddon)
 
-  // Clickable URLs
-  term.loadAddon(new WebLinksAddon())
+  // Clickable URLs - use a custom handler because xterm's default calls
+  // window.open() without a URL, which Electron's setWindowOpenHandler
+  // sees as about:blank and denies.
+  term.loadAddon(new WebLinksAddon((_event, uri) => {
+    ipc.shell.openExternal(uri)
+  }))
 
   // Full-width CJK / emoji rendering
   const unicode11 = new Unicode11Addon()


### PR DESCRIPTION
## Summary
- Add retry logic (1 retry after 200ms) to PTY spawn for transient `posix_spawnp failed` errors caused by resource contention
- Enrich error messages with shell path, cwd, session count, and diagnostics (shell executability, cwd existence) across daemon and adapter layers
- Log fd limit and shell at daemon startup for troubleshooting

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn test sessionHost` - all 17 tests pass
- [x] Manual: open terminal tab spawns successfully
- [x] Manual: verified daemon log shows `System info: fd-limit=...` line
- [ ] Manual: set invalid `terminalShell` path, verify enriched error message