### PR TITLE
Disable Spotify embedded app

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -120,12 +120,12 @@ function createWindow(): void {
   }
 }
 
-// Allow Spotify and other web apps to autoplay audio/video without a gesture.
+// Allow embedded web apps to autoplay audio/video without a gesture.
 // Must be set before app.whenReady() to take effect.
 app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required')
 
-// Spoof Chrome UA only for webapp partition sessions so sites like Spotify
-// serve their standard Chrome-compatible player bundles.
+// Spoof Chrome UA only for webapp partition sessions so embedded apps serve
+// their standard Chrome-compatible bundles.
 const CHROME_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
   'AppleWebKit/537.36 (KHTML, like Gecko) ' +
@@ -134,8 +134,8 @@ const CHROME_UA =
 function configureWebAppSession(sess: import('electron').Session): void {
   sess.setUserAgent(CHROME_UA)
 
-  // Web app sessions are user-initiated (Spotify, etc.) - grant all permissions
-  // so playback, DRM, clipboard, and other features work without prompts.
+  // Web app sessions are user-initiated - grant all permissions so playback,
+  // DRM, clipboard, and other features work without prompts.
   sess.setPermissionRequestHandler((_wc, _permission, callback) => {
     callback(true)
   })

--- a/src/renderer/components/Center/WebAppOverlay.tsx
+++ b/src/renderer/components/Center/WebAppOverlay.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useEffect, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useUIStore } from '@/store/ui'
+import { getDisabledEmbeddedAppWarningKey } from '@/lib/embeddedApps'
 import { AttentionChips } from './AttentionChips'
 
 /** Derive partition key from URL's root domain so apps on the same domain share auth.
@@ -39,7 +40,9 @@ export const WebAppOverlay = memo(function WebAppOverlay() {
   const setLastUrl = useUIStore((s) => s.setWebAppLastUrl)
 
   // Only mount webviews for visible + non-dormant apps to save memory
-  const mountedApps = embeddedApps.filter((a) => a.visible && !dormantAppIds.has(a.id))
+  const mountedApps = embeddedApps.filter((a) =>
+    a.visible && !dormantAppIds.has(a.id) && !getDisabledEmbeddedAppWarningKey(a)
+  )
 
   // Track which webviews already have listeners attached
   const attachedRef = useRef(new Set<string>())
@@ -109,7 +112,7 @@ export const WebAppOverlay = memo(function WebAppOverlay() {
     }) as EventListener)
 
     // Robust fallback: poll getTitle() for SPAs that update document.title via JS
-    // without triggering page-title-updated (e.g. Slack, Gmail, Spotify).
+    // without triggering page-title-updated (e.g. Slack, Gmail).
     // Uses did-navigate (not dom-ready) so polling restarts after full navigations
     // like OAuth redirects.
     const ensurePolling = (): void => {

--- a/src/renderer/components/Settings/SettingsApps.tsx
+++ b/src/renderer/components/Settings/SettingsApps.tsx
@@ -5,6 +5,7 @@ import { useUIStore } from '@/store/ui'
 import { AppFavicon } from '@/components/shared/AppFavicon'
 import { useTabReorder } from '@/hooks/useTabReorder'
 import { Toggle } from '@/components/shared/Toggle'
+import { getDisabledEmbeddedAppWarningKey } from '@/lib/embeddedApps'
 import type { EmbeddedApp } from '@/types'
 
 interface Preset {
@@ -83,11 +84,15 @@ export function SettingsApps() {
     if (!trimUrl.startsWith('http://') && !trimUrl.startsWith('https://')) {
       dispatch({ type: 'setError', value: t('apps.invalidUrl') }); return
     }
+    const disabledWarningKey = getDisabledEmbeddedAppWarningKey({ name: trimName, url: trimUrl })
+    if (disabledWarningKey) { dispatch({ type: 'setError', value: t(disabledWarningKey) }); return }
     addEmbeddedApp({ id: crypto.randomUUID(), name: trimName, url: trimUrl, visible: true })
     dispatch({ type: 'reset' })
   }, [form, addEmbeddedApp, t])
 
   const handleAddPreset = useCallback((preset: Preset) => {
+    if (getDisabledEmbeddedAppWarningKey(preset)) return
+
     if (preset.workspaceUrlTemplate) {
       dispatch({ type: 'startWorkspace', preset: preset.name })
     } else {
@@ -120,19 +125,47 @@ export function SettingsApps() {
         <div className="settings-apps-presets">
           {PRESETS.map((preset) => {
             const alreadyAdded = embeddedApps.some((a) => a.name === preset.name)
+            const disabledWarningKey = getDisabledEmbeddedAppWarningKey(preset)
+            const warningId = disabledWarningKey ? `settings-apps-preset-${preset.name.toLowerCase()}-warning` : undefined
             return (
               <button
                 key={preset.name}
-                className="btn btn--sm"
-                disabled={alreadyAdded}
+                className={[
+                  'btn',
+                  'btn--sm',
+                  disabledWarningKey ? 'settings-apps-preset--disabled' : '',
+                ].filter(Boolean).join(' ')}
+                disabled={alreadyAdded || Boolean(disabledWarningKey)}
+                aria-describedby={warningId}
+                title={disabledWarningKey ? t(disabledWarningKey) : undefined}
                 onClick={() => handleAddPreset(preset)}
               >
                 <AppFavicon url={preset.url} name={preset.name} size={14} />
-                {alreadyAdded ? t('apps.added') : preset.name}
+                {disabledWarningKey ? preset.name : alreadyAdded ? t('apps.added') : preset.name}
+                {disabledWarningKey && (
+                  <span className="settings-apps-preset-disabled-label">
+                    {t('apps.disabled')}
+                  </span>
+                )}
               </button>
             )
           })}
         </div>
+        {PRESETS.map((preset) => {
+          const disabledWarningKey = getDisabledEmbeddedAppWarningKey(preset)
+          if (!disabledWarningKey) return null
+
+          return (
+            <div
+              key={`${preset.name}-warning`}
+              id={`settings-apps-preset-${preset.name.toLowerCase()}-warning`}
+              className="settings-apps-warning"
+            >
+              <span className="settings-apps-warning-label">{t('apps.disabled')}</span>
+              <span>{t(disabledWarningKey)}</span>
+            </div>
+          )
+        })}
         {form.pendingPreset && (() => {
           const preset = PRESETS.find((p) => p.name === form.pendingPreset)
           if (!preset) return null
@@ -196,39 +229,47 @@ export function SettingsApps() {
           <div className="settings-field">
             <span className="settings-section-subtitle">{t('apps.configuredHeader')}</span>
             <div className="settings-apps-list">
-              {embeddedApps.map((app: EmbeddedApp) => (
-                <div
-                  key={app.id}
-                  className={[
-                    'settings-apps-list-row',
-                    dragKey === app.id ? 'settings-apps-list-row--dragging' : '',
-                    overKey === app.id ? 'settings-apps-list-row--drag-over' : '',
-                  ].filter(Boolean).join(' ')}
-                  draggable
-                  onDragStart={onDragStart(app.id)}
-                  onDragOver={onDragOver(app.id)}
-                  onDragLeave={onDragLeave}
-                  onDrop={onDrop(app.id)}
-                  onDragEnd={onDragEnd}
-                >
-                  <span className="settings-apps-drag-handle">⠿</span>
-                  <AppFavicon url={app.url} name={app.name} size={16} />
-                  <span className="settings-apps-list-name">{app.name}</span>
-                  <span className="settings-apps-list-url">{app.url}</span>
-                  <button
-                    className="btn btn--sm"
-                    onClick={() => app.visible ? hideWebApp(app.id) : showWebApp(app.id)}
+              {embeddedApps.map((app: EmbeddedApp) => {
+                const disabledWarningKey = getDisabledEmbeddedAppWarningKey(app)
+                return (
+                  <div
+                    key={app.id}
+                    className={[
+                      'settings-apps-list-row',
+                      disabledWarningKey ? 'settings-apps-list-row--disabled' : '',
+                      dragKey === app.id ? 'settings-apps-list-row--dragging' : '',
+                      overKey === app.id ? 'settings-apps-list-row--drag-over' : '',
+                    ].filter(Boolean).join(' ')}
+                    draggable
+                    title={disabledWarningKey ? t(disabledWarningKey) : undefined}
+                    onDragStart={onDragStart(app.id)}
+                    onDragOver={onDragOver(app.id)}
+                    onDragLeave={onDragLeave}
+                    onDrop={onDrop(app.id)}
+                    onDragEnd={onDragEnd}
                   >
-                    {app.visible ? t('apps.hide') : t('apps.show')}
-                  </button>
-                  <button
-                    className="btn btn-danger btn--sm"
-                    onClick={() => removeEmbeddedApp(app.id)}
-                  >
-                    ×
-                  </button>
-                </div>
-              ))}
+                    <span className="settings-apps-drag-handle">⠿</span>
+                    <AppFavicon url={app.url} name={app.name} size={16} />
+                    <span className="settings-apps-list-name">{app.name}</span>
+                    <span className="settings-apps-list-url">{app.url}</span>
+                    {disabledWarningKey && (
+                      <span className="settings-apps-list-warning">{t('apps.disabled')}</span>
+                    )}
+                    <button
+                      className="btn btn--sm"
+                      onClick={() => app.visible ? hideWebApp(app.id) : showWebApp(app.id)}
+                    >
+                      {app.visible ? t('apps.hide') : t('apps.show')}
+                    </button>
+                    <button
+                      className="btn btn-danger btn--sm"
+                      onClick={() => removeEmbeddedApp(app.id)}
+                    >
+                      ×
+                    </button>
+                  </div>
+                )
+              })}
             </div>
           </div>
         </>

--- a/src/renderer/components/Sidebar/ActivityBarApps.tsx
+++ b/src/renderer/components/Sidebar/ActivityBarApps.tsx
@@ -75,7 +75,7 @@ function ActivityBarAppItem({
           draggable={!disabledWarning}
           aria-disabled={Boolean(disabledWarning)}
           aria-label={tooltip}
-          {...dragHandlers}
+          {...(!disabledWarning ? dragHandlers : {})}
         >
           <span className="app-favicon-active-ring">
             <AppFavicon url={app.url} name={app.name} size={20} />

--- a/src/renderer/components/Sidebar/ActivityBarApps.tsx
+++ b/src/renderer/components/Sidebar/ActivityBarApps.tsx
@@ -6,6 +6,7 @@ import { AppFavicon } from '@/components/shared/AppFavicon'
 import { ContextMenu, type ContextMenuItem } from '@/components/shared/ContextMenu'
 import { Tooltip } from '@/components/shared/Tooltip'
 import { useTabReorder } from '@/hooks/useTabReorder'
+import { getDisabledEmbeddedAppWarningKey } from '@/lib/embeddedApps'
 import type { EmbeddedApp } from '@/types'
 
 interface AppItemProps {
@@ -32,8 +33,10 @@ function ActivityBarAppItem({
   app, isActive, isDormant, isDragging, isDragOver, badge,
   onToggle, onQuit, onHide, onRemove, dragHandlers,
 }: AppItemProps) {
-  const { t } = useTranslation('sidebar')
+  const { t } = useTranslation(['sidebar', 'settings'])
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null)
+  const disabledWarningKey = getDisabledEmbeddedAppWarningKey(app)
+  const disabledWarning = disabledWarningKey ? t(`settings:${disabledWarningKey}`) : null
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
@@ -43,7 +46,8 @@ function ActivityBarAppItem({
 
   const menuItems: ContextMenuItem[] = [
     {
-      label: isDormant ? t('appRelaunch') : t('appQuit'),
+      label: disabledWarning ? t('settings:apps.disabled') : isDormant ? t('appRelaunch') : t('appQuit'),
+      disabled: Boolean(disabledWarning),
       onClick: () => isDormant ? onToggle(app.id) : onQuit(app.id),
     },
     { label: t('appHideFromDock'), onClick: () => onHide(app.id) },
@@ -52,28 +56,31 @@ function ActivityBarAppItem({
   ]
 
   const effectiveActive = isActive && !isDormant
+  const tooltip = disabledWarning ?? (isDormant ? t('appDormant', { name: app.name }) : app.name)
 
   return (
     <>
-      <Tooltip content={isDormant ? t('appDormant', { name: app.name }) : app.name} position="right">
+      <Tooltip content={tooltip} position="right">
         <button
           className={[
             'activity-bar-item',
-            effectiveActive ? 'activity-bar-item--active' : '',
+            effectiveActive && !disabledWarning ? 'activity-bar-item--active' : '',
             isDormant ? 'activity-bar-app--dormant' : '',
+            disabledWarning ? 'activity-bar-app--disabled' : '',
             isDragging ? 'activity-bar-app--dragging' : '',
             isDragOver ? 'activity-bar-app--drag-over' : '',
           ].filter(Boolean).join(' ')}
-          onClick={() => onToggle(app.id)}
+          onClick={() => { if (!disabledWarning) onToggle(app.id) }}
           onContextMenu={handleContextMenu}
-          draggable
-          aria-label={isDormant ? t('appDormant', { name: app.name }) : app.name}
+          draggable={!disabledWarning}
+          aria-disabled={Boolean(disabledWarning)}
+          aria-label={tooltip}
           {...dragHandlers}
         >
           <span className="app-favicon-active-ring">
             <AppFavicon url={app.url} name={app.name} size={20} />
           </span>
-          {badge !== 0 && (
+          {!disabledWarning && badge !== 0 && (
             <span className="activity-bar-app-badge" aria-label={t('appBadgeUnread', { count: badge })}>
               {badge > 0 ? badge : ''}
             </span>

--- a/src/renderer/lib/__tests__/embeddedApps.test.ts
+++ b/src/renderer/lib/__tests__/embeddedApps.test.ts
@@ -25,4 +25,12 @@ describe('getDisabledEmbeddedAppWarningKey', () => {
       url: 'https://notion.so',
     })).toBeNull()
   })
+
+  it('handles null, undefined, or incomplete app objects gracefully', () => {
+    expect(getDisabledEmbeddedAppWarningKey(null)).toBeNull()
+    expect(getDisabledEmbeddedAppWarningKey(undefined)).toBeNull()
+    expect(getDisabledEmbeddedAppWarningKey({})).toBeNull()
+    expect(getDisabledEmbeddedAppWarningKey({ name: 'Spotify' })).toBe(SPOTIFY_DISABLED_WARNING_KEY)
+    expect(getDisabledEmbeddedAppWarningKey({ url: 'https://open.spotify.com' })).toBe(SPOTIFY_DISABLED_WARNING_KEY)
+  })
 })

--- a/src/renderer/lib/__tests__/embeddedApps.test.ts
+++ b/src/renderer/lib/__tests__/embeddedApps.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getDisabledEmbeddedAppWarningKey,
+  SPOTIFY_DISABLED_WARNING_KEY,
+} from '../embeddedApps'
+
+describe('getDisabledEmbeddedAppWarningKey', () => {
+  it('disables the Spotify preset by name', () => {
+    expect(getDisabledEmbeddedAppWarningKey({
+      name: 'Spotify',
+      url: 'https://open.spotify.com',
+    })).toBe(SPOTIFY_DISABLED_WARNING_KEY)
+  })
+
+  it('disables custom Spotify URLs', () => {
+    expect(getDisabledEmbeddedAppWarningKey({
+      name: 'Music',
+      url: 'https://accounts.spotify.com/login',
+    })).toBe(SPOTIFY_DISABLED_WARNING_KEY)
+  })
+
+  it('leaves other embedded apps enabled', () => {
+    expect(getDisabledEmbeddedAppWarningKey({
+      name: 'Notion',
+      url: 'https://notion.so',
+    })).toBeNull()
+  })
+})

--- a/src/renderer/lib/embeddedApps.ts
+++ b/src/renderer/lib/embeddedApps.ts
@@ -1,0 +1,23 @@
+export const SPOTIFY_DISABLED_WARNING_KEY = 'apps.spotifyDisabledWarning'
+
+interface EmbeddedAppIdentity {
+  name: string
+  url: string
+}
+
+function isSpotifyUrl(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase()
+    return hostname === 'spotify.com' || hostname.endsWith('.spotify.com')
+  } catch {
+    return false
+  }
+}
+
+export function getDisabledEmbeddedAppWarningKey(app: EmbeddedAppIdentity): string | null {
+  if (app.name.trim().toLowerCase() === 'spotify' || isSpotifyUrl(app.url)) {
+    return SPOTIFY_DISABLED_WARNING_KEY
+  }
+
+  return null
+}

--- a/src/renderer/lib/embeddedApps.ts
+++ b/src/renderer/lib/embeddedApps.ts
@@ -1,11 +1,13 @@
 export const SPOTIFY_DISABLED_WARNING_KEY = 'apps.spotifyDisabledWarning'
 
 interface EmbeddedAppIdentity {
-  name: string
-  url: string
+  name?: unknown
+  url?: unknown
 }
 
-function isSpotifyUrl(url: string): boolean {
+function isSpotifyUrl(url: unknown): boolean {
+  if (typeof url !== 'string' || !url) return false
+
   try {
     const hostname = new URL(url).hostname.toLowerCase()
     return hostname === 'spotify.com' || hostname.endsWith('.spotify.com')
@@ -14,8 +16,13 @@ function isSpotifyUrl(url: string): boolean {
   }
 }
 
-export function getDisabledEmbeddedAppWarningKey(app: EmbeddedAppIdentity): string | null {
-  if (app.name.trim().toLowerCase() === 'spotify' || isSpotifyUrl(app.url)) {
+export function getDisabledEmbeddedAppWarningKey(
+  app: EmbeddedAppIdentity | null | undefined
+): string | null {
+  if (!app || typeof app !== 'object') return null
+
+  const name = typeof app.name === 'string' ? app.name.trim().toLowerCase() : ''
+  if (name === 'spotify' || isSpotifyUrl(app.url)) {
     return SPOTIFY_DISABLED_WARNING_KEY
   }
 

--- a/src/renderer/locales/en/settings.json
+++ b/src/renderer/locales/en/settings.json
@@ -324,6 +324,8 @@
     "urlPlaceholder": "https://...",
     "add": "Add",
     "added": "Added",
+    "disabled": "Disabled",
+    "spotifyDisabledWarning": "Spotify is temporarily disabled while we fix playback reliability.",
     "configuredHeader": "Configured Apps",
     "show": "Show",
     "hide": "Hide",

--- a/src/renderer/locales/id/settings.json
+++ b/src/renderer/locales/id/settings.json
@@ -324,6 +324,8 @@
     "urlPlaceholder": "https://...",
     "add": "Tambah",
     "added": "Ditambahkan",
+    "disabled": "Dinonaktifkan",
+    "spotifyDisabledWarning": "Spotify dinonaktifkan sementara saat kami memperbaiki keandalan pemutaran.",
     "configuredHeader": "Aplikasi Terkonfigurasi",
     "show": "Tampilkan",
     "hide": "Sembunyikan",

--- a/src/renderer/locales/ja/settings.json
+++ b/src/renderer/locales/ja/settings.json
@@ -324,6 +324,8 @@
     "urlPlaceholder": "https://...",
     "add": "追加",
     "added": "追加済み",
+    "disabled": "無効",
+    "spotifyDisabledWarning": "Spotify は再生の安定性を修正するまで一時的に無効です。",
     "configuredHeader": "設定済みアプリ",
     "show": "表示",
     "hide": "非表示",

--- a/src/renderer/locales/zh/settings.json
+++ b/src/renderer/locales/zh/settings.json
@@ -324,6 +324,8 @@
     "urlPlaceholder": "https://...",
     "add": "添加",
     "added": "已添加",
+    "disabled": "已停用",
+    "spotifyDisabledWarning": "Spotify 暂时停用，等待我们修复播放稳定性问题。",
     "configuredHeader": "已配置的应用",
     "show": "显示",
     "hide": "隐藏",

--- a/src/renderer/styles/activity-bar.css
+++ b/src/renderer/styles/activity-bar.css
@@ -141,6 +141,20 @@
   opacity: 0.45;
 }
 
+.activity-bar-app--disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.activity-bar-app--disabled:hover {
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.activity-bar-app--disabled .app-favicon-active-ring {
+  filter: grayscale(1);
+}
+
 .activity-bar-app--dragging {
   opacity: 0.4;
 }

--- a/src/renderer/styles/apps.css
+++ b/src/renderer/styles/apps.css
@@ -12,6 +12,44 @@
   gap: var(--space-6);
 }
 
+.settings-apps-presets .btn:disabled,
+.settings-apps-presets .btn:disabled:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.settings-apps-preset--disabled {
+  border-color: var(--amber-tint-30);
+}
+
+.settings-apps-preset-disabled-label {
+  color: var(--amber);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+}
+
+.settings-apps-warning {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  margin-top: var(--space-8);
+  padding: var(--space-8) var(--space-10);
+  border: 1px solid var(--amber-tint-30);
+  border-radius: var(--radius);
+  background: var(--amber-tint-6);
+  color: var(--text-primary);
+  font-size: var(--text-base);
+}
+
+.settings-apps-warning-label {
+  color: var(--amber);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+}
+
 .settings-apps-custom-row {
   display: flex;
   gap: var(--space-8);
@@ -46,6 +84,11 @@
   border-top: 2px solid var(--accent);
 }
 
+.settings-apps-list-row--disabled {
+  cursor: default;
+  opacity: 0.65;
+}
+
 .settings-apps-drag-handle {
   color: var(--text-muted);
   font-size: var(--text-base);
@@ -67,6 +110,13 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.settings-apps-list-warning {
+  color: var(--amber);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  flex-shrink: 0;
 }
 
 /* ── Web App Overlay ─────────────────────────────────────────────────────── */

--- a/src/renderer/styles/apps.css
+++ b/src/renderer/styles/apps.css
@@ -21,7 +21,7 @@
 }
 
 .settings-apps-preset--disabled {
-  border-color: var(--amber-tint-30);
+  border-color: var(--amber-tint-30, rgba(230, 162, 60, 0.3));
 }
 
 .settings-apps-preset-disabled-label {
@@ -36,7 +36,7 @@
   gap: var(--space-8);
   margin-top: var(--space-8);
   padding: var(--space-8) var(--space-10);
-  border: 1px solid var(--amber-tint-30);
+  border: 1px solid var(--amber-tint-30, rgba(230, 162, 60, 0.3));
   border-radius: var(--radius);
   background: var(--amber-tint-6);
   color: var(--text-primary);

--- a/website/changelog/2026-05-26-v26-2-1.md
+++ b/website/changelog/2026-05-26-v26-2-1.md
@@ -19,5 +19,5 @@ Braid now installs status hooks for nine different CLI agents out of the box, so
 
 - **Drag-and-drop file paths** - Electron 28+ silently broke `File.path`, causing file drops onto terminals and chat to fail. Braid now uses the new `webUtils.getPathForFile()` API and prevents stray drops from navigating the window to `file:///` URLs.
 - **Terminal re-theming** - Switching themes previously only updated the active terminal. All open terminals now re-theme immediately.
-- **Widevine CDM in webviews** - Embedded apps like Spotify can now play protected content. The `plugins` attribute is set on `<webview>` tags so the Widevine CDM loads in guest processes.
+- **Widevine CDM in webviews** - Embedded apps can now load protected-content support when available. The `plugins` attribute is set on `<webview>` tags so the Widevine CDM loads in guest processes.
 - **Antigravity hook status** - The Antigravity (Gemini CLI) hook script would silently exit before reporting "done" status because it bailed on empty stdin. The guard has been removed so `PostInvocation` and `Stop` events now reach the hook server correctly.

--- a/website/changelog/2026-05-26-v26-2-3.md
+++ b/website/changelog/2026-05-26-v26-2-3.md
@@ -8,7 +8,7 @@ tags: [release]
 
 We're introducing the foundation for our upcoming mobile companion app! This release includes a new companion server with end-to-end encrypted (E2EE) pairing so you can securely control your terminal from your phone. Additionally, we've refined our webview permissions so embedded apps work seamlessly without annoying dialogs. 
 
-Thanks to Sujal for flagging the Spotify DRM playback issue that kicked off the v26.2.2 permission fixes!
+Thanks to Sujal for flagging the DRM playback issue that kicked off the v26.2.2 permission fixes!
 
 {/* truncate */}
 


### PR DESCRIPTION
## Summary

- Disables the Spotify embedded app preset - it can no longer be added or launched
- Existing Spotify apps in user configs are visually disabled with an amber warning explaining playback reliability issues
- Removes Spotify-specific references from comments and changelog entries

## Layers touched

- [x] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Sidebar / Center / Right panel:**
- `ActivityBarApps.tsx` - Disabled apps get `activity-bar-app--disabled` class, greyed out favicon, suppressed badge, blocked click, disabled drag, context menu shows "Disabled"
- `WebAppOverlay.tsx` - Filters out disabled apps from mounting webviews to save memory

**Lib:**
- New `lib/embeddedApps.ts` with `getDisabledEmbeddedAppWarningKey()` - central check that matches by name ("Spotify") or URL hostname (`*.spotify.com`)
- New `lib/__tests__/embeddedApps.test.ts` - unit tests for the disable check

**Settings:**
- `SettingsApps.tsx` - Preset buttons show "Disabled" label with amber border, warning banner below presets, configured app rows show warning badge, custom URL form rejects Spotify URLs

**Styles:**
- `activity-bar.css` - `.activity-bar-app--disabled` with greyscale filter and not-allowed cursor
- `apps.css` - Disabled preset styling, warning banner, disabled row, warning label in app list

**i18n:**
- Added `apps.disabled` and `apps.spotifyDisabledWarning` to all four locales (en, ja, id, zh)

**Docs:**
- Updated changelog entries to remove Spotify-specific mentions from v26.2.1 and v26.2.3

**Main process:**
- `index.ts` - Updated comments to be generic (removed Spotify references)

## How to test

1. `yarn dev`
2. Open Settings > Apps - verify Spotify preset is disabled with amber "Disabled" label and warning banner
3. Try adding a custom app with URL `https://open.spotify.com` - should be rejected
4. If Spotify was previously added, verify it appears greyed out in the activity bar with a tooltip explaining the issue
5. Verify other presets (Slack, Notion, etc.) still work normally

## Screenshots

<!-- N/A - reviewer can verify visually with `yarn dev` -->

## Checklist

- [x] Self-reviewed the diff
- [ ] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [ ] No console errors or warnings in DevTools
- [ ] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [ ] New state is added to the correct Zustand store