### PR TITLE
Fix Codex terminal input notifications

### DIFF
--- a/src/main/services/__tests__/agentHookServer.test.ts
+++ b/src/main/services/__tests__/agentHookServer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => []),
+  },
+}))
+
+import { mapHookEventToState } from '../agentHookServer'
+
+describe('mapHookEventToState', () => {
+  it('treats Codex request_user_input PreToolUse as waiting for input', () => {
+    expect(mapHookEventToState('codex', 'PreToolUse', 'request_user_input')).toBe('waiting')
+  })
+
+  it('keeps other Codex PreToolUse events as working', () => {
+    expect(mapHookEventToState('codex', 'PreToolUse', 'exec_command')).toBe('working')
+  })
+
+  it('clears Codex request_user_input after PostToolUse', () => {
+    expect(mapHookEventToState('codex', 'PostToolUse', 'request_user_input')).toBe('working')
+  })
+
+  it('preserves existing Codex permission mapping', () => {
+    expect(mapHookEventToState('codex', 'PermissionRequest')).toBe('waiting')
+  })
+
+  it('returns null for unmapped events', () => {
+    expect(mapHookEventToState('codex', 'UnknownEvent')).toBeNull()
+  })
+})

--- a/src/main/services/__tests__/codexHookService.test.ts
+++ b/src/main/services/__tests__/codexHookService.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type * as Os from 'os'
+
+const homedirMock = vi.hoisted(() => vi.fn<() => string>())
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof Os>()
+  return {
+    ...actual,
+    homedir: homedirMock,
+  }
+})
+
+let tmpHome: string
+
+beforeEach(() => {
+  vi.resetModules()
+  tmpHome = mkdtempSync(join(tmpdir(), 'braid-codex-hooks-'))
+  homedirMock.mockReturnValue(tmpHome)
+})
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true })
+  vi.clearAllMocks()
+})
+
+async function loadCodexHookService(): Promise<typeof import('../agentHooks/codex')> {
+  return import('../agentHooks/codex')
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf-8')) as unknown
+}
+
+describe('codex hook service', () => {
+  it('installs Codex hooks with config.toml trust entries', async () => {
+    const { ensureHooks, areHooksInstalled } = await loadCodexHookService()
+
+    ensureHooks()
+
+    expect(areHooksInstalled()).toBe(true)
+
+    const hooksPath = join(tmpHome, '.codex', 'hooks.json')
+    const hooksConfig = readJson(hooksPath) as {
+      hooks: Record<string, { hooks?: { command?: string }[] }[]>
+    }
+    expect(Object.keys(hooksConfig.hooks).sort()).toEqual([
+      'PermissionRequest',
+      'PostToolUse',
+      'PreToolUse',
+      'SessionStart',
+      'Stop',
+      'UserPromptSubmit',
+    ].sort())
+    expect(hooksConfig.hooks.PreToolUse?.[0]?.hooks?.[0]?.command).toBe(
+      '~/.braid/hooks/agent-status-codex.sh'
+    )
+
+    const configToml = readFileSync(join(tmpHome, '.codex', 'config.toml'), 'utf-8')
+    expect(configToml).toContain(':pre_tool_use:0:0')
+    expect(configToml).toContain('trusted_hash = "sha256:')
+
+    const script = readFileSync(join(tmpHome, '.braid', 'hooks', 'agent-status-codex.sh'), 'utf-8')
+    expect(script).toContain('BRAID_HOOK_VERSION=11')
+    expect(script).toContain('[ -z "$BRAID_HOOK_PORT" ] || [ -z "$BRAID_HOOK_TOKEN" ] || [ -z "$BRAID_TERMINAL_ID" ]')
+    expect(script).toContain('\\"name\\"')
+  })
+
+  it('trusts the actual managed hook index when user hooks already exist', async () => {
+    const codexDir = join(tmpHome, '.codex')
+    mkdirSync(codexDir, { recursive: true })
+    writeFileSync(
+      join(codexDir, 'hooks.json'),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [{ hooks: [{ type: 'command', command: 'user-hook' }] }],
+        },
+      }),
+      'utf-8'
+    )
+
+    const { ensureHooks, areHooksInstalled } = await loadCodexHookService()
+    ensureHooks()
+
+    expect(areHooksInstalled()).toBe(true)
+    const configToml = readFileSync(join(codexDir, 'config.toml'), 'utf-8')
+    expect(configToml).toContain(':pre_tool_use:1:0')
+  })
+
+  it('removes managed hooks and their trust entries', async () => {
+    const { ensureHooks, removeHooks, areHooksInstalled } = await loadCodexHookService()
+
+    ensureHooks()
+    removeHooks()
+
+    expect(areHooksInstalled()).toBe(false)
+    const hooksConfig = readJson(join(tmpHome, '.codex', 'hooks.json')) as {
+      hooks: Record<string, { hooks?: { command?: string }[] }[]>
+    }
+    expect(JSON.stringify(hooksConfig)).not.toContain('agent-status-codex.sh')
+
+    const configPath = join(tmpHome, '.codex', 'config.toml')
+    expect(existsSync(configPath) ? readFileSync(configPath, 'utf-8') : '').not.toContain(':pre_tool_use:')
+  })
+})

--- a/src/main/services/__tests__/codexHookService.test.ts
+++ b/src/main/services/__tests__/codexHookService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import type * as Os from 'os'
@@ -64,9 +64,35 @@ describe('codex hook service', () => {
     expect(configToml).toContain('trusted_hash = "sha256:')
 
     const script = readFileSync(join(tmpHome, '.braid', 'hooks', 'agent-status-codex.sh'), 'utf-8')
-    expect(script).toContain('BRAID_HOOK_VERSION=11')
-    expect(script).toContain('[ -z "$BRAID_HOOK_PORT" ] || [ -z "$BRAID_HOOK_TOKEN" ] || [ -z "$BRAID_TERMINAL_ID" ]')
+    expect(script).toContain('BRAID_HOOK_VERSION=12')
+    expect(script).toContain('if [ -z "$BRAID_HOOK_PORT" ] || [ -z "$BRAID_HOOK_TOKEN" ] || [ -z "$BRAID_TERMINAL_ID" ]; then')
     expect(script).toContain('\\"name\\"')
+  })
+
+  it('preserves symlinked config.toml when updating trust entries', async () => {
+    const codexDir = join(tmpHome, '.codex')
+    const dotfilesDir = join(tmpHome, 'dotfiles')
+    mkdirSync(codexDir, { recursive: true })
+    mkdirSync(dotfilesDir, { recursive: true })
+
+    const configPath = join(codexDir, 'config.toml')
+    const targetPath = join(dotfilesDir, 'codex-config.toml')
+    writeFileSync(targetPath, '# existing config\n', 'utf-8')
+
+    try {
+      symlinkSync(targetPath, configPath)
+    } catch {
+      return
+    }
+
+    const { ensureHooks, areHooksInstalled } = await loadCodexHookService()
+    ensureHooks()
+
+    expect(areHooksInstalled()).toBe(true)
+    expect(lstatSync(configPath).isSymbolicLink()).toBe(true)
+    expect(readFileSync(targetPath, 'utf-8')).toContain(':pre_tool_use:0:0')
+    expect(existsSync(`${configPath}.bak`)).toBe(false)
+    expect(existsSync(`${targetPath}.bak`)).toBe(false)
   })
 
   it('trusts the actual managed hook index when user hooks already exist', async () => {

--- a/src/main/services/agentHookServer.ts
+++ b/src/main/services/agentHookServer.ts
@@ -132,6 +132,8 @@ const EVENT_MAPS: Record<AgentHookTarget, Record<string, AgentStatusState>> = {
   },
 }
 
+const CODEX_USER_INPUT_TOOL_NAME = 'request_user_input'
+
 /** Valid agent IDs for URL routing. */
 const VALID_AGENTS = new Set<string>(Object.keys(EVENT_MAPS))
 
@@ -148,7 +150,16 @@ function parseRoute(url: string | undefined): AgentHookTarget | null {
 }
 
 /** Map an event name to a status state using the agent-specific mapping. */
-function mapEventToState(agentId: AgentHookTarget, event: string): AgentStatusState | null {
+export function mapHookEventToState(
+  agentId: AgentHookTarget,
+  event: string,
+  toolName?: string
+): AgentStatusState | null {
+  // Codex prompts created by request_user_input block on the user before the
+  // tool completes, so treat its PreToolUse hook as a waiting-for-input state.
+  if (agentId === 'codex' && event === 'PreToolUse' && toolName === CODEX_USER_INPUT_TOOL_NAME) {
+    return 'waiting'
+  }
   return EVENT_MAPS[agentId]?.[event] ?? null
 }
 
@@ -210,7 +221,7 @@ export async function startAgentHookServer(): Promise<{ port: number; token: str
           const parsed = JSON.parse(body) as HookRequestBody
           if (!parsed.terminalId || !parsed.event) return
 
-          const state = mapEventToState(agentId, parsed.event)
+          const state = mapHookEventToState(agentId, parsed.event, parsed.toolName)
           if (!state) return
 
           const status: AgentHookStatus = {

--- a/src/main/services/agentHooks/codex.ts
+++ b/src/main/services/agentHooks/codex.ts
@@ -1,9 +1,25 @@
 // ── Codex Hook Service ───────────────────────────────────────────────────────
-// Config: ~/.codex/hooks.json (JSON overlay - avoids TOML parsing)
+// Config: ~/.codex/hooks.json plus trusted hook hashes in ~/.codex/config.toml
 
 import { homedir } from 'os'
 import { join } from 'path'
-import { createAgentHookService } from './createService'
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { generateHookScript, HOOK_SCRIPT_VERSION } from './hookScript'
+import {
+  addBraidHook,
+  hasBraidHook,
+  readHooksJson,
+  removeBraidHooks,
+  writeHooksJson,
+  type HookConfig,
+} from './jsonHooksConfig'
+import {
+  hasHookTrustEntries,
+  removeHookTrustEntries,
+  upsertHookTrustEntries,
+  type CodexEventLabel,
+  type CodexTrustEntry,
+} from './codexTrust'
 
 const EVENTS = [
   'SessionStart',
@@ -14,8 +30,126 @@ const EVENTS = [
   'Stop',
 ] as const
 
-export const { ensureHooks, removeHooks, areHooksInstalled } = createAgentHookService({
-  agentId: 'codex',
-  configPath: join(homedir(), '.codex', 'hooks.json'),
-  events: EVENTS,
-})
+const CODEX_EVENT_LABEL: Record<(typeof EVENTS)[number], CodexEventLabel> = {
+  SessionStart: 'session_start',
+  UserPromptSubmit: 'user_prompt_submit',
+  PreToolUse: 'pre_tool_use',
+  PostToolUse: 'post_tool_use',
+  PermissionRequest: 'permission_request',
+  Stop: 'stop',
+}
+
+const HOOK_DIR = join(homedir(), '.braid', 'hooks')
+const SCRIPT_NAME = 'agent-status-codex.sh'
+const SCRIPT_PATH = join(HOOK_DIR, SCRIPT_NAME)
+const HOOK_COMMAND = `~/.braid/hooks/${SCRIPT_NAME}`
+const HOOKS_JSON_PATH = join(homedir(), '.codex', 'hooks.json')
+const CONFIG_TOML_PATH = join(homedir(), '.codex', 'config.toml')
+
+function readInstalledVersion(): number {
+  try {
+    if (!existsSync(SCRIPT_PATH)) return 0
+    const content = readFileSync(SCRIPT_PATH, 'utf-8')
+    const match = content.match(/BRAID_HOOK_VERSION=(\d+)/)
+    return match ? parseInt(match[1], 10) : 0
+  } catch {
+    return 0
+  }
+}
+
+function isBraidCodexHook(command: string | undefined): command is string {
+  return typeof command === 'string' && command.includes('.braid/hooks/') && command.includes(SCRIPT_NAME)
+}
+
+function findBraidHook(configs: HookConfig[]): {
+  groupIndex: number
+  handlerIndex: number
+  command: string
+} | null {
+  let found: { groupIndex: number; handlerIndex: number; command: string } | null = null
+  configs.forEach((config, groupIndex) => {
+    if (!Array.isArray(config.hooks)) return
+    config.hooks.forEach((hook, handlerIndex) => {
+      if (isBraidCodexHook(hook.command)) {
+        found = { groupIndex, handlerIndex, command: hook.command }
+      }
+    })
+  })
+  return found
+}
+
+function collectTrustEntries(hooksMap: Record<string, HookConfig[]>): CodexTrustEntry[] {
+  const entries: CodexTrustEntry[] = []
+  for (const event of EVENTS) {
+    const found = findBraidHook(hooksMap[event] ?? [])
+    if (!found) continue
+    entries.push({
+      sourcePath: HOOKS_JSON_PATH,
+      eventLabel: CODEX_EVENT_LABEL[event],
+      groupIndex: found.groupIndex,
+      handlerIndex: found.handlerIndex,
+      command: found.command,
+    })
+  }
+  return entries
+}
+
+export function ensureHooks(): void {
+  const installedVersion = readInstalledVersion()
+  if (installedVersion < HOOK_SCRIPT_VERSION) {
+    mkdirSync(HOOK_DIR, { recursive: true })
+    const script = generateHookScript({ agentId: 'codex' })
+    writeFileSync(SCRIPT_PATH, script, 'utf-8')
+    chmodSync(SCRIPT_PATH, 0o755)
+  }
+
+  const hooksMap = readHooksJson(HOOKS_JSON_PATH)
+  let changed = false
+
+  for (const event of EVENTS) {
+    const configs = hooksMap[event] ?? []
+    if (!hasBraidHook(configs, SCRIPT_NAME)) {
+      hooksMap[event] = addBraidHook(configs, HOOK_COMMAND)
+      changed = true
+    }
+  }
+
+  if (changed) writeHooksJson(HOOKS_JSON_PATH, hooksMap)
+
+  const trustEntries = collectTrustEntries(hooksMap)
+  upsertHookTrustEntries(CONFIG_TOML_PATH, trustEntries)
+}
+
+export function removeHooks(): void {
+  const hooksMap = readHooksJson(HOOKS_JSON_PATH)
+  const trustEntries = collectTrustEntries(hooksMap)
+  let changed = false
+
+  for (const event of Object.keys(hooksMap)) {
+    const cleaned = removeBraidHooks(hooksMap[event], SCRIPT_NAME)
+    if (cleaned.length !== hooksMap[event].length) {
+      hooksMap[event] = cleaned
+      changed = true
+    }
+    if (hooksMap[event].length === 0) {
+      delete hooksMap[event]
+      changed = true
+    }
+  }
+
+  if (changed) writeHooksJson(HOOKS_JSON_PATH, hooksMap)
+  removeHookTrustEntries(CONFIG_TOML_PATH, trustEntries)
+}
+
+export function areHooksInstalled(): boolean {
+  try {
+    const hooksMap = readHooksJson(HOOKS_JSON_PATH)
+    if (!EVENTS.every((event) => hasBraidHook(hooksMap[event] ?? [], SCRIPT_NAME))) {
+      return false
+    }
+    const trustEntries = collectTrustEntries(hooksMap)
+    return trustEntries.length === EVENTS.length && hasHookTrustEntries(CONFIG_TOML_PATH, trustEntries)
+  } catch {
+    return false
+  }
+}

--- a/src/main/services/agentHooks/codexTrust.ts
+++ b/src/main/services/agentHooks/codexTrust.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync } from 'fs'
 import { createHash, randomUUID } from 'crypto'
 import { dirname, join } from 'path'
 
@@ -180,14 +180,22 @@ function removeTrustBlock(content: string, key: string): string {
 }
 
 function writeConfigAtomically(configPath: string, contents: string): void {
-  const dir = dirname(configPath)
+  let targetPath = configPath
+  if (existsSync(configPath)) {
+    try {
+      targetPath = realpathSync.native(configPath)
+    } catch {
+      targetPath = configPath
+    }
+  }
+
+  const dir = dirname(targetPath)
   mkdirSync(dir, { recursive: true })
   const tmpPath = join(dir, `.${Date.now()}-${randomUUID()}.tmp`)
   let renamed = false
   try {
-    writeFileSync(tmpPath, contents, 'utf-8')
-    if (existsSync(configPath)) copyFileSync(configPath, `${configPath}.bak`)
-    renameSync(tmpPath, configPath)
+    writeFileSync(tmpPath, contents, { encoding: 'utf-8', mode: 0o600 })
+    renameSync(tmpPath, targetPath)
     renamed = true
   } finally {
     if (!renamed) {

--- a/src/main/services/agentHooks/codexTrust.ts
+++ b/src/main/services/agentHooks/codexTrust.ts
@@ -1,0 +1,224 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync } from 'fs'
+import { createHash, randomUUID } from 'crypto'
+import { dirname, join } from 'path'
+
+export type CodexEventLabel =
+  | 'session_start'
+  | 'user_prompt_submit'
+  | 'pre_tool_use'
+  | 'permission_request'
+  | 'post_tool_use'
+  | 'stop'
+
+export interface CodexTrustEntry {
+  sourcePath: string
+  eventLabel: CodexEventLabel
+  groupIndex: number
+  handlerIndex: number
+  command: string
+}
+
+interface CodexHookTrustState {
+  enabled?: boolean
+  trustedHash?: string
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = canonicalize((value as Record<string, unknown>)[key])
+    }
+    return out
+  }
+  return value
+}
+
+/** Match Codex's command_hook_hash identity for hooks.json command handlers. */
+export function computeTrustedHash(entry: CodexTrustEntry): string {
+  const identity = {
+    event_name: entry.eventLabel,
+    hooks: [{
+      async: false,
+      command: entry.command,
+      timeout: 600,
+      type: 'command',
+    }],
+  }
+  const serialized = JSON.stringify(canonicalize(identity))
+  return `sha256:${createHash('sha256').update(serialized).digest('hex')}`
+}
+
+export function getCodexCanonicalTrustPath(sourcePath: string): string {
+  try {
+    return realpathSync.native(sourcePath)
+  } catch {
+    return sourcePath
+  }
+}
+
+export function computeTrustKey(entry: CodexTrustEntry): string {
+  return `${getCodexCanonicalTrustPath(entry.sourcePath)}:${entry.eventLabel}:${entry.groupIndex}:${entry.handlerIndex}`
+}
+
+export function escapeTomlString(value: string): string {
+  return value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('"', '\\"')
+    .replaceAll('\b', '\\b')
+    .replaceAll('\f', '\\f')
+    .replaceAll('\n', '\\n')
+    .replaceAll('\r', '\\r')
+    .replaceAll('\t', '\\t')
+}
+
+function unescapeTomlBasicString(value: string): string {
+  return value.replace(/\\(["\\btnfrt])/g, (_match, ch: string) => {
+    switch (ch) {
+      case '"': return '"'
+      case '\\': return '\\'
+      case 'b': return '\b'
+      case 't': return '\t'
+      case 'n': return '\n'
+      case 'f': return '\f'
+      case 'r': return '\r'
+      default: return ch
+    }
+  })
+}
+
+function readTomlFile(configPath: string): string {
+  const raw = readFileSync(configPath, 'utf-8')
+  return raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw
+}
+
+export function readHookTrustEntries(configPath: string): Map<string, CodexHookTrustState> {
+  const entries = new Map<string, CodexHookTrustState>()
+  if (!existsSync(configPath)) return entries
+
+  let currentKey: string | null = null
+  for (const line of readTomlFile(configPath).split(/\r?\n/)) {
+    const header = /^\s*\[hooks\.state\."((?:\\.|[^"\\])*)"\]\s*(?:#.*)?$/.exec(line)
+    if (header) {
+      currentKey = unescapeTomlBasicString(header[1])
+      entries.set(currentKey, entries.get(currentKey) ?? {})
+      continue
+    }
+    if (/^\s*\[/.test(line)) {
+      currentKey = null
+      continue
+    }
+    if (!currentKey) continue
+
+    const enabled = /^\s*enabled\s*=\s*(true|false)\s*(?:#.*)?$/.exec(line)
+    if (enabled) {
+      entries.get(currentKey)!.enabled = enabled[1] === 'true'
+      continue
+    }
+    const trustedHash = /^\s*trusted_hash\s*=\s*"([^"]*)"\s*(?:#.*)?$/.exec(line)
+    if (trustedHash) {
+      entries.get(currentKey)!.trustedHash = trustedHash[1]
+    }
+  }
+
+  return entries
+}
+
+function buildTrustBlock(key: string, hash: string, enabled: boolean): string {
+  return [
+    `[hooks.state."${escapeTomlString(key)}"]`,
+    `enabled = ${enabled}`,
+    `trusted_hash = "${escapeTomlString(hash)}"`,
+  ].join('\n')
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function buildHeaderPattern(key: string): RegExp {
+  const escapedKey = escapeRegex(escapeTomlString(key))
+  return new RegExp(`(^|\\r?\\n)[ \\t]*\\[hooks\\.state\\."${escapedKey}"\\][ \\t]*(?:#[^\\r\\n]*)?(?=\\r?\\n|$)`)
+}
+
+function findNextTableHeader(text: string): number {
+  const match = /(?:^|\n)[ \t]*\[/.exec(text)
+  return match ? match.index + (match[0].startsWith('\n') ? 1 : 0) : -1
+}
+
+function upsertTrustBlock(content: string, key: string, hash: string): string {
+  const match = buildHeaderPattern(key).exec(content)
+  if (!match) {
+    const block = buildTrustBlock(key, hash, true)
+    if (!content) return `${block}\n`
+    const separator = content.endsWith('\n\n') ? '' : content.endsWith('\n') ? '\n' : '\n\n'
+    return `${content}${separator}${block}\n`
+  }
+
+  const headerStart = match.index + (match[1] ? match[1].length : 0)
+  const headerLineEnd = match.index + match[0].length
+  const after = content.slice(headerLineEnd)
+  const nextHeaderRel = findNextTableHeader(after)
+  const blockEnd = nextHeaderRel === -1 ? content.length : headerLineEnd + nextHeaderRel
+  const existingBlock = content.slice(headerLineEnd, blockEnd)
+  const enabledMatch = /^[ \t]*enabled[ \t]*=[ \t]*(true|false)[ \t\r]*(?:#.*)?$/m.exec(existingBlock)
+  const enabled = enabledMatch ? enabledMatch[1] === 'true' : true
+  return `${content.slice(0, headerStart)}${buildTrustBlock(key, hash, enabled)}\n${content.slice(blockEnd)}`
+}
+
+function removeTrustBlock(content: string, key: string): string {
+  const match = buildHeaderPattern(key).exec(content)
+  if (!match) return content
+
+  const cutStart = match.index + (match[1] ? match[1].length : 0)
+  const headerLineEnd = match.index + match[0].length
+  const after = content.slice(headerLineEnd)
+  const nextHeaderRel = findNextTableHeader(after)
+  const cutEnd = nextHeaderRel === -1 ? content.length : headerLineEnd + nextHeaderRel
+  return content.slice(0, cutStart) + content.slice(cutEnd)
+}
+
+function writeConfigAtomically(configPath: string, contents: string): void {
+  const dir = dirname(configPath)
+  mkdirSync(dir, { recursive: true })
+  const tmpPath = join(dir, `.${Date.now()}-${randomUUID()}.tmp`)
+  let renamed = false
+  try {
+    writeFileSync(tmpPath, contents, 'utf-8')
+    if (existsSync(configPath)) copyFileSync(configPath, `${configPath}.bak`)
+    renameSync(tmpPath, configPath)
+    renamed = true
+  } finally {
+    if (!renamed) {
+      try { unlinkSync(tmpPath) } catch {}
+    }
+  }
+}
+
+export function upsertHookTrustEntries(configPath: string, entries: readonly CodexTrustEntry[]): void {
+  const existing = existsSync(configPath) ? readTomlFile(configPath) : ''
+  let updated = existing
+  for (const entry of entries) {
+    updated = upsertTrustBlock(updated, computeTrustKey(entry), computeTrustedHash(entry))
+  }
+  if (updated !== existing) writeConfigAtomically(configPath, updated)
+}
+
+export function removeHookTrustEntries(configPath: string, entries: readonly CodexTrustEntry[]): void {
+  if (!existsSync(configPath)) return
+  const existing = readTomlFile(configPath)
+  let updated = existing
+  for (const entry of entries) {
+    updated = removeTrustBlock(updated, computeTrustKey(entry))
+  }
+  if (updated !== existing) writeConfigAtomically(configPath, updated)
+}
+
+export function hasHookTrustEntries(configPath: string, entries: readonly CodexTrustEntry[]): boolean {
+  const existing = readHookTrustEntries(configPath)
+  return entries.every((entry) => {
+    const state = existing.get(computeTrustKey(entry))
+    return state?.trustedHash === computeTrustedHash(entry) && state.enabled !== false
+  })
+}

--- a/src/main/services/agentHooks/hookScript.ts
+++ b/src/main/services/agentHooks/hookScript.ts
@@ -7,7 +7,7 @@
 //   4. POSTs to /hook/<agentId> on the loopback server
 
 /** Current hook script version. Bump to force re-install on next app launch. */
-export const HOOK_SCRIPT_VERSION = 11
+export const HOOK_SCRIPT_VERSION = 12
 
 export interface HookScriptOptions {
   /** Agent identifier - determines the POST endpoint path */
@@ -41,7 +41,9 @@ if [ -f "$HOOK_CONFIG" ]; then
 fi
 
 # Guard: only run inside Braid big terminals
-[ -z "$BRAID_HOOK_PORT" ] || [ -z "$BRAID_HOOK_TOKEN" ] || [ -z "$BRAID_TERMINAL_ID" ] && ${stdoutGuard}
+if [ -z "$BRAID_HOOK_PORT" ] || [ -z "$BRAID_HOOK_TOKEN" ] || [ -z "$BRAID_TERMINAL_ID" ]; then
+  ${stdoutGuard}
+fi
 
 # Read stdin (agent sends hook event JSON payload)
 input=$(cat)

--- a/src/main/services/agentHooks/hookScript.ts
+++ b/src/main/services/agentHooks/hookScript.ts
@@ -2,12 +2,12 @@
 //
 // Produces a bash script that:
 //   1. Reads port/token from ~/.braid/hooks/hook-server.json
-//   2. Guards on BRAID_HOOK_PORT (no-op outside Braid big terminals)
+//   2. Guards on Braid terminal env (no-op outside Braid big terminals)
 //   3. Reads stdin JSON, extracts hook_event_name and tool_name
 //   4. POSTs to /hook/<agentId> on the loopback server
 
 /** Current hook script version. Bump to force re-install on next app launch. */
-export const HOOK_SCRIPT_VERSION = 8
+export const HOOK_SCRIPT_VERSION = 11
 
 export interface HookScriptOptions {
   /** Agent identifier - determines the POST endpoint path */
@@ -21,6 +21,9 @@ export function generateHookScript(opts: HookScriptOptions): string {
   const { agentId, emitStdout = false } = opts
   const stdoutGuard = emitStdout ? 'echo \'{}\' && exit 0' : 'exit 0'
   const stdoutLine = emitStdout ? '\n# Agent requires valid JSON response on stdout\necho \'{}\'  \n' : ''
+  const toolNameFallback = agentId === 'codex'
+    ? '\n# Codex may expose function-tool names as `name` in some payloads.\n[ -z "$tool" ] && [[ "$input" =~ \\"name\\"[[:space:]]*:[[:space:]]*\\"([^\\"]+)\\" ]] && tool="${BASH_REMATCH[1]}"\n'
+    : ''
 
   return `#!/bin/bash
 # Braid agent status hook (${agentId}) - POSTs status to Braid's loopback HTTP server.
@@ -38,7 +41,7 @@ if [ -f "$HOOK_CONFIG" ]; then
 fi
 
 # Guard: only run inside Braid big terminals
-[ -z "$BRAID_HOOK_PORT" ] && ${stdoutGuard}
+[ -z "$BRAID_HOOK_PORT" ] || [ -z "$BRAID_HOOK_TOKEN" ] || [ -z "$BRAID_TERMINAL_ID" ] && ${stdoutGuard}
 
 # Read stdin (agent sends hook event JSON payload)
 input=$(cat)
@@ -50,6 +53,7 @@ event=""
 # Extract tool_name if present
 tool=""
 [[ "$input" =~ \\"tool_name\\"[[:space:]]*:[[:space:]]*\\"([^\\"]+)\\" ]] && tool="\${BASH_REMATCH[1]}"
+${toolNameFallback}
 
 # Extract is_interrupt for Stop events
 is_interrupt="false"

--- a/src/main/services/agentHooks/index.ts
+++ b/src/main/services/agentHooks/index.ts
@@ -11,18 +11,19 @@ import * as copilot from './copilot'
 import * as cursor from './cursor'
 import * as grok from './grok'
 import * as droid from './droid'
+import * as codex from './codex'
 import type { AgentHookService } from './types'
 
 export type { AgentHookTarget, AgentHookService } from './types'
 
-// Agents that use the standard JSON hooks format and can be auto-installed.
+// Agents that use supported hook config formats and can be auto-installed.
 // Not included:
-//   - codex: requires TOML trust entries in a managed Codex home directory
 //   - hermes: uses a Python plugin system + YAML config, not JSON hooks
-// These agents still have server-side event mappings so they work if hooks
+// Excluded agents can still have server-side event mappings so they work if hooks
 // are installed by other means (e.g. manually or via the agent's own tooling).
 const ALL_SERVICES: { name: string; service: AgentHookService }[] = [
   { name: 'claude', service: claude },
+  { name: 'codex', service: codex },
   { name: 'gemini', service: gemini },
   { name: 'antigravity', service: antigravity },
   { name: 'copilot', service: copilot },

--- a/src/renderer/components/Center/BigTerminalView.tsx
+++ b/src/renderer/components/Center/BigTerminalView.tsx
@@ -46,7 +46,7 @@ export function BigTerminalView({ terminalId, worktreePath, initialCommand, agen
     // Clear container of any stale children (safety net for tab switch).
     while (el.firstChild) el.removeChild(el.firstChild)
 
-    const entry = getOrCreate(terminalId, worktreePath, initialCommand)
+    const entry = getOrCreate(terminalId, worktreePath, initialCommand, agentId)
     entryRef.current = entry
 
     // Attach xterm to DOM (open on first mount, re-append on remount).
@@ -113,7 +113,7 @@ export function BigTerminalView({ terminalId, worktreePath, initialCommand, agen
         el.removeChild(entry.term.element)
       }
     }
-  }, [terminalId, worktreePath])
+  }, [terminalId, worktreePath, initialCommand, agentId])
 
   // Re-theme ALL cached big terminals when app theme changes (not just this one).
   useEffect(() => {

--- a/src/renderer/components/Center/BigTerminalView.tsx
+++ b/src/renderer/components/Center/BigTerminalView.tsx
@@ -3,7 +3,7 @@ import * as ipc from '@/lib/ipc'
 import { useTerminalFileDrop } from '@/hooks/useTerminalFileDrop'
 import { useTerminalClipboardPaste } from '@/hooks/useTerminalClipboardPaste'
 import { useUIStore } from '@/store/ui'
-import { getOrCreate, reThemeAllBigTerminals, type BigTermEntry } from './bigTerminalCache'
+import { getOrCreate, reThemeAllBigTerminals, updateBigTerminalAgentId, type BigTermEntry } from './bigTerminalCache'
 import { activateWebgl, disposeWebgl } from '@/components/Right/terminalCache'
 import { TerminalSearch } from '@/components/shared/TerminalSearch'
 import { BranchBar } from './BranchBar'
@@ -113,7 +113,11 @@ export function BigTerminalView({ terminalId, worktreePath, initialCommand, agen
         el.removeChild(entry.term.element)
       }
     }
-  }, [terminalId, worktreePath, initialCommand, agentId])
+  }, [terminalId, worktreePath])
+
+  useEffect(() => {
+    updateBigTerminalAgentId(terminalId, agentId)
+  }, [terminalId, agentId])
 
   // Re-theme ALL cached big terminals when app theme changes (not just this one).
   useEffect(() => {

--- a/src/renderer/components/Center/bigTerminalCache.ts
+++ b/src/renderer/components/Center/bigTerminalCache.ts
@@ -8,9 +8,10 @@ import { createTerminal, registerPtyFinder } from '@/components/Right/terminalCa
 import { registerAgentStatusOsc, registerBraidOsc9 } from '@/lib/agentStatusOsc'
 import { registerTitleDetection } from '@/lib/agentTitleDetection'
 import { replayIntoTerminal, isReplaying, POST_REPLAY_MODE_RESET } from '@/lib/replayGuard'
-import type { AgentStatusPayload, AgentStatusState } from '@/lib/agentStatus'
+import { isKnownAgentType, type AgentStatusPayload, type AgentStatusState, type AgentType } from '@/lib/agentStatus'
 import { createCompletionCoordinator, type CompletionCoordinator } from '@/lib/agentCompletionCoordinator'
 import { notifyTerminalStateChange, clearTerminalNotificationState } from '@/lib/terminalNotifications'
+import { isCodexUserInputPromptText, readTerminalBufferTail } from '@/lib/codexTerminalDetection'
 import { useUIStore } from '@/store/ui'
 import { useToastsStore } from '@/store/toasts'
 
@@ -30,6 +31,10 @@ export interface BigTermEntry {
   pendingFitRafId: number | null
   /** Completion coordinator for agent task completion detection. */
   completionCoordinator: CompletionCoordinator
+  /** Agent catalog id from tab metadata, when launched as a known CLI agent. */
+  agentId?: string
+  /** Debounced scan for Codex request_user_input panes. */
+  codexPromptScanTimer: ReturnType<typeof setTimeout> | null
   spawnPromise: Promise<void>
   /** Set by disposeBigTerminal so the in-flight spawn can bail out. */
   disposed: boolean
@@ -80,6 +85,41 @@ function ensureHookListener(): void {
   })
 }
 
+function normalizeAgentType(agentId?: string): AgentType | undefined {
+  return isKnownAgentType(agentId) ? agentId : undefined
+}
+
+function isKnownCodexTerminal(entry: BigTermEntry): boolean {
+  if (entry.agentId === 'codex') return true
+  const status = useUIStore.getState().bigTerminalStatusById[entry.terminalId]
+  return status?.agentType === 'codex'
+}
+
+function scanCodexUserInputPrompt(entry: BigTermEntry): void {
+  entry.codexPromptScanTimer = null
+  if (entry.disposed) return
+  if (isReplaying(entry.terminalId)) return
+  if (!isKnownCodexTerminal(entry)) return
+  if (!isCodexUserInputPromptText(readTerminalBufferTail(entry.term))) return
+
+  const current = useUIStore.getState().bigTerminalStatusById[entry.terminalId]
+  if (current?.state === 'waiting' && current.agentType === 'codex') return
+
+  const payload: AgentStatusPayload = { state: 'waiting', agentType: 'codex' }
+  useUIStore.getState().updateBigTerminalStatus(entry.terminalId, payload)
+  notifyTerminalStateChange(entry.terminalId, payload.state)
+}
+
+function scheduleCodexUserInputScan(entry: BigTermEntry): void {
+  if (entry.disposed || isReplaying(entry.terminalId)) return
+  if (!isKnownCodexTerminal(entry)) return
+  if (entry.codexPromptScanTimer) return
+
+  entry.codexPromptScanTimer = setTimeout(() => {
+    scanCodexUserInputPrompt(entry)
+  }, 80)
+}
+
 /**
  * Return existing entry or build a new one: create xterm, replay scrollback, spawn PTY.
  * Pass `initialCommand` to auto-run a command after the first PTY spawn (not on restore).
@@ -90,13 +130,17 @@ function ensureHookListener(): void {
  *   2. OSC 9999 / OSC 9: custom terminal sequences parsed by xterm.js.
  *   3. Title detection (fallback): watches braille spinners, Gemini markers, etc.
  */
-export function getOrCreate(terminalId: string, worktreePath: string, initialCommand?: string): BigTermEntry {
+export function getOrCreate(terminalId: string, worktreePath: string, initialCommand?: string, agentId?: string): BigTermEntry {
   ensureFinderRegistered()
   ensureHookListener()
   const existing = cache.get(terminalId)
-  if (existing) return existing
+  if (existing) {
+    if (agentId && !existing.agentId) existing.agentId = agentId
+    return existing
+  }
 
   const { term, fitAddon, searchAddon } = createTerminal()
+  const expectedAgentType = normalizeAgentType(agentId)
 
   // Completion coordinator fires when an agent finishes a task.
   // Toast + desktop notifications are handled by notifyTerminalStateChange.
@@ -118,6 +162,8 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
     webglDisabledAfterContextLoss: false,
     pendingFitRafId: null,
     completionCoordinator,
+    agentId,
+    codexPromptScanTimer: null,
     spawnPromise: Promise.resolve(),
     disposed: false
   }
@@ -136,11 +182,15 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
     notifyTerminalStateChange(terminalId, payload.state)
   })
 
-  registerTitleDetection(term, (result) => {
-    updateStatus({ state: result.state, agentType: result.agentType ?? undefined })
-    completionCoordinator.observeTitleStatus(result.state)
-    notifyTerminalStateChange(terminalId, result.state)
-  })
+  registerTitleDetection(
+    term,
+    (result) => {
+      updateStatus({ state: result.state, agentType: result.agentType ?? undefined })
+      completionCoordinator.observeTitleStatus(result.state)
+      notifyTerminalStateChange(terminalId, result.state)
+    },
+    { expectedAgentType }
+  )
 
   // OSC 9 (Braid hooks): Claude Code hooks return terminalSequence with
   // OSC 9 braid:STATE[:TOOL] payloads. Secondary to HTTP but still useful.
@@ -149,6 +199,11 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
     completionCoordinator.observeHookStatus(payload.state, false)
     notifyTerminalStateChange(terminalId, payload.state)
   })
+
+  // Fallback for Codex request_user_input when hooks are missing, disabled, or
+  // not trusted. The first-class path is the Codex PreToolUse hook mapping in
+  // the main-process hook server.
+  term.onWriteParsed(() => scheduleCodexUserInputScan(entry))
 
   entry.spawnPromise = (async () => {
     let hasScrollback = false
@@ -245,6 +300,10 @@ export function disposeBigTerminal(terminalId: string): void {
   if (entry.pendingFitRafId !== null) {
     cancelAnimationFrame(entry.pendingFitRafId)
     entry.pendingFitRafId = null
+  }
+  if (entry.codexPromptScanTimer) {
+    clearTimeout(entry.codexPromptScanTimer)
+    entry.codexPromptScanTimer = null
   }
   try { entry.webglAddon?.dispose() } catch {}
   entry.webglAddon = null

--- a/src/renderer/components/Center/bigTerminalCache.ts
+++ b/src/renderer/components/Center/bigTerminalCache.ts
@@ -1,4 +1,4 @@
-import { Terminal } from '@xterm/xterm'
+import { Terminal, type IDisposable } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import type { WebglAddon } from '@xterm/addon-webgl'
 import type { SearchAddon } from '@xterm/addon-search'
@@ -35,6 +35,8 @@ export interface BigTermEntry {
   agentId?: string
   /** Debounced scan for Codex request_user_input panes. */
   codexPromptScanTimer: ReturnType<typeof setTimeout> | null
+  /** xterm write listener used only for Codex prompt fallback scanning. */
+  codexPromptWriteDisposable: IDisposable | null
   spawnPromise: Promise<void>
   /** Set by disposeBigTerminal so the in-flight spawn can bail out. */
   disposed: boolean
@@ -60,6 +62,20 @@ function ensureFinderRegistered(): void {
 
 const VALID_STATES = new Set<string>(['working', 'blocked', 'waiting', 'done'])
 
+interface StatusApplyResult {
+  stateChanged: boolean
+}
+
+function applyTerminalStatus(terminalId: string, payload: AgentStatusPayload): StatusApplyResult {
+  const before = useUIStore.getState().bigTerminalStatusById[terminalId]
+  useUIStore.getState().updateBigTerminalStatus(terminalId, payload)
+  const after = useUIStore.getState().bigTerminalStatusById[terminalId]
+
+  return {
+    stateChanged: after !== before && after != null && before?.state !== after.state,
+  }
+}
+
 let hookListenerRegistered = false
 function ensureHookListener(): void {
   if (hookListenerRegistered) return
@@ -73,15 +89,22 @@ function ensureHookListener(): void {
 
     const payload: AgentStatusPayload = {
       state: state as AgentStatusState,
+      source: 'hook',
       agentType: (agentType as AgentStatusPayload['agentType']) ?? 'claude',
       toolName: toolName ?? undefined,
     }
-    useUIStore.getState().updateBigTerminalStatus(terminalId, payload)
-    entry.completionCoordinator.observeHookStatus(
-      payload.state,
-      interrupted ?? false
-    )
-    notifyTerminalStateChange(terminalId, payload.state)
+    const applied = applyTerminalStatus(terminalId, payload)
+    if (payload.agentType === 'codex') {
+      ensureCodexPromptScanListener(entry)
+      scheduleCodexUserInputScan(entry)
+    }
+    if (applied.stateChanged) {
+      entry.completionCoordinator.observeHookStatus(
+        payload.state,
+        interrupted ?? false
+      )
+      notifyTerminalStateChange(terminalId, payload.state)
+    }
   })
 }
 
@@ -105,9 +128,9 @@ function scanCodexUserInputPrompt(entry: BigTermEntry): void {
   const current = useUIStore.getState().bigTerminalStatusById[entry.terminalId]
   if (current?.state === 'waiting' && current.agentType === 'codex') return
 
-  const payload: AgentStatusPayload = { state: 'waiting', agentType: 'codex' }
-  useUIStore.getState().updateBigTerminalStatus(entry.terminalId, payload)
-  notifyTerminalStateChange(entry.terminalId, payload.state)
+  const payload: AgentStatusPayload = { state: 'waiting', source: 'terminal_scan', agentType: 'codex' }
+  const applied = applyTerminalStatus(entry.terminalId, payload)
+  if (applied.stateChanged) notifyTerminalStateChange(entry.terminalId, payload.state)
 }
 
 function scheduleCodexUserInputScan(entry: BigTermEntry): void {
@@ -118,6 +141,20 @@ function scheduleCodexUserInputScan(entry: BigTermEntry): void {
   entry.codexPromptScanTimer = setTimeout(() => {
     scanCodexUserInputPrompt(entry)
   }, 80)
+}
+
+function ensureCodexPromptScanListener(entry: BigTermEntry): void {
+  if (entry.codexPromptWriteDisposable) return
+  entry.codexPromptWriteDisposable = entry.term.onWriteParsed(() => scheduleCodexUserInputScan(entry))
+}
+
+function updateEntryAgentId(entry: BigTermEntry, agentId?: string): void {
+  if (!agentId) return
+  entry.agentId = agentId
+  if (agentId === 'codex') {
+    ensureCodexPromptScanListener(entry)
+    scheduleCodexUserInputScan(entry)
+  }
 }
 
 /**
@@ -135,7 +172,7 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
   ensureHookListener()
   const existing = cache.get(terminalId)
   if (existing) {
-    if (agentId && !existing.agentId) existing.agentId = agentId
+    updateEntryAgentId(existing, agentId)
     return existing
   }
 
@@ -164,6 +201,7 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
     completionCoordinator,
     agentId,
     codexPromptScanTimer: null,
+    codexPromptWriteDisposable: null,
     spawnPromise: Promise.resolve(),
     disposed: false
   }
@@ -173,21 +211,31 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
   // OSC 9999: handles any agent that emits custom hook sequences.
   // Title detection: handles Claude (braille spinners), Gemini (✦/◇/✋),
   // Codex, Aider, and any agent with keyword-based titles.
-  const updateStatus = (payload: AgentStatusPayload) =>
-    useUIStore.getState().updateBigTerminalStatus(terminalId, payload)
+  const updateStatus = (payload: AgentStatusPayload) => {
+    const applied = applyTerminalStatus(terminalId, payload)
+    if (payload.agentType === 'codex') {
+      ensureCodexPromptScanListener(entry)
+      scheduleCodexUserInputScan(entry)
+    }
+    return applied
+  }
 
   registerAgentStatusOsc(term, (payload) => {
-    updateStatus(payload)
-    completionCoordinator.observeHookStatus(payload.state, payload.interrupted)
-    notifyTerminalStateChange(terminalId, payload.state)
+    const applied = updateStatus({ ...payload, source: 'hook' })
+    if (applied.stateChanged) {
+      completionCoordinator.observeHookStatus(payload.state, payload.interrupted)
+      notifyTerminalStateChange(terminalId, payload.state)
+    }
   })
 
   registerTitleDetection(
     term,
     (result) => {
-      updateStatus({ state: result.state, agentType: result.agentType ?? undefined })
-      completionCoordinator.observeTitleStatus(result.state)
-      notifyTerminalStateChange(terminalId, result.state)
+      const applied = updateStatus({ state: result.state, source: 'title', agentType: result.agentType ?? undefined })
+      if (applied.stateChanged) {
+        completionCoordinator.observeTitleStatus(result.state)
+        notifyTerminalStateChange(terminalId, result.state)
+      }
     },
     { expectedAgentType }
   )
@@ -195,15 +243,14 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
   // OSC 9 (Braid hooks): Claude Code hooks return terminalSequence with
   // OSC 9 braid:STATE[:TOOL] payloads. Secondary to HTTP but still useful.
   registerBraidOsc9(term, (payload) => {
-    updateStatus(payload)
-    completionCoordinator.observeHookStatus(payload.state, false)
-    notifyTerminalStateChange(terminalId, payload.state)
+    const applied = updateStatus({ ...payload, source: 'hook' })
+    if (applied.stateChanged) {
+      completionCoordinator.observeHookStatus(payload.state, false)
+      notifyTerminalStateChange(terminalId, payload.state)
+    }
   })
 
-  // Fallback for Codex request_user_input when hooks are missing, disabled, or
-  // not trusted. The first-class path is the Codex PreToolUse hook mapping in
-  // the main-process hook server.
-  term.onWriteParsed(() => scheduleCodexUserInputScan(entry))
+  if (expectedAgentType === 'codex') ensureCodexPromptScanListener(entry)
 
   entry.spawnPromise = (async () => {
     let hasScrollback = false
@@ -279,6 +326,12 @@ export function getOrCreate(terminalId: string, worktreePath: string, initialCom
   return entry
 }
 
+export function updateBigTerminalAgentId(terminalId: string, agentId?: string): void {
+  const entry = cache.get(terminalId)
+  if (!entry) return
+  updateEntryAgentId(entry, agentId)
+}
+
 /** Re-theme all cached big terminals when the app theme changes. */
 export function reThemeAllBigTerminals(): void {
   const theme = getTerminalTheme()
@@ -305,6 +358,8 @@ export function disposeBigTerminal(terminalId: string): void {
     clearTimeout(entry.codexPromptScanTimer)
     entry.codexPromptScanTimer = null
   }
+  try { entry.codexPromptWriteDisposable?.dispose() } catch {}
+  entry.codexPromptWriteDisposable = null
   try { entry.webglAddon?.dispose() } catch {}
   entry.webglAddon = null
   entry.completionCoordinator.reset()

--- a/src/renderer/components/MissionControl/MissionControl.tsx
+++ b/src/renderer/components/MissionControl/MissionControl.tsx
@@ -9,6 +9,7 @@ import { usePrCacheStore } from '@/store/prCache'
 import { useMissionControlStore } from '@/store/missionControl'
 import { SESSION_COLUMNS, PR_COLUMNS, assignSessionColumn, assignPrColumn, assignTerminalColumn } from '@/lib/kanbanColumns'
 import { getSessionTitle } from '@/lib/sessionTitle'
+import { isKnownAgentType } from '@/lib/agentStatus'
 import { IconTerminal, IconGitFork } from '@/components/shared/icons'
 import { KanbanColumn } from './KanbanColumn'
 import { McFilterBar } from './McFilterBar'
@@ -191,6 +192,7 @@ function useTerminalBoardData(active: boolean): Map<SessionColumnId, TerminalCar
           const statusEntry = bigTerminalStatusById[tab.id]
           // Only show terminals with a detected agent status
           if (!statusEntry) continue
+          const tabAgentType = isKnownAgentType(tab.agentId) ? tab.agentId : null
 
           if (filterQuery && !matchesQuery(filterQuery, wt.branch, tab.label, project.name)) continue
 
@@ -206,7 +208,7 @@ function useTerminalBoardData(active: boolean): Map<SessionColumnId, TerminalCar
             branch: wt.branch,
             path: wt.path,
             agentState: statusEntry.state,
-            agentType: statusEntry.agentType,
+            agentType: tabAgentType ?? statusEntry.agentType,
             toolName: statusEntry.toolName,
             updatedAt: statusEntry.updatedAt,
             column: col,

--- a/src/renderer/lib/__tests__/agentStatus.test.ts
+++ b/src/renderer/lib/__tests__/agentStatus.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createAgentStatusEntry, updateAgentStatusEntry } from '../agentStatus'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('updateAgentStatusEntry', () => {
+  it('ignores duplicate status payloads without refreshing updatedAt', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1000)
+    const entry = createAgentStatusEntry('working', 'codex')
+
+    now.mockReturnValue(2000)
+    const updated = updateAgentStatusEntry(entry, { state: 'working', agentType: 'codex' })
+
+    expect(updated).toBe(entry)
+    expect(updated.updatedAt).toBe(1000)
+    expect(updated.stateHistory).toHaveLength(1)
+  })
+
+  it('updates metadata without treating it as a state transition', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1000)
+    const entry = createAgentStatusEntry('working', 'codex')
+
+    now.mockReturnValue(2000)
+    const updated = updateAgentStatusEntry(entry, {
+      state: 'working',
+      agentType: 'codex',
+      toolName: 'Bash',
+    })
+
+    expect(updated).not.toBe(entry)
+    expect(updated.updatedAt).toBe(1000)
+    expect(updated.stateHistory).toHaveLength(1)
+    expect(updated.toolName).toBe('Bash')
+  })
+
+  it('records real state transitions', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1000)
+    const entry = createAgentStatusEntry('working', 'codex')
+
+    now.mockReturnValue(2000)
+    const updated = updateAgentStatusEntry(entry, { state: 'waiting', agentType: 'codex' })
+
+    expect(updated.updatedAt).toBe(2000)
+    expect(updated.stateHistory).toEqual([
+      { state: 'working', timestamp: 1000 },
+      { state: 'waiting', timestamp: 2000 },
+    ])
+  })
+
+  it('does not let title detection override a hook state', () => {
+    const entry = createAgentStatusEntry('waiting', 'codex', 'hook')
+
+    const updated = updateAgentStatusEntry(entry, {
+      state: 'working',
+      agentType: 'codex',
+      source: 'title',
+    })
+
+    expect(updated).toBe(entry)
+  })
+
+  it('lets hook state override title detection', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1000)
+    const entry = createAgentStatusEntry('working', 'codex', 'title')
+
+    now.mockReturnValue(2000)
+    const updated = updateAgentStatusEntry(entry, {
+      state: 'waiting',
+      agentType: 'codex',
+      source: 'hook',
+    })
+
+    expect(updated.state).toBe('waiting')
+    expect(updated.source).toBe('hook')
+    expect(updated.updatedAt).toBe(2000)
+  })
+
+  it('promotes the source without resetting timers when hook confirms the same state', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1000)
+    const entry = createAgentStatusEntry('working', 'codex', 'title')
+
+    now.mockReturnValue(2000)
+    const updated = updateAgentStatusEntry(entry, {
+      state: 'working',
+      agentType: 'codex',
+      source: 'hook',
+    })
+
+    expect(updated).not.toBe(entry)
+    expect(updated.source).toBe('hook')
+    expect(updated.updatedAt).toBe(1000)
+    expect(updated.stateHistory).toHaveLength(1)
+  })
+})

--- a/src/renderer/lib/__tests__/agentTitleDetection.test.ts
+++ b/src/renderer/lib/__tests__/agentTitleDetection.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { detectAgentStatusFromTitle } from '../agentTitleDetection'
+
+describe('detectAgentStatusFromTitle', () => {
+  it('keeps the legacy Claude fallback for ambiguous braille spinners', () => {
+    expect(detectAgentStatusFromTitle('⠋ Working')).toEqual({
+      state: 'working',
+      agentType: 'claude',
+    })
+  })
+
+  it('uses the terminal agent for ambiguous braille spinners', () => {
+    expect(detectAgentStatusFromTitle('⠋ Working', { expectedAgentType: 'codex' })).toEqual({
+      state: 'working',
+      agentType: 'codex',
+    })
+  })
+
+  it('lets an explicit title agent override the terminal fallback', () => {
+    expect(detectAgentStatusFromTitle('⠋ Claude Code', { expectedAgentType: 'codex' })).toEqual({
+      state: 'working',
+      agentType: 'claude',
+    })
+  })
+
+  it('uses the terminal agent for generic waiting titles', () => {
+    expect(detectAgentStatusFromTitle('? waiting for approval', { expectedAgentType: 'codex' })).toEqual({
+      state: 'waiting',
+      agentType: 'codex',
+    })
+  })
+})

--- a/src/renderer/lib/__tests__/codexTerminalDetection.test.ts
+++ b/src/renderer/lib/__tests__/codexTerminalDetection.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { isCodexUserInputPromptText } from '../codexTerminalDetection'
+
+describe('isCodexUserInputPromptText', () => {
+  it('detects the Codex request_user_input question pane', () => {
+    expect(isCodexUserInputPromptText([
+      'Questions 0/1 answered',
+      'Question 1/1 (1 unanswered)',
+      'option 1/2 [ ] Continue',
+      'Submit with 1 unanswered question',
+    ].join('\n'))).toBe(true)
+  })
+
+  it('detects a fully answered question that still needs submit', () => {
+    expect(isCodexUserInputPromptText([
+      'Questions 1/1 answered',
+      'Question 1/1',
+      'answer: use the existing notification path',
+      'ctrl+s to submit all',
+    ].join('\n'))).toBe(true)
+  })
+
+  it('ignores interrupted transcript text that is no longer an active prompt', () => {
+    expect(isCodexUserInputPromptText([
+      'Questions (interrupted)',
+      '  - (unanswered)',
+      '    answer:',
+    ].join('\n'))).toBe(false)
+  })
+
+  it('ignores ordinary command output mentioning questions', () => {
+    expect(isCodexUserInputPromptText('FAQ: questions answered in the README')).toBe(false)
+  })
+})

--- a/src/renderer/lib/agentStatus.ts
+++ b/src/renderer/lib/agentStatus.ts
@@ -13,6 +13,10 @@ export const KNOWN_AGENT_TYPES = [
 
 export type AgentType = (typeof KNOWN_AGENT_TYPES)[number]
 
+export function isKnownAgentType(value: string | null | undefined): value is AgentType {
+  return typeof value === 'string' && (KNOWN_AGENT_TYPES as readonly string[]).includes(value)
+}
+
 // ── Status states ────────────────────────────────────────────────────────────
 
 export const AGENT_STATUS_STATES = ['working', 'blocked', 'waiting', 'done'] as const

--- a/src/renderer/lib/agentStatus.ts
+++ b/src/renderer/lib/agentStatus.ts
@@ -23,11 +23,24 @@ export const AGENT_STATUS_STATES = ['working', 'blocked', 'waiting', 'done'] as 
 
 export type AgentStatusState = (typeof AGENT_STATUS_STATES)[number]
 
+// ── Status sources ───────────────────────────────────────────────────────────
+
+export const AGENT_STATUS_SOURCES = ['title', 'terminal_scan', 'hook'] as const
+export type AgentStatusSource = (typeof AGENT_STATUS_SOURCES)[number]
+
+const AGENT_STATUS_SOURCE_PRIORITY: Record<AgentStatusSource, number> = {
+  title: 1,
+  terminal_scan: 2,
+  hook: 3,
+}
+
 // ── Payloads ─────────────────────────────────────────────────────────────────
 
 /** Payload from an OSC 9999 sequence or title-based detection. */
 export interface AgentStatusPayload {
   state: AgentStatusState
+  /** Detection source. Higher-priority sources protect against fallback churn. */
+  source?: AgentStatusSource
   /** Agent type identifier, e.g. 'claude', 'codex', 'gemini'. */
   agentType?: AgentType
   /** Tool currently being executed, e.g. "Edit", "Bash". */
@@ -64,19 +77,23 @@ export interface AgentStatusEntry {
   stateHistory: AgentStateHistoryEntry[]
   /** Timestamp of the last status update. */
   updatedAt: number
+  /** Source of the current state. */
+  source: AgentStatusSource
 }
 
 /** Create an initial (empty) status entry. */
 export function createAgentStatusEntry(
   state: AgentStatusState,
-  agentType?: AgentType
+  agentType?: AgentType,
+  source: AgentStatusSource = 'title'
 ): AgentStatusEntry {
   return {
     state,
     agentType: agentType ?? null,
     toolName: null,
     stateHistory: [{ state, timestamp: Date.now() }],
-    updatedAt: Date.now()
+    updatedAt: Date.now(),
+    source
   }
 }
 
@@ -85,16 +102,45 @@ export function updateAgentStatusEntry(
   prev: AgentStatusEntry,
   payload: AgentStatusPayload
 ): AgentStatusEntry {
+  const payloadSource = payload.source ?? 'title'
+  const payloadPriority = AGENT_STATUS_SOURCE_PRIORITY[payloadSource]
+  const prevPriority = AGENT_STATUS_SOURCE_PRIORITY[prev.source]
+  const isLowerPriority = payloadPriority < prevPriority
+  const stateChanged = payload.state !== prev.state
+
+  if (isLowerPriority && stateChanged) return prev
+
+  const nextSource = isLowerPriority ? prev.source : payloadSource
+  const nextAgentType = isLowerPriority
+    ? prev.agentType ?? payload.agentType ?? null
+    : payload.agentType ?? prev.agentType
+  const nextToolName = isLowerPriority
+    ? prev.toolName
+    : payload.toolName !== undefined ? payload.toolName : prev.toolName
+  const metadataChanged = nextAgentType !== prev.agentType || nextToolName !== prev.toolName
+  const sourceChanged = nextSource !== prev.source
+
+  if (!stateChanged && !metadataChanged && !sourceChanged) return prev
+  if (!stateChanged) {
+    return {
+      ...prev,
+      agentType: nextAgentType,
+      toolName: nextToolName,
+      source: nextSource
+    }
+  }
+
   const now = Date.now()
   const history = [...prev.stateHistory, { state: payload.state, timestamp: now }]
   if (history.length > MAX_HISTORY) history.splice(0, history.length - MAX_HISTORY)
 
   return {
     state: payload.state,
-    agentType: payload.agentType ?? prev.agentType,
-    toolName: payload.toolName !== undefined ? payload.toolName : prev.toolName,
+    agentType: nextAgentType,
+    toolName: nextToolName,
     stateHistory: history,
-    updatedAt: now
+    updatedAt: now,
+    source: nextSource
   }
 }
 

--- a/src/renderer/lib/agentTitleDetection.ts
+++ b/src/renderer/lib/agentTitleDetection.ts
@@ -16,6 +16,14 @@ export interface TitleDetectionResult {
   agentType: AgentType | null
 }
 
+export interface TitleDetectionOptions {
+  /**
+   * Catalog agent for the terminal tab. Used only when the title/status marker
+   * is ambiguous, such as shared braille spinners.
+   */
+  expectedAgentType?: AgentType
+}
+
 // ── Per-agent Unicode markers ────────────────────────────────────────────────
 
 // Claude Code: braille spinners when working, eight-spoked asterisk when idle
@@ -68,21 +76,25 @@ function detectAgentTypeFromTitle(title: string): AgentType | null {
  * 1. Agent-specific Unicode markers (most reliable)
  * 2. Generic status keywords (fallback)
  */
-export function detectAgentStatusFromTitle(title: string): TitleDetectionResult | null {
+export function detectAgentStatusFromTitle(
+  title: string,
+  options: TitleDetectionOptions = {}
+): TitleDetectionResult | null {
   if (!title) return null
   const first = title.charAt(0)
+  const expectedAgentType = options.expectedAgentType ?? null
 
   // ── Claude Code ──────────────────────────────────────────────────────────
   // Braille spinners = working
   if (BRAILLE_SPINNERS.has(first)) {
     return {
       state: 'working',
-      agentType: detectAgentTypeFromTitle(title) ?? 'claude'
+      agentType: detectAgentTypeFromTitle(title) ?? expectedAgentType ?? 'claude'
     }
   }
   // Idle marker
   if (first === CLAUDE_IDLE) {
-    return { state: 'done', agentType: 'claude' }
+    return { state: 'done', agentType: detectAgentTypeFromTitle(title) ?? expectedAgentType ?? 'claude' }
   }
 
   // ── Gemini CLI ───────────────────────────────────────────────────────────
@@ -100,14 +112,14 @@ export function detectAgentStatusFromTitle(title: string): TitleDetectionResult 
   if (first === '?') {
     return {
       state: 'waiting',
-      agentType: detectAgentTypeFromTitle(title)
+      agentType: detectAgentTypeFromTitle(title) ?? expectedAgentType
     }
   }
 
   // ── Generic keyword-based detection ──────────────────────────────────────
   // Check for agent name in the title body to identify the agent type,
   // then use keyword matching for status.
-  const agentType = detectAgentTypeFromTitle(title)
+  const agentType = detectAgentTypeFromTitle(title) ?? expectedAgentType
 
   if (WAITING_KEYWORDS.test(title)) {
     return { state: 'waiting', agentType }
@@ -133,10 +145,11 @@ export function detectAgentStatusFromTitle(title: string): TitleDetectionResult 
  */
 export function registerTitleDetection(
   term: Terminal,
-  onStatus: (result: TitleDetectionResult) => void
+  onStatus: (result: TitleDetectionResult) => void,
+  options: TitleDetectionOptions = {}
 ): void {
   term.onTitleChange((title) => {
-    const result = detectAgentStatusFromTitle(title)
+    const result = detectAgentStatusFromTitle(title, options)
     if (result) onStatus(result)
   })
 }

--- a/src/renderer/lib/codexTerminalDetection.ts
+++ b/src/renderer/lib/codexTerminalDetection.ts
@@ -1,0 +1,35 @@
+import type { Terminal } from '@xterm/xterm'
+
+const CODEX_QUESTION_HEADER = /\bQuestions?\s+\d+\s*\/\s*\d+\b/i
+const CODEX_FIELD_HEADER = /\b(?:Question|Field)\s+\d+\s*\/\s*\d+\b/i
+const CODEX_SUBMIT_HINT = /\b(?:Submit with|to submit (?:answer|all))\b/i
+const CODEX_INPUT_MARKER = /\b(?:unanswered|answer:|user_note:|option\s+\d+\s*\/\s*\d+)\b/i
+
+/**
+ * Fallback for Codex request_user_input when the first-class hook path is not
+ * available, for example when hooks are not installed or are still untrusted.
+ * Detect only the structured pane text so ordinary command output in a Codex
+ * terminal does not become a waiting notification.
+ */
+export function isCodexUserInputPromptText(text: string): boolean {
+  if (!text) return false
+
+  const hasQuestionHeader = CODEX_QUESTION_HEADER.test(text) || CODEX_FIELD_HEADER.test(text)
+  if (!hasQuestionHeader) return false
+
+  return CODEX_INPUT_MARKER.test(text) || CODEX_SUBMIT_HINT.test(text)
+}
+
+/** Read the tail of the active xterm buffer as plain text for status detection. */
+export function readTerminalBufferTail(term: Terminal, maxLines = 32): string {
+  const buffer = term.buffer.active
+  const start = Math.max(0, buffer.length - maxLines)
+  const lines: string[] = []
+
+  for (let i = start; i < buffer.length; i++) {
+    const line = buffer.getLine(i)
+    if (line) lines.push(line.translateToString(true))
+  }
+
+  return lines.join('\n')
+}

--- a/src/renderer/store/ui/terminals.ts
+++ b/src/renderer/store/ui/terminals.ts
@@ -139,9 +139,10 @@ export const createTerminalsSlice: StateCreator<UIState, [], [], TerminalsSlice>
       let next: AgentStatusEntry
       if (prev) {
         next = updateAgentStatusEntry(prev, payload)
+        if (next === prev) return s
       } else {
         // Create initial entry, then merge full payload to capture toolName etc.
-        const initial = createAgentStatusEntry(payload.state, payload.agentType)
+        const initial = createAgentStatusEntry(payload.state, payload.agentType, payload.source)
         next = payload.toolName ? { ...initial, toolName: payload.toolName } : initial
       }
       return { bigTerminalStatusById: { ...s.bigTerminalStatusById, [terminalId]: next } }


### PR DESCRIPTION
## Summary

- Fix Codex `request_user_input` tool calls not triggering "waiting for input" notifications in Braid
- Map Codex `PreToolUse` hook events for `request_user_input` to the `waiting` state in the hook server
- Add terminal buffer fallback detection for Codex question prompts when hooks are unavailable or untrusted
- Enable auto-installation of Codex hooks (previously excluded due to TOML trust requirement) with proper `config.toml` trust entry management

## Layers touched

- [x] **Main process** (`src/main/`) - services, IPC handlers
- [ ] **Preload** (`src/preload/`) - context bridge API
- [x] **Renderer** (`src/renderer/`) - components, stores, lib
- [ ] **Styles** (`App.css`)

## Changes

**Center:**
- `BigTerminalView.tsx`: Pass `agentId` through to `getOrCreate` for Codex terminal identification
- `bigTerminalCache.ts`: Add fallback `onWriteParsed` scan that detects Codex `request_user_input` question panes via terminal buffer text matching; propagate `agentId` metadata through cache entries

**Services** (`agentHooks/`):
- `agentHookServer.ts`: Extract `mapHookEventToState` (now exported + tested), add special case mapping Codex `PreToolUse` + `request_user_input` to `waiting` state, and `PostToolUse` + `request_user_input` back to `working`
- `codex.ts`: Rewrite from generic `createAgentHookService` to custom implementation that manages both `hooks.json` entries and `config.toml` trust entries, so Codex auto-trusts Braid's managed hooks
- `codexTrust.ts`: New module for reading/writing Codex `config.toml` trust blocks - computes `sha256` hashes matching Codex's `command_hook_hash` identity format, with atomic file writes and TOML escaping
- `hookScript.ts`: Bump version to 11, add Codex-specific `name` field fallback for tool name extraction, tighten env var guard to check all three required variables
- `index.ts`: Add Codex to the auto-installed agent hook services list

**Lib:**
- `agentStatus.ts`: Add `isKnownAgentType` type guard
- `agentTitleDetection.ts`: Accept `expectedAgentType` option so ambiguous braille spinners and generic status titles can be attributed to the correct agent (e.g., Codex instead of defaulting to Claude)
- `codexTerminalDetection.ts`: New module with regex-based detection of Codex `request_user_input` structured pane text from terminal buffer output

**Mission Control:**
- `MissionControl.tsx`: Prefer tab-level `agentId` over status-detected `agentType` for terminal cards

## How to test

1. `yarn dev`
2. Open a Codex terminal in Braid (add a worktree, open a big terminal, run `codex`)
3. Give Codex a task that triggers `request_user_input` (e.g., ask it to do something that requires clarification)
4. Verify the terminal status changes to "waiting" (yellow dot) when the input prompt appears
5. Answer the prompt and verify status returns to "working"
6. Check Mission Control - Codex terminal cards should show correct agent type

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass - `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store