### PR TITLE
fix: propagate terminal resize to all tabs, not just the active one

### DIFF
--- a/src/renderer/components/Center/BigTerminalView.tsx
+++ b/src/renderer/components/Center/BigTerminalView.tsx
@@ -140,7 +140,10 @@ export function BigTerminalView({ terminalId, worktreePath, initialCommand, agen
         const entry = entryRef.current
         if (entry) {
           entry.term.options.fontSize = prevSize
-          try { entry.fitAddon.fit() } catch { /* ignore */ }
+          try {
+            entry.fitAddon.fit()
+            if (entry.ptyId) ipc.pty.resize(entry.ptyId, entry.term.cols, entry.term.rows)
+          } catch { /* ignore */ }
         }
       }
     })

--- a/src/renderer/components/Right/TabbedTerminal.tsx
+++ b/src/renderer/components/Right/TabbedTerminal.tsx
@@ -183,8 +183,13 @@ export function TabbedTerminal({ worktreePath, projectId, projectPath, hidden, c
     tab.resizeObserver?.disconnect()
     const observer = new ResizeObserver(() => {
       if (activeTabIdRef.current === tab.id) {
-        try { tab.fitAddon.fit(); if (tab.ptyId) ipc.pty.resize(tab.ptyId, tab.term.cols, tab.term.rows) }
-        catch { /* ignore */ }
+        try {
+          tab.fitAddon.fit()
+          const { cols, rows } = tab.term
+          for (const t of tabsRef.current) {
+            if (t.ptyId) ipc.pty.resize(t.ptyId, cols, rows)
+          }
+        } catch { /* ignore */ }
       }
     })
     observer.observe(el)

--- a/src/renderer/components/Right/TabbedTerminal.tsx
+++ b/src/renderer/components/Right/TabbedTerminal.tsx
@@ -181,15 +181,20 @@ export function TabbedTerminal({ worktreePath, projectId, projectPath, hidden, c
 
   const setupResizeObserver = useCallback((tab: TermTab, el: HTMLDivElement) => {
     tab.resizeObserver?.disconnect()
+    let rafId: number | null = null
     const observer = new ResizeObserver(() => {
       if (activeTabIdRef.current === tab.id) {
-        try {
-          tab.fitAddon.fit()
-          const { cols, rows } = tab.term
-          for (const t of tabsRef.current) {
-            if (t.ptyId) ipc.pty.resize(t.ptyId, cols, rows)
-          }
-        } catch { /* ignore */ }
+        if (rafId !== null) return
+        rafId = requestAnimationFrame(() => {
+          rafId = null
+          try {
+            tab.fitAddon.fit()
+            const { cols, rows } = tab.term
+            for (const t of tabsRef.current) {
+              if (t.ptyId) ipc.pty.resize(t.ptyId, cols, rows)
+            }
+          } catch { /* ignore */ }
+        })
       }
     })
     observer.observe(el)

--- a/src/renderer/components/Right/useTerminalLifecycle.ts
+++ b/src/renderer/components/Right/useTerminalLifecycle.ts
@@ -54,18 +54,20 @@ export function useTerminalLifecycle({
       if (state.terminalFontSize !== prevSize) {
         prevSize = state.terminalFontSize
         for (const cached of terminalCache.values()) {
-          let fitCols = 0, fitRows = 0
           for (const tab of cached.tabs) {
             tab.term.options.fontSize = prevSize
-            try {
-              tab.fitAddon.fit()
-              if (tab.term.cols > 0) { fitCols = tab.term.cols; fitRows = tab.term.rows }
-            } catch { /* ignore */ }
           }
-          if (fitCols > 0) {
-            for (const tab of cached.tabs) {
-              if (tab.ptyId) ipc.pty.resize(tab.ptyId, fitCols, fitRows)
-            }
+          const activeTab = cached.tabs.find((t) => t.id === cached.activeTabId) || cached.tabs[0]
+          if (activeTab) {
+            try {
+              activeTab.fitAddon.fit()
+              const { cols, rows } = activeTab.term
+              if (cols > 0 && rows > 0) {
+                for (const tab of cached.tabs) {
+                  if (tab.ptyId) ipc.pty.resize(tab.ptyId, cols, rows)
+                }
+              }
+            } catch { /* ignore */ }
           }
         }
       }

--- a/src/renderer/components/Right/useTerminalLifecycle.ts
+++ b/src/renderer/components/Right/useTerminalLifecycle.ts
@@ -54,9 +54,18 @@ export function useTerminalLifecycle({
       if (state.terminalFontSize !== prevSize) {
         prevSize = state.terminalFontSize
         for (const cached of terminalCache.values()) {
+          let fitCols = 0, fitRows = 0
           for (const tab of cached.tabs) {
             tab.term.options.fontSize = prevSize
-            try { tab.fitAddon.fit() } catch { /* ignore */ }
+            try {
+              tab.fitAddon.fit()
+              if (tab.term.cols > 0) { fitCols = tab.term.cols; fitRows = tab.term.rows }
+            } catch { /* ignore */ }
+          }
+          if (fitCols > 0) {
+            for (const tab of cached.tabs) {
+              if (tab.ptyId) ipc.pty.resize(tab.ptyId, fitCols, fitRows)
+            }
           }
         }
       }
@@ -144,7 +153,10 @@ export function useTerminalLifecycle({
           requestAnimationFrame(() => {
             try {
               activeTab.fitAddon.fit()
-              if (activeTab.ptyId) ipc.pty.resize(activeTab.ptyId, activeTab.term.cols, activeTab.term.rows)
+              const { cols, rows } = activeTab.term
+              for (const t of restoredTabs) {
+                if (t.ptyId) ipc.pty.resize(t.ptyId, cols, rows)
+              }
             } catch { /* ignore */ }
           })
         }
@@ -195,7 +207,10 @@ export function useTerminalLifecycle({
         }
         try {
           tab.fitAddon.fit()
-          if (tab.ptyId) ipc.pty.resize(tab.ptyId, tab.term.cols, tab.term.rows)
+          const { cols, rows } = tab.term
+          for (const t of tabsRef.current) {
+            if (t.ptyId) ipc.pty.resize(t.ptyId, cols, rows)
+          }
         } catch { /* ignore */ }
       }
     })


### PR DESCRIPTION
## Summary

- Inactive terminal tabs kept stale PTY dimensions, causing misformatted output until the user switched to them
- Now when the container resizes, the active tab's cols/rows are propagated to all tabs' PTYs
- Also adds missing `pty.resize()` calls after font-size changes in BigTerminalView and the side terminal lifecycle hook

## Layers touched

- [x] **Renderer** (`src/renderer/`) — components, stores, lib

## Changes

**Center panel:**
- `BigTerminalView.tsx` - Added `pty.resize()` after `fitAddon.fit()` in the font-size change handler so the PTY learns the new grid dimensions

**Right panel:**
- `TabbedTerminal.tsx` - `setupResizeObserver` now iterates all tabs and sends `pty.resize()` with the active tab's cols/rows, instead of only resizing the active tab
- `useTerminalLifecycle.ts` - Three call sites updated to propagate resize to all tabs: font-size change handler, worktree switch restore, and hidden toggle

## How to test

1. `yarn dev`
2. Open the right-panel terminal, create 2-3 terminal tabs
3. Run `tput cols` in each tab to see the current column count
4. Resize the right panel (drag the splitter)
5. Switch to an inactive tab and run `tput cols` - it should reflect the new size immediately
6. Change terminal font size in Settings > Editor - all tabs should reflow correctly

## Checklist

- [x] Self-reviewed the diff
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools