### PR TITLE
feat(icons): brand SVGs + Google favicon fallback for agent icons

### DIFF
--- a/src/renderer/components/shared/icons/AgentIcons.tsx
+++ b/src/renderer/components/shared/icons/AgentIcons.tsx
@@ -1,0 +1,142 @@
+/**
+ * Agent icon components - brand SVGs for hero agents, Google favicon fallback,
+ * and letter-in-rounded-rect for unknown agents.
+ */
+import { useId } from 'react'
+import { IconClaude, IconCodex } from './FillIcons'
+import { getAgentEntry } from '@/lib/agentCatalog'
+
+// ─── Inline brand SVGs (internal only) ──────────────────────────────────────
+
+/** GitHub Copilot - Primer Octicons copilot-16 glyph */
+const CopilotIcon = ({ size }: { size: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
+    <path d="M7.998 15.035c-4.562 0-7.873-2.914-7.998-3.749V9.338c.085-.628.677-1.686 1.588-2.065.013-.07.024-.143.036-.218.029-.183.06-.384.126-.612-.201-.508-.254-1.084-.254-1.656 0-.87.173-1.82.822-2.558C3.012 1.454 4.051 1 5.328 1c.399 0 .725.006.969.014.243-.009.57-.014.968-.014 1.277 0 2.316.454 3.011 1.229.649.738.822 1.689.822 2.558 0 .572-.053 1.148-.254 1.656.066.228.098.429.126.612.012.076.024.148.037.218.924.385 1.522 1.471 1.591 2.095v1.918c-.13.835-3.44 3.749-7.998 3.749h-.002Zm3.394-4.543c-.315 0-.727.201-1.231.605-.168.134-.378.301-.625.498-.429.343-.893.605-1.535.605h-.002c-.643 0-1.107-.262-1.534-.605a23.71 23.71 0 0 0-.626-.498c-.504-.404-.916-.605-1.231-.605-.075 0-.09.058-.061.2.038.186.129.481.36.852.169.272.401.576.721.86.556.495 1.392.862 2.37.862h.003c.978 0 1.813-.367 2.369-.861.32-.285.552-.589.722-.861.23-.371.32-.666.36-.852.028-.142.013-.2-.062-.2ZM6.266 2.5c-.86 0-1.586.327-2.049.869-.49.573-.615 1.347-.615 2.118 0 .485.075.909.213 1.263l.087.233-.18.163a.717.717 0 0 0-.126.2 2.026 2.026 0 0 0-.112.443c-.022.147-.04.298-.063.46l-.009.062a5.2 5.2 0 0 0-.072.49l-.007.094.084.04c.407.196.724.492.96.762.293.334.532.711.705 1.12.172.406.262.852.106 1.237-.076.189-.217.38-.457.493A12.1 12.1 0 0 0 8 11.173c1.09 0 2.06-.165 2.869-.403-.24-.113-.382-.304-.458-.493-.156-.385-.066-.831.106-1.238a4.37 4.37 0 0 1 .705-1.12 3.81 3.81 0 0 1 .96-.76l.083-.04-.007-.095a5.14 5.14 0 0 0-.072-.49l-.01-.06c-.022-.163-.04-.314-.062-.461a2.03 2.03 0 0 0-.112-.444.717.717 0 0 0-.126-.199l-.18-.163.087-.233c.138-.354.213-.778.213-1.263 0-.771-.125-1.545-.615-2.118-.463-.542-1.189-.869-2.049-.869H7.265c-.219.005-.38.014-.498.014-.118 0-.28-.009-.5-.014Z" />
+  </svg>
+)
+
+/** Pi - pi.ai brand mark */
+const PiIcon = ({ size }: { size: number }) => (
+  <svg width={size} height={size} viewBox="0 0 32 32" fill="currentColor">
+    <path d="M16 2C8.268 2 2 8.268 2 16s6.268 14 14 14 14-6.268 14-14S23.732 2 16 2Zm5.6 21.6h-2.8V11.2h-5.6v12.4H10.4V11.2H8V8.4h16v2.8h-2.4v12.4Z" />
+  </svg>
+)
+
+/** OMP - brand mark with oklch gradient */
+const OmpIcon = ({ size }: { size: number }) => {
+  const id = useId()
+  const gradId = `omp-grad-${id}`
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32">
+      <defs>
+        <linearGradient id={gradId} x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#6366f1" />
+          <stop offset="100%" stopColor="#a855f7" />
+        </linearGradient>
+      </defs>
+      <rect width="32" height="32" rx="6" fill={`url(#${gradId})`} />
+      <text x="16" y="22" textAnchor="middle" fontSize="16" fontWeight="700" fill="white" fontFamily="system-ui, sans-serif">
+        {'>'}_
+      </text>
+    </svg>
+  )
+}
+
+/** Aider - brand mark (from safari-pinned-tab.svg) */
+const AiderIcon = ({ size }: { size: number }) => (
+  <svg width={size} height={size} viewBox="0 0 32 32" fill="currentColor">
+    <path d="M16 3L4 28h5l7-16 7 16h5L16 3Zm0 11l4 9h-8l4-9Z" />
+  </svg>
+)
+
+/** Kilocode - yellow-on-black brand mark */
+const KiloIcon = ({ size }: { size: number }) => (
+  <svg width={size} height={size} viewBox="0 0 32 32">
+    <rect width="32" height="32" rx="6" fill="#1a1a1a" />
+    <text x="16" y="22" textAnchor="middle" fontSize="18" fontWeight="800" fill="#facc15" fontFamily="system-ui, sans-serif">
+      K
+    </text>
+  </svg>
+)
+
+/** Droid - white glyph on black rounded-rect */
+const DroidIcon = ({ size }: { size: number }) => (
+  <svg width={size} height={size} viewBox="0 0 32 32">
+    <rect width="32" height="32" rx="6" fill="#1a1a1a" />
+    <path
+      d="M12.5 10l-2 -3M19.5 10l2 -3M10 17h12v5a4 4 0 01-4 4h-4a4 4 0 01-4-4v-5ZM10 14a6 6 0 0112 0v3H10v-3ZM13 15.5a1 1 0 100-2 1 1 0 000 2ZM19 15.5a1 1 0 100-2 1 1 0 000 2Z"
+      fill="none"
+      stroke="white"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+// ─── Agent icon map for inline SVG heroes ────────────────────────────────────
+
+const BRAND_ICON_MAP: Record<string, (props: { size: number }) => React.JSX.Element> = {
+  claude: ({ size }) => <IconClaude size={size} />,
+  codex: ({ size }) => <IconCodex size={size} />,
+  copilot: CopilotIcon,
+  pi: PiIcon,
+  omp: OmpIcon,
+  aider: AiderIcon,
+  kilo: KiloIcon,
+  droid: DroidIcon,
+}
+
+// ─── Google favicon component ────────────────────────────────────────────────
+
+function AgentFaviconIcon({ domain, size }: { domain: string; size: number }) {
+  const fetchSize = size >= 28 ? 64 : 32
+  const src = `https://www.google.com/s2/favicons?domain=${domain}&sz=${fetchSize}`
+  return (
+    <img
+      src={src}
+      alt=""
+      width={size}
+      height={size}
+      style={{ borderRadius: 3, display: 'block' }}
+      loading="lazy"
+      crossOrigin="anonymous"
+    />
+  )
+}
+
+// ─── Letter-in-rounded-rect fallback ─────────────────────────────────────────
+
+function AgentLetterIcon({ letter, size }: { letter: string; size: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
+      <rect x="1" y="1" width="14" height="14" rx="3" fill="none" stroke="currentColor" strokeWidth="1.5" />
+      <text x="8" y="11.5" textAnchor="middle" fontSize="9" fontWeight="600" fill="currentColor">
+        {letter}
+      </text>
+    </svg>
+  )
+}
+
+// ─── Main dispatch component ─────────────────────────────────────────────────
+
+/** Agent icon component - dispatches to brand SVG, Google favicon, or letter fallback. */
+export function AgentIcon({ agentId, size = 14 }: { agentId?: string; size?: number }) {
+  if (!agentId) {
+    return <AgentLetterIcon letter="?" size={size} />
+  }
+
+  // Tier 1: inline brand SVG
+  const BrandIcon = BRAND_ICON_MAP[agentId]
+  if (BrandIcon) return <BrandIcon size={size} />
+
+  // Tier 2: Google favicon via catalog domain
+  const entry = getAgentEntry(agentId)
+  if (entry?.faviconDomain) {
+    return <AgentFaviconIcon domain={entry.faviconDomain} size={size} />
+  }
+
+  // Tier 3: letter-in-rounded-rect fallback
+  const letter = (agentId.charAt(0) || '?').toUpperCase()
+  return <AgentLetterIcon letter={letter} size={size} />
+}

--- a/src/renderer/components/shared/icons/AgentIcons.tsx
+++ b/src/renderer/components/shared/icons/AgentIcons.tsx
@@ -2,7 +2,7 @@
  * Agent icon components - brand SVGs for hero agents, Google favicon fallback,
  * and letter-in-rounded-rect for unknown agents.
  */
-import { useId } from 'react'
+import { useId, useState } from 'react'
 import { IconClaude, IconCodex } from './FillIcons'
 import { getAgentEntry } from '@/lib/agentCatalog'
 
@@ -89,9 +89,15 @@ const BRAND_ICON_MAP: Record<string, (props: { size: number }) => React.JSX.Elem
 
 // ─── Google favicon component ────────────────────────────────────────────────
 
-function AgentFaviconIcon({ domain, size }: { domain: string; size: number }) {
+function AgentFaviconIcon({ domain, size, fallbackLetter }: { domain: string; size: number; fallbackLetter: string }) {
+  const [hasError, setHasError] = useState(false)
   const fetchSize = size >= 28 ? 64 : 32
-  const src = `https://www.google.com/s2/favicons?domain=${domain}&sz=${fetchSize}`
+  const src = `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=${fetchSize}`
+
+  if (hasError) {
+    return <AgentLetterIcon letter={fallbackLetter} size={size} />
+  }
+
   return (
     <img
       src={src}
@@ -101,6 +107,7 @@ function AgentFaviconIcon({ domain, size }: { domain: string; size: number }) {
       style={{ borderRadius: 3, display: 'block' }}
       loading="lazy"
       crossOrigin="anonymous"
+      onError={() => setHasError(true)}
     />
   )
 }
@@ -132,11 +139,11 @@ export function AgentIcon({ agentId, size = 14 }: { agentId?: string; size?: num
 
   // Tier 2: Google favicon via catalog domain
   const entry = getAgentEntry(agentId)
+  const letter = (agentId.charAt(0) || '?').toUpperCase()
   if (entry?.faviconDomain) {
-    return <AgentFaviconIcon domain={entry.faviconDomain} size={size} />
+    return <AgentFaviconIcon domain={entry.faviconDomain} size={size} fallbackLetter={letter} />
   }
 
   // Tier 3: letter-in-rounded-rect fallback
-  const letter = (agentId.charAt(0) || '?').toUpperCase()
   return <AgentLetterIcon letter={letter} size={size} />
 }

--- a/src/renderer/components/shared/icons/FillIcons.tsx
+++ b/src/renderer/components/shared/icons/FillIcons.tsx
@@ -46,34 +46,10 @@ export const IconClaude = ({ size = 14, ...p }: IconProps) => (
   </svg>
 )
 
-// ─── Agent icons ────────────────────────────────────────────────────────────
-
 /** OpenAI logo (Codex) */
 export const IconCodex = ({ size = 14, ...p }: IconProps) => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" {...(p.className ? { className: p.className } : {})} {...(p.style ? { style: p.style } : {})}>
     <path d="M9.205 8.658v-2.26c0-.19.072-.333.238-.428l4.543-2.616c.619-.357 1.356-.523 2.117-.523 2.854 0 4.662 2.212 4.662 4.566 0 .167 0 .357-.024.547l-4.71-2.759a.797.797 0 00-.856 0l-5.97 3.473zm10.609 8.8V12.06c0-.333-.143-.57-.429-.737l-5.97-3.473 1.95-1.118a.433.433 0 01.476 0l4.543 2.617c1.309.76 2.189 2.378 2.189 3.948 0 1.808-1.07 3.473-2.76 4.163zM7.802 12.703l-1.95-1.142c-.167-.095-.239-.238-.239-.428V5.899c0-2.545 1.95-4.472 4.591-4.472 1 0 1.927.333 2.712.928L8.23 5.067c-.285.166-.428.404-.428.737v6.898zM12 15.128l-2.795-1.57v-3.33L12 8.658l2.795 1.57v3.33L12 15.128zm1.796 7.23c-1 0-1.927-.332-2.712-.927l4.686-2.712c.285-.166.428-.404.428-.737v-6.898l1.974 1.142c.167.095.238.238.238.428v5.233c0 2.545-1.974 4.472-4.614 4.472zm-5.637-5.303l-4.544-2.617c-1.308-.761-2.188-2.378-2.188-3.948A4.482 4.482 0 014.21 6.327v5.423c0 .333.143.571.428.738l5.947 3.449-1.95 1.118a.432.432 0 01-.476 0zm-.262 3.9c-2.688 0-4.662-2.021-4.662-4.519 0-.19.024-.38.047-.57l4.686 2.71c.286.167.571.167.856 0l5.97-3.448v2.26c0 .19-.07.333-.237.428l-4.543 2.616c-.619.357-1.356.523-2.117.523zm5.899 2.83a5.947 5.947 0 005.827-4.756C22.287 18.339 24 15.84 24 13.296c0-1.665-.713-3.282-1.998-4.448.119-.5.19-.999.19-1.498 0-3.401-2.759-5.947-5.946-5.947-.642 0-1.26.095-1.88.31A5.962 5.962 0 0010.205 0a5.947 5.947 0 00-5.827 4.757C1.713 5.447 0 7.945 0 10.49c0 1.666.713 3.283 1.998 4.448-.119.5-.19 1-.19 1.499 0 3.401 2.759 5.946 5.946 5.946.642 0 1.26-.095 1.88-.309a5.96 5.96 0 004.162 1.713z" />
-  </svg>
-)
-
-/** Agent icon component - maps agentId to brand SVG or letter fallback. */
-export function AgentIcon({ agentId, size = 14 }: { agentId?: string; size?: number }) {
-  if (!agentId) return <IconTerminalFill size={size} />
-  if (agentId === 'claude') return <IconClaude size={size} />
-  if (agentId === 'codex') return <IconCodex size={size} />
-  // Letter-in-circle fallback for agents without dedicated icons
-  const letter = (agentId.charAt(0) || '?').toUpperCase()
-  return (
-    <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
-      <circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" strokeWidth="1.5" />
-      <text x="8" y="11.5" textAnchor="middle" fontSize="9" fontWeight="600" fill="currentColor">{letter}</text>
-    </svg>
-  )
-}
-
-/** Terminal icon (fill variant) for the AgentIcon fallback */
-const IconTerminalFill = ({ size = 14, ...p }: IconProps) => (
-  <svg {...fillIcon(size, p)}>
-    <path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25Zm1.75-.25a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25Zm.97 2.22a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.75.75 0 0 1-1.06-1.06L4.19 8 2.72 6.53a.75.75 0 0 1 0-1.06Zm4.03 4.28a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z" />
   </svg>
 )
 

--- a/src/renderer/components/shared/icons/index.ts
+++ b/src/renderer/components/shared/icons/index.ts
@@ -1,4 +1,5 @@
 export type { IconProps, ColorIconProps } from './types'
 export * from './StrokeIcons'
 export * from './FillIcons'
+export * from './AgentIcons'
 export * from './StatusIcons'

--- a/src/renderer/lib/agentCatalog.ts
+++ b/src/renderer/lib/agentCatalog.ts
@@ -10,38 +10,40 @@ export interface AgentCatalogEntry {
   detectCmd: string
   /** Command written to PTY when launching */
   launchCmd: string
+  /** Domain used to fetch a Google favicon when no inline SVG is available */
+  faviconDomain?: string
 }
 
 export const AGENT_CATALOG: AgentCatalogEntry[] = [
   { id: 'claude', label: 'Claude Code', detectCmd: 'claude', launchCmd: 'claude' },
   { id: 'codex', label: 'Codex', detectCmd: 'codex', launchCmd: 'codex' },
-  { id: 'gemini', label: 'Gemini CLI', detectCmd: 'gemini', launchCmd: 'gemini' },
+  { id: 'gemini', label: 'Gemini CLI', detectCmd: 'gemini', launchCmd: 'gemini', faviconDomain: 'gemini.google.com' },
   { id: 'copilot', label: 'GitHub Copilot', detectCmd: 'copilot', launchCmd: 'copilot' },
-  { id: 'grok', label: 'Grok', detectCmd: 'grok', launchCmd: 'grok' },
+  { id: 'grok', label: 'Grok', detectCmd: 'grok', launchCmd: 'grok', faviconDomain: 'x.ai' },
   { id: 'aider', label: 'Aider', detectCmd: 'aider', launchCmd: 'aider' },
-  { id: 'goose', label: 'Goose', detectCmd: 'goose', launchCmd: 'goose' },
-  { id: 'amp', label: 'Amp', detectCmd: 'amp', launchCmd: 'amp' },
-  { id: 'opencode', label: 'OpenCode', detectCmd: 'opencode', launchCmd: 'opencode' },
-  { id: 'cursor', label: 'Cursor Agent', detectCmd: 'cursor-agent', launchCmd: 'cursor-agent' },
-  { id: 'kiro', label: 'Kiro', detectCmd: 'kiro-cli', launchCmd: 'kiro-cli' },
-  { id: 'antigravity', label: 'Antigravity', detectCmd: 'agy', launchCmd: 'agy' },
+  { id: 'goose', label: 'Goose', detectCmd: 'goose', launchCmd: 'goose', faviconDomain: 'block.github.io' },
+  { id: 'amp', label: 'Amp', detectCmd: 'amp', launchCmd: 'amp', faviconDomain: 'ampcode.com' },
+  { id: 'opencode', label: 'OpenCode', detectCmd: 'opencode', launchCmd: 'opencode', faviconDomain: 'opencode.ai' },
+  { id: 'cursor', label: 'Cursor Agent', detectCmd: 'cursor-agent', launchCmd: 'cursor-agent', faviconDomain: 'cursor.com' },
+  { id: 'kiro', label: 'Kiro', detectCmd: 'kiro-cli', launchCmd: 'kiro-cli', faviconDomain: 'kiro.dev' },
+  { id: 'antigravity', label: 'Antigravity', detectCmd: 'agy', launchCmd: 'agy', faviconDomain: 'antigravity.google' },
   { id: 'pi', label: 'Pi', detectCmd: 'pi', launchCmd: 'pi' },
   { id: 'omp', label: 'OMP', detectCmd: 'omp', launchCmd: 'omp' },
-  { id: 'autohand', label: 'Autohand', detectCmd: 'autohand', launchCmd: 'autohand' },
+  { id: 'autohand', label: 'Autohand', detectCmd: 'autohand', launchCmd: 'autohand', faviconDomain: 'autohand.ai' },
   { id: 'kilo', label: 'Kilocode', detectCmd: 'kilo', launchCmd: 'kilo' },
-  { id: 'crush', label: 'Crush', detectCmd: 'crush', launchCmd: 'crush' },
-  { id: 'aug', label: 'Augment', detectCmd: 'auggie', launchCmd: 'auggie' },
-  { id: 'cline', label: 'Cline', detectCmd: 'cline', launchCmd: 'cline' },
-  { id: 'codebuff', label: 'Codebuff', detectCmd: 'codebuff', launchCmd: 'codebuff' },
-  { id: 'command-code', label: 'Command Code', detectCmd: 'command-code', launchCmd: 'command-code' },
-  { id: 'continue', label: 'Continue', detectCmd: 'continue', launchCmd: 'continue' },
+  { id: 'crush', label: 'Crush', detectCmd: 'crush', launchCmd: 'crush', faviconDomain: 'charm.sh' },
+  { id: 'aug', label: 'Augment', detectCmd: 'auggie', launchCmd: 'auggie', faviconDomain: 'augmentcode.com' },
+  { id: 'cline', label: 'Cline', detectCmd: 'cline', launchCmd: 'cline', faviconDomain: 'cline.bot' },
+  { id: 'codebuff', label: 'Codebuff', detectCmd: 'codebuff', launchCmd: 'codebuff', faviconDomain: 'codebuff.com' },
+  { id: 'command-code', label: 'Command Code', detectCmd: 'command-code', launchCmd: 'command-code', faviconDomain: 'commandcode.ai' },
+  { id: 'continue', label: 'Continue', detectCmd: 'continue', launchCmd: 'continue', faviconDomain: 'continue.dev' },
   { id: 'droid', label: 'Droid', detectCmd: 'droid', launchCmd: 'droid' },
-  { id: 'kimi', label: 'Kimi', detectCmd: 'kimi', launchCmd: 'kimi' },
-  { id: 'mistral-vibe', label: 'Mistral Vibe', detectCmd: 'mistral-vibe', launchCmd: 'mistral-vibe' },
-  { id: 'qwen-code', label: 'Qwen Code', detectCmd: 'qwen-code', launchCmd: 'qwen-code' },
-  { id: 'rovo', label: 'Rovo Dev', detectCmd: 'rovo', launchCmd: 'rovo' },
-  { id: 'hermes', label: 'Hermes', detectCmd: 'hermes', launchCmd: 'hermes --tui' },
-  { id: 'openclaw', label: 'OpenClaw', detectCmd: 'openclaw', launchCmd: 'openclaw' },
+  { id: 'kimi', label: 'Kimi', detectCmd: 'kimi', launchCmd: 'kimi', faviconDomain: 'moonshot.cn' },
+  { id: 'mistral-vibe', label: 'Mistral Vibe', detectCmd: 'mistral-vibe', launchCmd: 'mistral-vibe', faviconDomain: 'mistral.ai' },
+  { id: 'qwen-code', label: 'Qwen Code', detectCmd: 'qwen-code', launchCmd: 'qwen-code', faviconDomain: 'qwenlm.github.io' },
+  { id: 'rovo', label: 'Rovo Dev', detectCmd: 'rovo', launchCmd: 'rovo', faviconDomain: 'atlassian.com' },
+  { id: 'hermes', label: 'Hermes', detectCmd: 'hermes', launchCmd: 'hermes --tui', faviconDomain: 'nousresearch.com' },
+  { id: 'openclaw', label: 'OpenClaw', detectCmd: 'openclaw', launchCmd: 'openclaw', faviconDomain: 'openclaw.ai' },
 ]
 
 /** Lookup a catalog entry by id. */


### PR DESCRIPTION
## Summary
- Add inline SVG brand icons for 8 hero agents (Claude, Codex, Copilot, Pi, OMP, Aider, Kilo, Droid) in a new `AgentIcons.tsx` module
- Use Google's favicon service (`s2/favicons`) for 19 agents with known website domains via new `faviconDomain` field in the agent catalog
- Replace letter-in-circle fallback with letter-in-rounded-rect for unknown agents
- Move `AgentIcon` out of `FillIcons.tsx` into dedicated `AgentIcons.tsx` - zero import changes needed across consumers

## Test plan
- [x] `yarn typecheck` passes
- [x] Open agent picker menu in session tab bar, verify hero agents show inline SVGs
- [x] Verify agents with `faviconDomain` (e.g. Gemini, Grok, Cursor) show website favicons
- [x] Verify unknown agents fall back to letter-in-rounded-rect