### PR TITLE
Improve terminal contrast in light themes

### DIFF
--- a/src/renderer/components/Center/bigTerminalCache.ts
+++ b/src/renderer/components/Center/bigTerminalCache.ts
@@ -3,7 +3,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import type { WebglAddon } from '@xterm/addon-webgl'
 import type { SearchAddon } from '@xterm/addon-search'
 import * as ipc from '@/lib/ipc'
-import { getTerminalTheme } from '@/themes/terminal'
+import { getTerminalMinimumContrastRatio, getTerminalTheme } from '@/themes/terminal'
 import { createTerminal, registerPtyFinder } from '@/components/Right/terminalCache'
 import { registerAgentStatusOsc, registerBraidOsc9 } from '@/lib/agentStatusOsc'
 import { registerTitleDetection } from '@/lib/agentTitleDetection'
@@ -227,8 +227,10 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
 /** Re-theme all cached big terminals when the app theme changes. */
 export function reThemeAllBigTerminals(): void {
   const theme = getTerminalTheme()
+  const minimumContrastRatio = getTerminalMinimumContrastRatio()
   for (const entry of cache.values()) {
     entry.term.options.theme = theme
+    entry.term.options.minimumContrastRatio = minimumContrastRatio
   }
 }
 

--- a/src/renderer/components/Right/SetupPanel.tsx
+++ b/src/renderer/components/Right/SetupPanel.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 import * as ipc from '@/lib/ipc'
 import { useUIStore } from '@/store/ui'
 import { useProjectsStore } from '@/store/projects'
-import { getTerminalTheme, TERMINAL_MINIMUM_CONTRAST_RATIO } from '@/themes/terminal'
+import { getTerminalMinimumContrastRatio, getTerminalTheme } from '@/themes/terminal'
 import { activateWebgl } from './terminalCache'
 import { IconWrench } from '@/components/shared/icons'
 import { Button, EmptyState } from '@/components/ui'
@@ -39,7 +39,7 @@ function getOrCreateCache(worktreePath: string): CachedSetup {
     theme: getTerminalTheme(),
     fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', monospace",
     fontSize: useUIStore.getState().terminalFontSize,
-    minimumContrastRatio: TERMINAL_MINIMUM_CONTRAST_RATIO,
+    minimumContrastRatio: getTerminalMinimumContrastRatio(),
     cursorBlink: false,
     disableStdin: true,
     allowProposedApi: true
@@ -191,8 +191,10 @@ export function SetupPanel({ worktreePath, projectId, hidden }: Props) {
       if (state.activeThemeId !== prevId) {
         prevId = state.activeThemeId
         requestAnimationFrame(() => {
+          const minimumContrastRatio = getTerminalMinimumContrastRatio()
           for (const cached of setupCache.values()) {
             cached.term.options.theme = getTerminalTheme()
+            cached.term.options.minimumContrastRatio = minimumContrastRatio
           }
         })
       }

--- a/src/renderer/components/Right/SetupPanel.tsx
+++ b/src/renderer/components/Right/SetupPanel.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 import * as ipc from '@/lib/ipc'
 import { useUIStore } from '@/store/ui'
 import { useProjectsStore } from '@/store/projects'
-import { getTerminalTheme } from '@/themes/terminal'
+import { getTerminalTheme, TERMINAL_MINIMUM_CONTRAST_RATIO } from '@/themes/terminal'
 import { activateWebgl } from './terminalCache'
 import { IconWrench } from '@/components/shared/icons'
 import { Button, EmptyState } from '@/components/ui'
@@ -39,6 +39,7 @@ function getOrCreateCache(worktreePath: string): CachedSetup {
     theme: getTerminalTheme(),
     fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', monospace",
     fontSize: useUIStore.getState().terminalFontSize,
+    minimumContrastRatio: TERMINAL_MINIMUM_CONTRAST_RATIO,
     cursorBlink: false,
     disableStdin: true,
     allowProposedApi: true

--- a/src/renderer/components/Right/TerminalPanel.tsx
+++ b/src/renderer/components/Right/TerminalPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { Terminal } from '@xterm/xterm'
 import * as ipc from '@/lib/ipc'
-import { getTerminalTheme } from '@/themes/terminal'
+import { getTerminalMinimumContrastRatio, getTerminalTheme } from '@/themes/terminal'
 import { useUIStore } from '@/store/ui'
 import { createTerminal, activateWebgl } from './terminalCache'
 import '@xterm/xterm/css/xterm.css'
@@ -92,6 +92,7 @@ export function TerminalPanel({ worktreePath }: Props) {
         requestAnimationFrame(() => {
           if (termRef.current) {
             termRef.current.options.theme = getTerminalTheme()
+            termRef.current.options.minimumContrastRatio = getTerminalMinimumContrastRatio()
           }
         })
       }

--- a/src/renderer/components/Right/terminalCache.ts
+++ b/src/renderer/components/Right/terminalCache.ts
@@ -6,7 +6,7 @@ import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { SearchAddon } from '@xterm/addon-search'
 import { LigaturesAddon } from '@xterm/addon-ligatures'
 import * as ipc from '@/lib/ipc'
-import { getTerminalTheme } from '@/themes/terminal'
+import { getTerminalTheme, TERMINAL_MINIMUM_CONTRAST_RATIO } from '@/themes/terminal'
 import { useUIStore } from '@/store/ui'
 import { SK } from '@/lib/storageKeys'
 
@@ -99,6 +99,7 @@ export function createTerminal(): { term: Terminal; fitAddon: FitAddon; searchAd
     theme: getTerminalTheme(),
     fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', monospace",
     fontSize: useUIStore.getState().terminalFontSize,
+    minimumContrastRatio: TERMINAL_MINIMUM_CONTRAST_RATIO,
     cursorBlink: true,
     allowProposedApi: true
   })

--- a/src/renderer/components/Right/terminalCache.ts
+++ b/src/renderer/components/Right/terminalCache.ts
@@ -6,7 +6,7 @@ import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { SearchAddon } from '@xterm/addon-search'
 import { LigaturesAddon } from '@xterm/addon-ligatures'
 import * as ipc from '@/lib/ipc'
-import { getTerminalTheme, TERMINAL_MINIMUM_CONTRAST_RATIO } from '@/themes/terminal'
+import { getTerminalMinimumContrastRatio, getTerminalTheme } from '@/themes/terminal'
 import { useUIStore } from '@/store/ui'
 import { SK } from '@/lib/storageKeys'
 
@@ -99,7 +99,7 @@ export function createTerminal(): { term: Terminal; fitAddon: FitAddon; searchAd
     theme: getTerminalTheme(),
     fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', monospace",
     fontSize: useUIStore.getState().terminalFontSize,
-    minimumContrastRatio: TERMINAL_MINIMUM_CONTRAST_RATIO,
+    minimumContrastRatio: getTerminalMinimumContrastRatio(),
     cursorBlink: true,
     allowProposedApi: true
   })
@@ -195,9 +195,11 @@ export function loadRightTerminalTabs(worktreePath: string): PersistedTabInfo[] 
 /** Re-theme all cached terminals when the app theme changes */
 export function reThemeAllTerminals(): void {
   const theme = getTerminalTheme()
+  const minimumContrastRatio = getTerminalMinimumContrastRatio()
   for (const cached of terminalCache.values()) {
     for (const tab of cached.tabs) {
       tab.term.options.theme = theme
+      tab.term.options.minimumContrastRatio = minimumContrastRatio
     }
   }
 }

--- a/src/renderer/themes/__tests__/terminal.test.ts
+++ b/src/renderer/themes/__tests__/terminal.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { getTerminalTheme } from '../terminal'
+import {
+  getTerminalMinimumContrastRatio,
+  getTerminalTheme,
+  TERMINAL_DARK_MINIMUM_CONTRAST_RATIO,
+  TERMINAL_LIGHT_MINIMUM_CONTRAST_RATIO
+} from '../terminal'
 
 const HEX_RE = /^#[0-9a-fA-F]{6}$/
 
 // Simulate CSS custom properties on document.documentElement
 beforeEach(() => {
+  document.documentElement.removeAttribute('data-theme')
+
   const vars: Record<string, string> = {
     '--bg-primary': '#0d1117',
     '--text-primary': '#e6edf3',
@@ -79,5 +86,13 @@ describe('getTerminalTheme', () => {
   it('includes selectionBackground', () => {
     const theme = getTerminalTheme()
     expect(theme.selectionBackground).toBeTruthy()
+  })
+
+  it('enforces contrast only for light themes', () => {
+    document.documentElement.setAttribute('data-theme', 'light')
+    expect(getTerminalMinimumContrastRatio()).toBe(TERMINAL_LIGHT_MINIMUM_CONTRAST_RATIO)
+
+    document.documentElement.setAttribute('data-theme', 'dark')
+    expect(getTerminalMinimumContrastRatio()).toBe(TERMINAL_DARK_MINIMUM_CONTRAST_RATIO)
   })
 })

--- a/src/renderer/themes/terminal.ts
+++ b/src/renderer/themes/terminal.ts
@@ -1,5 +1,7 @@
 import type { ITheme } from '@xterm/xterm'
 
+export const TERMINAL_MINIMUM_CONTRAST_RATIO = 4.5
+
 /** Read a CSS variable from :root, with fallback */
 function cssVar(name: string, fallback: string): string {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback

--- a/src/renderer/themes/terminal.ts
+++ b/src/renderer/themes/terminal.ts
@@ -1,6 +1,13 @@
 import type { ITheme } from '@xterm/xterm'
 
-export const TERMINAL_MINIMUM_CONTRAST_RATIO = 4.5
+export const TERMINAL_LIGHT_MINIMUM_CONTRAST_RATIO = 4.5
+export const TERMINAL_DARK_MINIMUM_CONTRAST_RATIO = 1
+
+export function getTerminalMinimumContrastRatio(): number {
+  return document.documentElement.getAttribute('data-theme') === 'light'
+    ? TERMINAL_LIGHT_MINIMUM_CONTRAST_RATIO
+    : TERMINAL_DARK_MINIMUM_CONTRAST_RATIO
+}
 
 /** Read a CSS variable from :root, with fallback */
 function cssVar(name: string, fallback: string): string {


### PR DESCRIPTION
## Summary

- Set `minimumContrastRatio` to WCAG AA (4.5) on xterm.js terminals so ANSI colors remain readable in light themes

## Layers touched

- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Right panel:**
- `SetupPanel.tsx` / `terminalCache.ts` — apply `minimumContrastRatio` option when creating xterm.js `Terminal` instances

**Themes** (`themes/terminal.ts`):
- Export `TERMINAL_MINIMUM_CONTRAST_RATIO = 4.5` constant (WCAG AA level)

## How to test

1. `yarn dev`
2. Switch to a light theme (Settings > Appearance)
3. Open a terminal in the right panel
4. Run a command that produces colored output (e.g. `ls --color`, `git log --oneline`)
5. Verify all text has sufficient contrast against the light background - previously faint colors (yellow, cyan) should now be darkened automatically

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store