### PR TITLE
fix: drag-and-drop file paths, terminal re-theming, and Widevine CDM for webviews

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, webFrame } from 'electron'
+import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 import type { TemplateKind, CreateTemplateArgs, CreateTemplateResult, TemplateLogEntry } from '../shared/templates'
 
 const api = {
@@ -450,6 +450,11 @@ const api = {
     },
   },
 
+  // Drag — Electron 28+ replacement for deprecated File.path
+  drag: {
+    getPathForFile: (file: File) => webUtils.getPathForFile(file),
+  },
+
   // Settings sync
   settings: {
     sync: (values: Record<string, unknown>) => ipcRenderer.invoke('settings:sync', values),
@@ -463,3 +468,8 @@ const api = {
 export type ElectronAPI = typeof api
 
 contextBridge.exposeInMainWorld('api', api)
+
+// Prevent dropping files anywhere from navigating the Electron window to file:///...
+// Capture phase so it fires before any React handlers; no stopPropagation so React still sees the event.
+document.addEventListener('dragover', (e) => { e.preventDefault() }, true)
+document.addEventListener('drop', (e) => { e.preventDefault() }, true)

--- a/src/renderer/components/Center/BigTerminalView.tsx
+++ b/src/renderer/components/Center/BigTerminalView.tsx
@@ -2,9 +2,8 @@ import { useEffect, useRef, useCallback, useState } from 'react'
 import * as ipc from '@/lib/ipc'
 import { useTerminalFileDrop } from '@/hooks/useTerminalFileDrop'
 import { useTerminalClipboardPaste } from '@/hooks/useTerminalClipboardPaste'
-import { getTerminalTheme } from '@/themes/terminal'
 import { useUIStore } from '@/store/ui'
-import { getOrCreate, type BigTermEntry } from './bigTerminalCache'
+import { getOrCreate, reThemeAllBigTerminals, type BigTermEntry } from './bigTerminalCache'
 import { activateWebgl, disposeWebgl } from '@/components/Right/terminalCache'
 import { TerminalSearch } from '@/components/shared/TerminalSearch'
 import '@xterm/xterm/css/xterm.css'
@@ -114,16 +113,13 @@ export function BigTerminalView({ terminalId, worktreePath, initialCommand }: Pr
     }
   }, [terminalId, worktreePath])
 
-  // Re-theme when app theme changes.
+  // Re-theme ALL cached big terminals when app theme changes (not just this one).
   useEffect(() => {
     let prevId = useUIStore.getState().activeThemeId
     const unsub = useUIStore.subscribe((state) => {
       if (state.activeThemeId !== prevId) {
         prevId = state.activeThemeId
-        requestAnimationFrame(() => {
-          const entry = entryRef.current
-          if (entry) entry.term.options.theme = getTerminalTheme()
-        })
+        requestAnimationFrame(() => reThemeAllBigTerminals())
       }
     })
     return unsub

--- a/src/renderer/components/Center/ChatInput.tsx
+++ b/src/renderer/components/Center/ChatInput.tsx
@@ -22,6 +22,7 @@ import type { AgentSession, SlashCommand, SnippetAttachment } from '@/types'
 import { parseSnippets, stripAttachmentBlocks } from './diffCommentUtils'
 import type { AttachedFile } from '@/types'
 import { IconArrowDown, IconClose } from '@/components/shared/icons'
+import { drag } from '@/lib/ipc'
 import { flash } from '@/store/flash'
 import { useTranslation } from 'react-i18next'
 import type { ChatViewAction, ChatViewState } from './ChatView'
@@ -169,7 +170,7 @@ export function ChatInput({
       if (!file) continue
 
       if (entry?.isDirectory) {
-        const path = (file as File & { path: string }).path
+        const path = drag.getPathForFile(file)
         if (path) folderPaths.push(path)
       } else {
         nonFolderFiles.push(file)

--- a/src/renderer/components/Center/WebAppOverlay.tsx
+++ b/src/renderer/components/Center/WebAppOverlay.tsx
@@ -147,6 +147,7 @@ export const WebAppOverlay = memo(function WebAppOverlay() {
           src={webAppLastUrls[app.id] ?? app.url}
           partition={`persist:webapp-${getPartitionKey(app.url)}`}
           allowpopups={true}
+          plugins={true}
           style={{
             display: activeWebAppId === app.id ? 'flex' : 'none',
             flex: 1,

--- a/src/renderer/components/Center/bigTerminalCache.ts
+++ b/src/renderer/components/Center/bigTerminalCache.ts
@@ -3,6 +3,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import type { WebglAddon } from '@xterm/addon-webgl'
 import type { SearchAddon } from '@xterm/addon-search'
 import * as ipc from '@/lib/ipc'
+import { getTerminalTheme } from '@/themes/terminal'
 import { createTerminal, registerPtyFinder } from '@/components/Right/terminalCache'
 import { registerAgentStatusOsc, registerBraidOsc9 } from '@/lib/agentStatusOsc'
 import { registerTitleDetection } from '@/lib/agentTitleDetection'
@@ -221,6 +222,14 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
   })()
 
   return entry
+}
+
+/** Re-theme all cached big terminals when the app theme changes. */
+export function reThemeAllBigTerminals(): void {
+  const theme = getTerminalTheme()
+  for (const entry of cache.values()) {
+    entry.term.options.theme = theme
+  }
 }
 
 /** Kill PTY, dispose xterm, remove from cache, and delete persisted scrollback. */

--- a/src/renderer/hooks/__tests__/useTerminalFileDrop.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminalFileDrop.test.ts
@@ -8,9 +8,11 @@ import { FILE_PATH_MIME } from '@/lib/fileDragMime'
 // ---------------------------------------------------------------------------
 
 const mockPtyWrite = vi.fn()
+const mockGetPathForFile = vi.fn()
 
 vi.mock('@/lib/ipc', () => ({
   pty: { write: (...args: unknown[]) => mockPtyWrite(...args) },
+  drag: { getPathForFile: (f: File) => mockGetPathForFile(f) },
 }))
 
 // ---------------------------------------------------------------------------
@@ -24,7 +26,7 @@ function makeTarget(ptyId: string | null = 'pty-1') {
 type DragEventInit = {
   types?: string[]
   getData?: (type: string) => string
-  files?: Array<{ path: string }>
+  files?: File[]
 }
 
 function makeDragEvent(init: DragEventInit = {}) {
@@ -51,6 +53,11 @@ function makeDragEventNoTransfer() {
     stopPropagation: vi.fn(),
     currentTarget: el,
   } as unknown as React.DragEvent
+}
+
+/** Create a minimal File-like object for use with the mock getPathForFile. */
+function fakeFile(name: string): File {
+  return new File([''], name)
 }
 
 // ---------------------------------------------------------------------------
@@ -143,27 +150,37 @@ describe('useTerminalFileDrop', () => {
       expect(target.focus).toHaveBeenCalled()
     })
 
-    it('writes native file paths to PTY', () => {
+    it('writes native file paths to PTY via getPathForFile', () => {
       const target = makeTarget('pty-2')
       const { result } = renderHook(() => useTerminalFileDrop(() => target))
+      const f1 = fakeFile('a.txt')
+      const f2 = fakeFile('b.txt')
+      mockGetPathForFile.mockImplementation((f: File) => {
+        if (f === f1) return '/tmp/a.txt'
+        if (f === f2) return '/tmp/b.txt'
+        return ''
+      })
       const event = makeDragEvent({
         types: ['Files'],
-        files: [{ path: '/tmp/a.txt' }, { path: '/tmp/b.txt' }],
+        files: [f1, f2],
       })
 
       result.current.onDrop(event)
 
       expect(event.preventDefault).toHaveBeenCalled()
+      expect(mockGetPathForFile).toHaveBeenCalledWith(f1)
+      expect(mockGetPathForFile).toHaveBeenCalledWith(f2)
       expect(mockPtyWrite).toHaveBeenCalledWith('pty-2', '/tmp/a.txt /tmp/b.txt ')
       expect(target.focus).toHaveBeenCalled()
     })
 
-    it('calls preventDefault even when native files have no .path', () => {
+    it('calls preventDefault even when getPathForFile returns empty', () => {
       const target = makeTarget('pty-1')
       const { result } = renderHook(() => useTerminalFileDrop(() => target))
+      mockGetPathForFile.mockReturnValue('')
       const event = makeDragEvent({
         types: ['Files'],
-        files: [{ path: '' }],
+        files: [fakeFile('empty.txt')],
       })
 
       result.current.onDrop(event)
@@ -201,10 +218,11 @@ describe('useTerminalFileDrop', () => {
     it('prefers internal FileTree drag over native Files', () => {
       const target = makeTarget('pty-1')
       const { result } = renderHook(() => useTerminalFileDrop(() => target))
+      mockGetPathForFile.mockReturnValue('/other/file.ts')
       const event = makeDragEvent({
         types: [FILE_PATH_MIME, 'Files'],
         getData: (type: string) => type === FILE_PATH_MIME ? '/src/index.ts' : '',
-        files: [{ path: '/other/file.ts' }],
+        files: [fakeFile('file.ts')],
       })
 
       result.current.onDrop(event)

--- a/src/renderer/hooks/useTerminalFileDrop.ts
+++ b/src/renderer/hooks/useTerminalFileDrop.ts
@@ -68,7 +68,7 @@ export function useTerminalFileDrop(getTarget: () => TerminalFileDropTarget | nu
       e.preventDefault()
       e.stopPropagation()
       const paths = Array.from(files)
-        .map((f) => (f as File & { path: string }).path)
+        .map((f) => ipc.drag.getPathForFile(f))
         .filter(Boolean)
       if (paths.length === 0) return
       const target = getTarget()

--- a/src/renderer/lib/ipc.ts
+++ b/src/renderer/lib/ipc.ts
@@ -308,6 +308,10 @@ export const claudeConfig = {
     api().claudeConfig.authenticateMcpServer(serverName, serverConfig) as Promise<{ success: boolean; error?: string }>,
 }
 
+export const drag = {
+  getPathForFile: (file: File) => api().drag.getPathForFile(file) as string,
+}
+
 export const settings = {
   sync: (values: Record<string, unknown>) => api().settings.sync(values),
   getApiKey: () => api().settings.getApiKey(),


### PR DESCRIPTION
## Summary
- **Drag-and-drop fix**: Electron 28+ deprecated `File.path` (returns empty string), silently breaking file drag-and-drop onto terminals and folder detection in ChatInput. Exposes `webUtils.getPathForFile()` through the preload context bridge as `drag.getPathForFile`. Adds document-level `dragover`/`drop` prevention to stop file drops from navigating the Electron window to `file:///` URLs.
- **Terminal re-theming**: Previously only the active big terminal was re-themed on theme change. Now `reThemeAllBigTerminals()` iterates all cached instances so switching themes updates every terminal immediately.
- **Widevine CDM in webviews**: The `plugins: true` flag on the main BrowserWindow only enables the CDM for the host renderer. Webview guest processes (used by embedded apps like Spotify) need the `plugins` attribute set independently on the `<webview>` tag to load the Widevine CDM.

## Review comments (Gemini)
- [x] ~Wrap `getPathForFile` in try-catch~ - Not needed: the preload bridge only receives real DOM `File` objects from drag events. Adding a try-catch here would silently swallow real bugs.
- [x] ~Set `dropEffect = 'none'` on global dragover~ - Intentionally omitted. Drop targets (terminal, chat input) already set `dropEffect = 'copy'` in their own handlers. Setting `'none'` globally would flash the wrong cursor before the target handler fires.
- [x] ~Centralize theme subscription in bigTerminalCache~ - The current approach (component-level `useEffect`) is correct: it only runs `reThemeAllBigTerminals()` when a `BigTerminalView` is mounted, avoiding module-level side effects in the cache module.
- [x] Copilot: no comments generated

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn test useTerminalFileDrop` passes (12/12)
- [ ] Drag a file from Finder onto Big Terminal - path is pasted
- [ ] Drag a file from Finder onto right-panel terminal - path is pasted
- [ ] Drag a file onto empty space (sidebar) - window does NOT navigate away
- [ ] Drag an image onto chat input - still compresses and attaches
- [ ] Drag a folder onto chat input - folder is attached as context
- [ ] Switch theme with multiple big terminals open - all re-theme immediately
- [ ] Open Spotify in embedded apps - playback works (Widevine CDM loads in webview)