### PR TITLE
Refresh onboarding setup flow

### DIFF
--- a/src/renderer/components/Onboarding/OnboardingLayout.tsx
+++ b/src/renderer/components/Onboarding/OnboardingLayout.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/Button'
-import { IconSparkle, IconArrowLeft } from '@/components/shared/icons'
+import { IconArrowLeft, IconCheckFill } from '@/components/shared/icons'
+import braidLogoUrl from '../../../../build/icon.svg?url'
 
 const STEP_LABEL_KEYS = [
   'onboarding.stepLabel.welcome',
@@ -41,6 +42,7 @@ export function OnboardingLayout({
   children,
 }: Props) {
   const { t } = useTranslation('common')
+  const currentStepLabel = STEP_LABEL_KEYS[currentStep] ? t(STEP_LABEL_KEYS[currentStep]) : ''
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -59,59 +61,96 @@ export function OnboardingLayout({
 
   return (
     <div className="ob-layout" onClick={(e) => e.stopPropagation()}>
-      <div className="ob-layout-header">
+      <aside className="ob-sidebar" aria-label={t('onboarding.welcome.title')}>
         <div className="ob-brand">
-          <IconSparkle size={24} />
+          <span className="ob-brand-mark">
+            <img src={braidLogoUrl} alt="" className="ob-brand-logo" aria-hidden="true" />
+          </span>
           <span className="ob-brand-name">Braid</span>
         </div>
-      </div>
 
-      <div className="ob-progress-row">
-        <div className="ob-progress-bar">
+        <div className="ob-rail-summary">
+          <span className="ob-rail-kicker">{t('onboarding.welcome.eyebrow')}</span>
+          <span className="ob-rail-counter">
+            {currentStep + 1} {t('onboarding.of')} {totalSteps}
+          </span>
+        </div>
+
+        <ol className="ob-step-rail">
           {Array.from({ length: totalSteps }, (_, i) => (
-            <div
+            <li
               key={i}
-              className={`ob-progress-segment${
+              className={`ob-rail-step${
                 i < currentStep
-                  ? ' ob-progress-segment--done'
+                  ? ' ob-rail-step--done'
                   : i === currentStep
-                    ? ' ob-progress-segment--active'
+                    ? ' ob-rail-step--active'
                     : ''
               }`}
-              title={STEP_LABEL_KEYS[i] ? t(STEP_LABEL_KEYS[i]) : undefined}
-            />
+              aria-current={i === currentStep ? 'step' : undefined}
+            >
+              <span className="ob-rail-node">
+                {i < currentStep ? <IconCheckFill size={10} /> : i + 1}
+              </span>
+              <span className="ob-rail-label">
+                {STEP_LABEL_KEYS[i] ? t(STEP_LABEL_KEYS[i]) : ''}
+              </span>
+            </li>
           ))}
-        </div>
-        <span className="ob-progress-counter">
-          {currentStep + 1} {t('onboarding.of')} {totalSteps}
+        </ol>
+      </aside>
+
+      <section className="ob-panel">
+        <span id="ob-current-step-title" className="ob-sr-only">
+          {currentStepLabel}
         </span>
-      </div>
 
-      <div className="ob-content">{children}</div>
+        <div className="ob-mobile-progress">
+          <div className="ob-progress-bar" aria-hidden="true">
+            {Array.from({ length: totalSteps }, (_, i) => (
+              <span
+                key={i}
+                className={`ob-progress-segment${
+                  i < currentStep
+                    ? ' ob-progress-segment--done'
+                    : i === currentStep
+                      ? ' ob-progress-segment--active'
+                      : ''
+                }`}
+              />
+            ))}
+          </div>
+          <span className="ob-progress-counter">
+            {currentStep + 1} {t('onboarding.of')} {totalSteps}
+          </span>
+        </div>
 
-      <div className="ob-footer">
-        <div className="ob-footer-left">
-          {showSkip && (
-            <button className="ob-skip-link" onClick={onSkip}>
-              {t('onboarding.skipSetup')}
-            </button>
-          )}
+        <div className="ob-content">{children}</div>
+
+        <div className="ob-footer">
+          <div className="ob-footer-left">
+            {showSkip && (
+              <button className="ob-skip-link" onClick={onSkip}>
+                {t('onboarding.skipSetup')}
+              </button>
+            )}
+          </div>
+          <div className="ob-footer-right">
+            {showBack && currentStep > 0 && (
+              <Button onClick={onBack}>
+                <IconArrowLeft size={12} />
+                {t('onboarding.back')}
+              </Button>
+            )}
+            {showContinue && (
+              <Button variant="primary" onClick={onContinue} disabled={!canContinue}>
+                {continueLabel ?? t('onboarding.continue')}
+                <kbd className="ob-kbd">&#8984;&#9166;</kbd>
+              </Button>
+            )}
+          </div>
         </div>
-        <div className="ob-footer-right">
-          {showBack && currentStep > 0 && (
-            <Button onClick={onBack}>
-              <IconArrowLeft size={12} />
-              {t('onboarding.back')}
-            </Button>
-          )}
-          {showContinue && (
-            <Button variant="primary" onClick={onContinue} disabled={!canContinue}>
-              {continueLabel ?? t('onboarding.continue')}
-              <kbd className="ob-kbd">&#8984;&#9166;</kbd>
-            </Button>
-          )}
-        </div>
-      </div>
+      </section>
     </div>
   )
 }

--- a/src/renderer/components/Onboarding/OnboardingLayout.tsx
+++ b/src/renderer/components/Onboarding/OnboardingLayout.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/Button'
+import { IconSparkle, IconArrowLeft } from '@/components/shared/icons'
+
+const STEP_LABEL_KEYS = [
+  'onboarding.stepLabel.welcome',
+  'onboarding.stepLabel.agent',
+  'onboarding.stepLabel.theme',
+  'onboarding.stepLabel.notifications',
+  'onboarding.stepLabel.integrations',
+  'onboarding.stepLabel.project',
+  'onboarding.stepLabel.explore',
+]
+
+interface Props {
+  currentStep: number
+  totalSteps: number
+  onBack: () => void
+  onContinue: () => void
+  onSkip: () => void
+  canContinue?: boolean
+  showBack?: boolean
+  showSkip?: boolean
+  showContinue?: boolean
+  continueLabel?: string
+  children: React.ReactNode
+}
+
+export function OnboardingLayout({
+  currentStep,
+  totalSteps,
+  onBack,
+  onContinue,
+  onSkip,
+  canContinue = true,
+  showBack = true,
+  showSkip = true,
+  showContinue = true,
+  continueLabel,
+  children,
+}: Props) {
+  const { t } = useTranslation('common')
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && canContinue && showContinue) {
+        e.preventDefault()
+        onContinue()
+      }
+    },
+    [canContinue, showContinue, onContinue],
+  )
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [handleKeyDown])
+
+  return (
+    <div className="ob-layout" onClick={(e) => e.stopPropagation()}>
+      <div className="ob-layout-header">
+        <div className="ob-brand">
+          <IconSparkle size={24} />
+          <span className="ob-brand-name">Braid</span>
+        </div>
+      </div>
+
+      <div className="ob-progress-row">
+        <div className="ob-progress-bar">
+          {Array.from({ length: totalSteps }, (_, i) => (
+            <div
+              key={i}
+              className={`ob-progress-segment${
+                i < currentStep
+                  ? ' ob-progress-segment--done'
+                  : i === currentStep
+                    ? ' ob-progress-segment--active'
+                    : ''
+              }`}
+              title={STEP_LABEL_KEYS[i] ? t(STEP_LABEL_KEYS[i]) : undefined}
+            />
+          ))}
+        </div>
+        <span className="ob-progress-counter">
+          {currentStep + 1} {t('onboarding.of')} {totalSteps}
+        </span>
+      </div>
+
+      <div className="ob-content">{children}</div>
+
+      <div className="ob-footer">
+        <div className="ob-footer-left">
+          {showSkip && (
+            <button className="ob-skip-link" onClick={onSkip}>
+              {t('onboarding.skipSetup')}
+            </button>
+          )}
+        </div>
+        <div className="ob-footer-right">
+          {showBack && currentStep > 0 && (
+            <Button onClick={onBack}>
+              <IconArrowLeft size={12} />
+              {t('onboarding.back')}
+            </Button>
+          )}
+          {showContinue && (
+            <Button variant="primary" onClick={onContinue} disabled={!canContinue}>
+              {continueLabel ?? t('onboarding.continue')}
+              <kbd className="ob-kbd">&#8984;&#9166;</kbd>
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Onboarding/OnboardingOverlay.tsx
+++ b/src/renderer/components/Onboarding/OnboardingOverlay.tsx
@@ -90,8 +90,16 @@ function SkipConfirmDialog({ onSkip, onCancel }: { onSkip: () => void; onCancel:
   const { t } = useTranslation('common')
   return (
     <div className="ob-skip-dialog-backdrop" onClick={onCancel}>
-      <div className="ob-skip-dialog" onClick={(e) => e.stopPropagation()}>
-        <h3 className="ob-skip-dialog-title">{t('onboarding.skipConfirm.title')}</h3>
+      <div
+        className="ob-skip-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ob-skip-dialog-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 id="ob-skip-dialog-title" className="ob-skip-dialog-title">
+          {t('onboarding.skipConfirm.title')}
+        </h3>
         <p className="ob-skip-dialog-desc">{t('onboarding.skipConfirm.desc')}</p>
         <div className="ob-skip-dialog-actions">
           <Button onClick={onSkip}>{t('onboarding.skipConfirm.skip')}</Button>
@@ -232,6 +240,7 @@ function OnboardingContent() {
       tabIndex={-1}
       role="dialog"
       aria-modal="true"
+      aria-labelledby="ob-current-step-title"
       onClick={handleBackdropClick}
     >
       <OnboardingLayout

--- a/src/renderer/components/Onboarding/OnboardingOverlay.tsx
+++ b/src/renderer/components/Onboarding/OnboardingOverlay.tsx
@@ -28,7 +28,6 @@ const TOTAL_STEPS = STEPS.length
 interface State {
   currentStep: number
   checks: Record<CheckKey, CheckStatus>
-  installAttempted: Partial<Record<CheckKey, boolean>>
   showGhAuthDialog: boolean
 }
 
@@ -38,14 +37,12 @@ type Action =
   | { type: 'back' }
   | { type: 'start_checks' }
   | { type: 'set_check'; key: CheckKey; status: CheckStatus }
-  | { type: 'mark_install_attempted'; key: CheckKey }
   | { type: 'show_gh_auth' }
   | { type: 'hide_gh_auth' }
 
 const initialState: State = {
   currentStep: 0,
   checks: { git: 'pending', gh: 'pending', ghAuth: 'pending', acli: 'pending' },
-  installAttempted: {},
   showGhAuthDialog: false,
 }
 
@@ -64,8 +61,6 @@ function reducer(state: State, action: Action): State {
       }
     case 'set_check':
       return { ...state, checks: { ...state.checks, [action.key]: action.status } }
-    case 'mark_install_attempted':
-      return { ...state, installAttempted: { ...state.installAttempted, [action.key]: true } }
     case 'show_gh_auth':
       return { ...state, showGhAuthDialog: true }
     case 'hide_gh_auth':
@@ -126,17 +121,20 @@ function OnboardingContent() {
     return () => cancelAnimationFrame(frame)
   }, [])
 
-  // Escape key opens skip confirmation
+  // Escape key opens or closes skip confirmation
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
+      if (e.key !== 'Escape') return
+      e.preventDefault()
+      if (showSkipConfirm) {
+        setShowSkipConfirm(false)
+      } else if (!state.showGhAuthDialog) {
         setShowSkipConfirm(true)
       }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [])
+  }, [showSkipConfirm, state.showGhAuthDialog])
 
   // Auto-advance past project step when a project is added
   useEffect(() => {
@@ -178,7 +176,6 @@ function OnboardingContent() {
       dispatch({ type: 'show_gh_auth' })
       return
     }
-    dispatch({ type: 'mark_install_attempted', key })
     dispatch({ type: 'set_check', key, status: 'installing' })
     try { await shell.installTool(key) } catch { /* recheck below */ }
     dispatch({ type: 'set_check', key, status: 'checking' })
@@ -232,6 +229,9 @@ function OnboardingContent() {
 
   const step = STEPS[state.currentStep]
   const isLastStep = step === 'explore'
+  const hasActiveEnvironmentCheck = step === 'environment' && Object.values(state.checks).some(
+    (status) => status === 'checking' || status === 'installing',
+  )
 
   return (
     <div
@@ -249,7 +249,7 @@ function OnboardingContent() {
         onBack={goBack}
         onContinue={isLastStep ? handleFinish : goNext}
         onSkip={askSkip}
-        canContinue
+        canContinue={!hasActiveEnvironmentCheck}
         showBack={state.currentStep > 0}
         showSkip={!isLastStep}
         showContinue
@@ -262,10 +262,8 @@ function OnboardingContent() {
         {step === 'environment' && (
           <EnvironmentStep
             checks={state.checks}
-            installAttempted={state.installAttempted}
             onRunChecks={runChecks}
             onInstall={installAndRecheck}
-            onOpenExternal={shell.openExternal}
           />
         )}
         {step === 'project' && <ProjectStep />}

--- a/src/renderer/components/Onboarding/OnboardingOverlay.tsx
+++ b/src/renderer/components/Onboarding/OnboardingOverlay.tsx
@@ -1,352 +1,146 @@
-import { useEffect, useReducer, useCallback, useRef } from 'react'
+import { useEffect, useReducer, useCallback, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useUIStore } from '@/store/ui'
 import { useProjectsStore } from '@/store/projects'
-import { shell, claudeCli, jira } from '@/lib/ipc'
-import { Spinner } from '@/components/ui/Spinner'
+import { shell, jira } from '@/lib/ipc'
 import { Button } from '@/components/ui/Button'
-import {
-  IconCheckmark,
-  IconXCircle,
-  IconRefresh,
-  IconExternalLink,
-  IconSparkle,
-} from '@/components/shared/icons'
 import { GhAuthDialog } from '@/components/shared/GhAuthDialog'
+import { OnboardingLayout } from './OnboardingLayout'
+import {
+  WelcomeStep,
+  ModelStep,
+  ThemeStep,
+  NotificationStep,
+  EnvironmentStep,
+  ProjectStep,
+  ExploreStep,
+} from './steps'
+import type { CheckKey, CheckStatus } from './steps'
 
-// ── Types ────────────────────────────────────────────────────────────────────
+// ── Constants ────────────────────────────────────────────────────────────────
 
-type Step = 'welcome' | 'doctor' | 'project'
-type CheckKey = 'git' | 'claude' | 'gh' | 'ghAuth' | 'acli'
-type CheckStatus = 'pending' | 'checking' | 'ok' | 'fail' | 'installing'
+const STEPS = ['welcome', 'model', 'theme', 'notifications', 'environment', 'project', 'explore'] as const
+const TOTAL_STEPS = STEPS.length
+
+// ── State ────────────────────────────────────────────────────────────────────
 
 interface State {
-  step: Step
+  currentStep: number
   checks: Record<CheckKey, CheckStatus>
-  /** Tracks which keys have had at least one install attempt. After a failed
-   *  attempt the row surfaces the docs link so the user has a fallback path. */
   installAttempted: Partial<Record<CheckKey, boolean>>
   showGhAuthDialog: boolean
 }
 
 type Action =
-  | { type: 'set_step'; step: Step }
+  | { type: 'go_to'; step: number }
+  | { type: 'next' }
+  | { type: 'back' }
   | { type: 'start_checks' }
   | { type: 'set_check'; key: CheckKey; status: CheckStatus }
   | { type: 'mark_install_attempted'; key: CheckKey }
-  | { type: 'show_gh_auth_dialog' }
-  | { type: 'hide_gh_auth_dialog' }
+  | { type: 'show_gh_auth' }
+  | { type: 'hide_gh_auth' }
 
 const initialState: State = {
-  step: 'welcome',
-  checks: { git: 'pending', claude: 'pending', gh: 'pending', ghAuth: 'pending', acli: 'pending' },
+  currentStep: 0,
+  checks: { git: 'pending', gh: 'pending', ghAuth: 'pending', acli: 'pending' },
   installAttempted: {},
   showGhAuthDialog: false,
 }
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
-    case 'set_step':
-      return { ...state, step: action.step }
+    case 'go_to':
+      return { ...state, currentStep: Math.max(0, Math.min(TOTAL_STEPS - 1, action.step)) }
+    case 'next':
+      return { ...state, currentStep: Math.min(TOTAL_STEPS - 1, state.currentStep + 1) }
+    case 'back':
+      return { ...state, currentStep: Math.max(0, state.currentStep - 1) }
     case 'start_checks':
       return {
         ...state,
-        checks: { git: 'checking', claude: 'checking', gh: 'checking', ghAuth: 'checking', acli: 'checking' },
+        checks: { git: 'checking', gh: 'checking', ghAuth: 'checking', acli: 'checking' },
       }
     case 'set_check':
       return { ...state, checks: { ...state.checks, [action.key]: action.status } }
     case 'mark_install_attempted':
       return { ...state, installAttempted: { ...state.installAttempted, [action.key]: true } }
-    case 'show_gh_auth_dialog':
+    case 'show_gh_auth':
       return { ...state, showGhAuthDialog: true }
-    case 'hide_gh_auth_dialog':
+    case 'hide_gh_auth':
       return { ...state, showGhAuthDialog: false }
     default:
       return state
   }
 }
 
-// ── Check metadata ────────────────────────────────────────────────────────────
-
-interface AutoInstall {
-  /** i18n key for the button label — defaults to `onboarding.doctor.install` */
-  buttonLabelKey?: string
-  /** i18n key for inline progress text shown while the install command runs */
-  progressKey: string
-}
-
-interface CheckMeta {
-  label: string
-  required: boolean
-  installHint?: string
-  installUrl?: string
-  /** When set, shows an actionable button that runs the install command */
-  autoInstall?: AutoInstall
-}
-
-const CHECK_META: Record<CheckKey, CheckMeta> = {
-  git: {
-    label: 'Git',
-    required: true,
-    autoInstall: { progressKey: 'onboarding.doctor.progressGit' },
-  },
-  claude: {
-    label: 'Claude Code',
-    required: true,
-    installUrl: 'https://claude.ai/download',
-    autoInstall: { progressKey: 'onboarding.doctor.progressClaude' },
-  },
-  gh: {
-    label: 'GitHub CLI',
-    required: true,
-    installUrl: 'https://cli.github.com/',
-    autoInstall: { progressKey: 'onboarding.doctor.progressGh' },
-  },
-  ghAuth: {
-    label: 'GitHub CLI (authenticated)',
-    required: true,
-    autoInstall: {
-      buttonLabelKey: 'onboarding.doctor.logIn',
-      progressKey: 'onboarding.doctor.progressGhAuth',
-    },
-  },
-  acli: {
-    label: 'Atlassian CLI',
-    required: false,
-    installUrl: 'https://developer.atlassian.com/cloud/acli/guides/install-acli/',
-    autoInstall: { progressKey: 'onboarding.doctor.progressAcli' },
-  },
-}
-
-// ── Check functions (module-level so useCallback deps stay stable) ────────────
+// ── Check functions ──────────────────────────────────────────────────────────
 
 const CHECK_FNS: Record<CheckKey, () => Promise<boolean>> = {
   git: () => shell.checkTool('git'),
-  claude: async () => {
-    try {
-      const detected = await claudeCli.detectPath()
-      if (detected !== null) return true
-    } catch {
-      // dynamic require broken in some build configs — fall through
-    }
-    return shell.checkTool('claude')
-  },
   gh: () => shell.checkTool('gh'),
   ghAuth: () => shell.checkGhAuth(),
   acli: () => jira.isAvailable(),
 }
 
-// ── Sub-components ────────────────────────────────────────────────────────────
+// ── Skip confirmation dialog ─────────────────────────────────────────────────
 
-function StepDots({ step }: { step: Step }) {
-  const steps: Step[] = ['welcome', 'doctor', 'project']
-  return (
-    <div className="onboarding-step-dots">
-      {steps.map((s) => (
-        <div key={s} className={`onboarding-step-dot${step === s ? ' onboarding-step-dot--active' : ''}`} />
-      ))}
-    </div>
-  )
-}
-
-function CheckStatusIcon({ status }: { status: CheckStatus }) {
-  if (status === 'checking' || status === 'installing') return <Spinner size="sm" />
-  if (status === 'ok') return <IconCheckmark size={14} className="onboarding-check-ok" />
-  if (status === 'fail') return <IconXCircle size={14} className="onboarding-check-fail" />
-  return <div className="onboarding-check-pending" />
-}
-
-function CheckRow({
-  checkKey,
-  status,
-  installAttempted,
-  onInstall,
-}: {
-  checkKey: CheckKey
-  status: CheckStatus
-  installAttempted: boolean
-  onInstall: (key: CheckKey) => void
-}) {
-  const meta = CHECK_META[checkKey]
-  const { t } = useTranslation('common')
-  const busy = status === 'installing' || status === 'checking'
-
-  return (
-    <div className={`onboarding-check-row${status === 'ok' ? ' onboarding-check-row--ok' : ''}`}>
-      <div className="onboarding-check-info">
-        <span className="onboarding-check-label">
-          {meta.label}
-          {!meta.required && (
-            <span className="onboarding-check-optional">{t('onboarding.doctor.optional')}</span>
-          )}
-        </span>
-
-        {status === 'fail' && (
-          <div className="onboarding-check-actions">
-            {meta.autoInstall && (
-              <button className="onboarding-install-btn" disabled={busy} onClick={() => onInstall(checkKey)}>
-                {meta.autoInstall.buttonLabelKey ? t(meta.autoInstall.buttonLabelKey) : t('onboarding.doctor.install')}
-              </button>
-            )}
-            {/* After a failed install attempt, always surface the docs link as a fallback */}
-            {(installAttempted || !meta.autoInstall) && meta.installUrl ? (
-              <button className="onboarding-check-link" onClick={() => shell.openExternal(meta.installUrl!)}>
-                {t('onboarding.doctor.openDocs')} <IconExternalLink size={10} />
-              </button>
-            ) : !meta.autoInstall && meta.installHint ? (
-              <code className="onboarding-check-code">{meta.installHint}</code>
-            ) : null}
-          </div>
-        )}
-
-        {busy && (
-          <span className="onboarding-check-progress">
-            {meta.autoInstall ? t(meta.autoInstall.progressKey) : t('onboarding.doctor.installing')}
-          </span>
-        )}
-      </div>
-
-      <div className="onboarding-check-status">
-        <CheckStatusIcon status={status} />
-      </div>
-    </div>
-  )
-}
-
-// ── Steps ─────────────────────────────────────────────────────────────────────
-
-function WelcomeStep({ onNext }: { onNext: () => void }) {
+function SkipConfirmDialog({ onSkip, onCancel }: { onSkip: () => void; onCancel: () => void }) {
   const { t } = useTranslation('common')
   return (
-    <div className="onboarding-step">
-      <div className="onboarding-welcome-icon">
-        <IconSparkle size={40} />
-      </div>
-      <h1 className="onboarding-title">{t('onboarding.welcome.title')}</h1>
-      <p className="onboarding-subtitle">{t('onboarding.welcome.subtitle')}</p>
-      <p className="onboarding-description">{t('onboarding.welcome.description')}</p>
-      <Button variant="primary" onClick={onNext}>
-        {t('onboarding.welcome.getStarted')}
-      </Button>
-    </div>
-  )
-}
-
-function DoctorStep({
-  checks,
-  installAttempted,
-  onRunChecks,
-  onInstall,
-  onNext,
-}: {
-  checks: Record<CheckKey, CheckStatus>
-  installAttempted: Partial<Record<CheckKey, boolean>>
-  onRunChecks: () => void
-  onInstall: (key: CheckKey) => void
-  onNext: () => void
-}) {
-  const { t } = useTranslation('common')
-  const allDone = Object.values(checks).every((s) => s === 'ok' || s === 'fail')
-  // Don't block continue while ghAuth is installing — the OAuth browser flow can
-  // take a while and the user should be able to skip it.
-  const anyBusy = Object.entries(checks).some(
-    ([k, s]) => (s === 'checking' || s === 'pending' || s === 'installing') && k !== 'ghAuth'
-  )
-  const hasRequiredFailures = Object.entries(checks).some(
-    ([k, s]) => s === 'fail' && CHECK_META[k as CheckKey].required
-  )
-
-  useEffect(() => { onRunChecks() }, [onRunChecks])
-
-  return (
-    <div className="onboarding-step">
-      <h1 className="onboarding-title">{t('onboarding.doctor.title')}</h1>
-      <p className="onboarding-subtitle">{t('onboarding.doctor.subtitle')}</p>
-      <div className="onboarding-checks">
-        {(Object.keys(checks) as CheckKey[]).map((key) => (
-          <CheckRow
-            key={key}
-            checkKey={key}
-            status={checks[key]}
-            installAttempted={!!installAttempted[key]}
-            onInstall={onInstall}
-          />
-        ))}
-      </div>
-      <div className="onboarding-actions">
-        {allDone && hasRequiredFailures && (
-          <Button size="sm" onClick={onRunChecks} className="onboarding-retry-btn">
-            <IconRefresh size={12} /> {t('onboarding.doctor.retry')}
-          </Button>
-        )}
-        <Button variant="primary" onClick={onNext} disabled={anyBusy}>
-          {hasRequiredFailures
-            ? t('onboarding.doctor.continueAnyway')
-            : t('onboarding.doctor.continue')}
-        </Button>
+    <div className="ob-skip-dialog-backdrop" onClick={onCancel}>
+      <div className="ob-skip-dialog" onClick={(e) => e.stopPropagation()}>
+        <h3 className="ob-skip-dialog-title">{t('onboarding.skipConfirm.title')}</h3>
+        <p className="ob-skip-dialog-desc">{t('onboarding.skipConfirm.desc')}</p>
+        <div className="ob-skip-dialog-actions">
+          <Button onClick={onSkip}>{t('onboarding.skipConfirm.skip')}</Button>
+          <Button variant="primary" onClick={onCancel}>{t('onboarding.skipConfirm.keepGoing')}</Button>
+        </div>
       </div>
     </div>
   )
 }
 
-function ProjectStep({ onSkip }: { onSkip: () => void }) {
-  const { t } = useTranslation('common')
-  const setShowAddProject = useUIStore((s) => s.setShowAddProject)
-  const projects = useProjectsStore((s) => s.projects)
-  const setOnboardingComplete = useUIStore((s) => s.setOnboardingComplete)
-
-  useEffect(() => {
-    if (projects.length > 0) setOnboardingComplete(true)
-  }, [projects.length, setOnboardingComplete])
-
-  return (
-    <div className="onboarding-step">
-      <h1 className="onboarding-title">{t('onboarding.project.title')}</h1>
-      <p className="onboarding-subtitle">{t('onboarding.project.subtitle')}</p>
-      <div className="onboarding-project-actions">
-        <Button variant="primary" onClick={() => setShowAddProject(true)}>
-          {t('onboarding.project.openProject')}
-        </Button>
-        <button className="onboarding-skip-link" onClick={onSkip}>
-          {t('onboarding.project.skip')}
-        </button>
-      </div>
-    </div>
-  )
-}
-
-// ── Main overlay ──────────────────────────────────────────────────────────────
+// ── Content ──────────────────────────────────────────────────────────────────
 
 function OnboardingContent() {
+  const { t } = useTranslation('common')
   const [state, dispatch] = useReducer(reducer, initialState)
+  const [showSkipConfirm, setShowSkipConfirm] = useState(false)
   const setOnboardingComplete = useUIStore((s) => s.setOnboardingComplete)
-  const cardRef = useRef<HTMLDivElement>(null)
+  const setFeatureTourComplete = useUIStore((s) => s.setFeatureTourComplete)
+  const hasProjects = useProjectsStore((s) => s.projects.length > 0)
+  const containerRef = useRef<HTMLDivElement>(null)
 
-  // Focus the card on mount so keyboard navigation works immediately
   useEffect(() => {
-    const frame = requestAnimationFrame(() => cardRef.current?.focus())
+    const frame = requestAnimationFrame(() => containerRef.current?.focus())
     return () => cancelAnimationFrame(frame)
   }, [])
 
-  // Escape on the project step acts like "Skip for now"
+  // Escape key opens skip confirmation
   useEffect(() => {
-    if (state.step !== 'project') return
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') { e.stopPropagation(); setOnboardingComplete(true) }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setShowSkipConfirm(true)
+      }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [state.step, setOnboardingComplete])
+  }, [])
+
+  // Auto-advance past project step when a project is added
+  useEffect(() => {
+    if (hasProjects && STEPS[state.currentStep] === 'project') {
+      dispatch({ type: 'next' })
+    }
+  }, [hasProjects, state.currentStep])
 
   const runChecks = useCallback(async () => {
     dispatch({ type: 'start_checks' })
-
-    // Run independent checks in parallel, but hold ghAuth until gh resolves —
-    // there's no point checking gh auth if the CLI itself isn't installed.
     const independent = (Object.keys(CHECK_FNS) as CheckKey[]).filter((k) => k !== 'ghAuth')
     const results = new Map<CheckKey, boolean>()
-
     await Promise.all(
       independent.map(async (key) => {
         try {
@@ -357,10 +151,8 @@ function OnboardingContent() {
           results.set(key, false)
           dispatch({ type: 'set_check', key, status: 'fail' })
         }
-      })
+      }),
     )
-
-    // Only check ghAuth if gh itself passed
     if (results.get('gh')) {
       try {
         const ok = await CHECK_FNS.ghAuth()
@@ -373,16 +165,14 @@ function OnboardingContent() {
     }
   }, [])
 
-  // Runs the install command then immediately re-checks, regardless of install outcome.
-  // ghAuth uses the Device Flow dialog instead of shell.installTool.
   const installAndRecheck = useCallback(async (key: CheckKey) => {
     if (key === 'ghAuth') {
-      dispatch({ type: 'show_gh_auth_dialog' })
+      dispatch({ type: 'show_gh_auth' })
       return
     }
     dispatch({ type: 'mark_install_attempted', key })
     dispatch({ type: 'set_check', key, status: 'installing' })
-    try { await shell.installTool(key) } catch { /* still recheck below */ }
+    try { await shell.installTool(key) } catch { /* recheck below */ }
     dispatch({ type: 'set_check', key, status: 'checking' })
     try {
       const ok = await CHECK_FNS[key]()
@@ -393,7 +183,7 @@ function OnboardingContent() {
   }, [])
 
   const handleGhAuthSuccess = useCallback(async () => {
-    dispatch({ type: 'hide_gh_auth_dialog' })
+    dispatch({ type: 'hide_gh_auth' })
     dispatch({ type: 'set_check', key: 'ghAuth', status: 'checking' })
     try {
       const ok = await CHECK_FNS.ghAuth()
@@ -403,49 +193,94 @@ function OnboardingContent() {
     }
   }, [])
 
-  const goToDoctor = useCallback(() => dispatch({ type: 'set_step', step: 'doctor' }), [])
-  const goToProject = useCallback(() => dispatch({ type: 'set_step', step: 'project' }), [])
-  const handleSkip = useCallback(() => setOnboardingComplete(true), [setOnboardingComplete])
+  const goNext = useCallback(() => dispatch({ type: 'next' }), [])
+  const goBack = useCallback(() => {
+    const prev = state.currentStep - 1
+    if (hasProjects && STEPS[prev] === 'project') {
+      dispatch({ type: 'go_to', step: prev - 1 })
+    } else {
+      dispatch({ type: 'back' })
+    }
+  }, [state.currentStep, hasProjects])
+
+  const askSkip = useCallback(() => setShowSkipConfirm(true), [])
+  const confirmSkip = useCallback(() => {
+    setShowSkipConfirm(false)
+    setOnboardingComplete(true)
+  }, [setOnboardingComplete])
+
+  const handleFinish = useCallback(() => {
+    setOnboardingComplete(true)
+  }, [setOnboardingComplete])
+
+  const handleTakeTour = useCallback(() => {
+    setFeatureTourComplete(false)
+    setOnboardingComplete(true)
+  }, [setOnboardingComplete, setFeatureTourComplete])
+
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) setShowSkipConfirm(true)
+  }, [])
+
+  const step = STEPS[state.currentStep]
+  const isLastStep = step === 'explore'
 
   return (
-    <div className="onboarding-overlay" role="dialog" aria-modal="true">
-      <div className="onboarding-card" ref={cardRef} tabIndex={-1}>
-        <StepDots step={state.step} />
-        {state.step === 'welcome' && <WelcomeStep onNext={goToDoctor} />}
-        {state.step === 'doctor' && (
-          <DoctorStep
+    <div
+      className="ob-overlay"
+      ref={containerRef}
+      tabIndex={-1}
+      role="dialog"
+      aria-modal="true"
+      onClick={handleBackdropClick}
+    >
+      <OnboardingLayout
+        currentStep={state.currentStep}
+        totalSteps={TOTAL_STEPS}
+        onBack={goBack}
+        onContinue={isLastStep ? handleFinish : goNext}
+        onSkip={askSkip}
+        canContinue
+        showBack={state.currentStep > 0}
+        showSkip={!isLastStep}
+        showContinue
+        continueLabel={isLastStep ? t('onboarding.explore.finish') : undefined}
+      >
+        {step === 'welcome' && <WelcomeStep />}
+        {step === 'model' && <ModelStep />}
+        {step === 'theme' && <ThemeStep />}
+        {step === 'notifications' && <NotificationStep />}
+        {step === 'environment' && (
+          <EnvironmentStep
             checks={state.checks}
             installAttempted={state.installAttempted}
             onRunChecks={runChecks}
             onInstall={installAndRecheck}
-            onNext={goToProject}
+            onOpenExternal={shell.openExternal}
           />
         )}
-        {state.step === 'project' && <ProjectStep onSkip={handleSkip} />}
-      </div>
+        {step === 'project' && <ProjectStep />}
+        {step === 'explore' && <ExploreStep onTakeTour={handleTakeTour} />}
+      </OnboardingLayout>
+
+      {showSkipConfirm && (
+        <SkipConfirmDialog onSkip={confirmSkip} onCancel={() => setShowSkipConfirm(false)} />
+      )}
+
       <GhAuthDialog
         isOpen={state.showGhAuthDialog}
-        onClose={() => dispatch({ type: 'hide_gh_auth_dialog' })}
+        onClose={() => dispatch({ type: 'hide_gh_auth' })}
         onSuccess={handleGhAuthSuccess}
       />
     </div>
   )
 }
 
+// ── Export ────────────────────────────────────────────────────────────────────
+
 export function OnboardingOverlay() {
   const onboardingComplete = useUIStore((s) => s.onboardingComplete)
-  const setOnboardingComplete = useUIStore((s) => s.setOnboardingComplete)
-  const showAddProject = useUIStore((s) => s.showAddProject)
-  const hasProjects = useProjectsStore((s) => s.projects.length > 0)
 
-  // Auto-complete onboarding when a project exists. This covers the case where
-  // the user adds a project via AddProjectDialog (which unmounts the overlay
-  // while showAddProject is true). Without this, closing the dialog re-mounts
-  // the overlay from step 1 because the ProjectStep effect never ran.
-  useEffect(() => {
-    if (!onboardingComplete && hasProjects) setOnboardingComplete(true)
-  }, [onboardingComplete, hasProjects, setOnboardingComplete])
-
-  if (onboardingComplete || showAddProject) return null
+  if (onboardingComplete) return null
   return createPortal(<OnboardingContent />, document.body)
 }

--- a/src/renderer/components/Onboarding/steps/EnvironmentStep.tsx
+++ b/src/renderer/components/Onboarding/steps/EnvironmentStep.tsx
@@ -118,10 +118,8 @@ function JiraCard({
 
 interface Props {
   checks: Record<CheckKey, CheckStatus>
-  installAttempted: Partial<Record<CheckKey, boolean>>
   onRunChecks: () => void
   onInstall: (key: CheckKey) => void
-  onOpenExternal: (url: string) => void
 }
 
 export function EnvironmentStep({ checks, onRunChecks, onInstall }: Props) {

--- a/src/renderer/components/Onboarding/steps/EnvironmentStep.tsx
+++ b/src/renderer/components/Onboarding/steps/EnvironmentStep.tsx
@@ -1,0 +1,176 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Spinner } from '@/components/ui/Spinner'
+import { Button } from '@/components/ui/Button'
+import { IconGitHub } from '@/components/shared/icons'
+
+export type CheckKey = 'git' | 'gh' | 'ghAuth' | 'acli'
+export type CheckStatus = 'pending' | 'checking' | 'ok' | 'fail' | 'installing'
+
+function StatusBadge({ status }: { status: CheckStatus }) {
+  const { t } = useTranslation('common')
+  if (status === 'checking' || status === 'installing' || status === 'pending') {
+    return <span className="ob-int-badge ob-int-badge--checking"><Spinner size="sm" /></span>
+  }
+  if (status === 'ok') {
+    return (
+      <span className="ob-int-badge ob-int-badge--connected">
+        <span className="ob-int-badge-dot ob-int-badge-dot--green" />
+        {t('onboarding.integrations.connected')}
+      </span>
+    )
+  }
+  return null
+}
+
+function GitHubCard({
+  ghStatus,
+  authStatus,
+  onInstall,
+  onRecheck,
+}: {
+  ghStatus: CheckStatus
+  authStatus: CheckStatus
+  onInstall: (key: CheckKey) => void
+  onRecheck: () => void
+}) {
+  const { t } = useTranslation('common')
+  const connected = ghStatus === 'ok' && authStatus === 'ok'
+  const busy = ghStatus === 'checking' || ghStatus === 'installing' || authStatus === 'checking' || authStatus === 'installing'
+  const effectiveStatus: CheckStatus = connected ? 'ok' : busy ? 'checking' : ghStatus === 'pending' ? 'pending' : 'fail'
+
+  return (
+    <div className="ob-int-card">
+      <div className="ob-int-card-icon">
+        <IconGitHub size={22} />
+      </div>
+      <div className="ob-int-card-body">
+        <div className="ob-int-card-header">
+          <span className="ob-int-card-name">GitHub</span>
+          <StatusBadge status={effectiveStatus} />
+        </div>
+        <span className="ob-int-card-desc">{t('onboarding.integrations.ghDesc')}</span>
+      </div>
+      {!connected && !busy && (
+        <div className="ob-int-card-actions">
+          {ghStatus === 'fail' && (
+            <Button size="sm" onClick={() => onInstall('gh')}>
+              {t('onboarding.doctor.install')}
+            </Button>
+          )}
+          {ghStatus === 'ok' && authStatus === 'fail' && (
+            <Button size="sm" onClick={() => onInstall('ghAuth')}>
+              {t('onboarding.integrations.connect')}
+            </Button>
+          )}
+          <Button size="sm" onClick={onRecheck}>
+            {t('onboarding.integrations.recheck')}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function JiraCard({
+  status,
+  onInstall,
+  onRecheck,
+}: {
+  status: CheckStatus
+  onInstall: (key: CheckKey) => void
+  onRecheck: () => void
+}) {
+  const { t } = useTranslation('common')
+  const connected = status === 'ok'
+  const busy = status === 'checking' || status === 'installing'
+
+  return (
+    <div className="ob-int-card">
+      <div className="ob-int-card-icon">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+          <path d="M11.53 2c0 4.97 3.03 8 8 8h.47c0 4.97-3.03 8-8 8-.97 0-2 .5-2 2s1.03 2 2 2c6.63 0 12-5.37 12-12S18.63-2 12-2c-.97 0-2 .5-2 2s1.03 2 1.53 2z" fill="#2684FF" transform="translate(0 2)"/>
+          <path d="M12.47 22c0-4.97-3.03-8-8-8H4c0-4.97 3.03-8 8-8 .97 0 2-.5 2-2s-1.03-2-2-2C5.37 2 0 7.37 0 14s5.37 12 12 12c.97 0 2-.5 2-2s-1.03-2-1.53-2z" fill="#2684FF" opacity="0.65" transform="translate(0 -2)"/>
+        </svg>
+      </div>
+      <div className="ob-int-card-body">
+        <div className="ob-int-card-header">
+          <span className="ob-int-card-name">Jira</span>
+          <StatusBadge status={status} />
+        </div>
+        <span className="ob-int-card-desc">{t('onboarding.integrations.jiraDesc')}</span>
+      </div>
+      {!connected && !busy && (
+        <div className="ob-int-card-actions">
+          {status === 'fail' && (
+            <Button size="sm" onClick={() => onInstall('acli')}>
+              {t('onboarding.doctor.install')}
+            </Button>
+          )}
+          <Button size="sm" onClick={onRecheck}>
+            {t('onboarding.integrations.recheck')}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface Props {
+  checks: Record<CheckKey, CheckStatus>
+  installAttempted: Partial<Record<CheckKey, boolean>>
+  onRunChecks: () => void
+  onInstall: (key: CheckKey) => void
+  onOpenExternal: (url: string) => void
+}
+
+export function EnvironmentStep({ checks, onRunChecks, onInstall }: Props) {
+  const { t } = useTranslation('common')
+
+  useEffect(() => { onRunChecks() }, [onRunChecks])
+
+  return (
+    <div className="ob-step">
+      <h1 className="ob-heading">{t('onboarding.integrations.title')}</h1>
+      <p className="ob-subtitle">{t('onboarding.integrations.subtitle')}</p>
+
+      <ul className="ob-int-benefits">
+        <li>{t('onboarding.integrations.benefit1')}</li>
+        <li>{t('onboarding.integrations.benefit2')}</li>
+        <li>{t('onboarding.integrations.benefit3')}</li>
+      </ul>
+
+      <div className="ob-int-list">
+        <div className="ob-int-card ob-int-card--compact">
+          <div className="ob-int-card-icon">
+            <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M15.698 7.287L8.712.302a1.03 1.03 0 0 0-1.457 0l-1.45 1.45 1.84 1.84a1.223 1.223 0 0 1 1.548 1.56l1.773 1.774a1.224 1.224 0 1 1-.733.693L8.52 5.905v3.978a1.225 1.225 0 1 1-1.008-.036V5.836a1.225 1.225 0 0 1-.665-1.607L5.02 2.4.302 7.12a1.03 1.03 0 0 0 0 1.457l6.986 6.986a1.03 1.03 0 0 0 1.457 0l6.953-6.953a1.031 1.031 0 0 0 0-1.457" />
+            </svg>
+          </div>
+          <div className="ob-int-card-body">
+            <span className="ob-int-card-name">Git</span>
+            <span className="ob-int-card-desc">{t('onboarding.integrations.gitDesc')}</span>
+          </div>
+          <StatusBadge status={checks.git} />
+          {checks.git === 'fail' && (
+            <Button size="sm" onClick={() => onInstall('git')}>
+              {t('onboarding.doctor.install')}
+            </Button>
+          )}
+        </div>
+
+        <GitHubCard
+          ghStatus={checks.gh}
+          authStatus={checks.ghAuth}
+          onInstall={onInstall}
+          onRecheck={onRunChecks}
+        />
+        <JiraCard
+          status={checks.acli}
+          onInstall={onInstall}
+          onRecheck={onRunChecks}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Onboarding/steps/ExploreStep.tsx
+++ b/src/renderer/components/Onboarding/steps/ExploreStep.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next'
+import { IconChevronRight } from '@/components/shared/icons'
+
+interface Props {
+  onTakeTour: () => void
+}
+
+export function ExploreStep({ onTakeTour }: Props) {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="ob-step">
+      <h1 className="ob-heading">{t('onboarding.explore.title')}</h1>
+      <p className="ob-subtitle">{t('onboarding.explore.subtitle')}</p>
+
+      <div className="ob-explore-preview">
+        <div className="ob-explore-feature-list">
+          <div className="ob-explore-feature">
+            <span className="ob-explore-feature-dot" />
+            <span>{t('onboarding.explore.feature1')}</span>
+          </div>
+          <div className="ob-explore-feature">
+            <span className="ob-explore-feature-dot" />
+            <span>{t('onboarding.explore.feature2')}</span>
+          </div>
+          <div className="ob-explore-feature">
+            <span className="ob-explore-feature-dot" />
+            <span>{t('onboarding.explore.feature3')}</span>
+          </div>
+          <div className="ob-explore-feature">
+            <span className="ob-explore-feature-dot" />
+            <span>{t('onboarding.explore.feature4')}</span>
+          </div>
+        </div>
+      </div>
+
+      <button className="ob-tour-btn" onClick={onTakeTour}>
+        {t('onboarding.explore.takeTour')} <IconChevronRight size={12} />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/Onboarding/steps/ExploreStep.tsx
+++ b/src/renderer/components/Onboarding/steps/ExploreStep.tsx
@@ -13,6 +13,35 @@ export function ExploreStep({ onTakeTour }: Props) {
       <h1 className="ob-heading">{t('onboarding.explore.title')}</h1>
       <p className="ob-subtitle">{t('onboarding.explore.subtitle')}</p>
 
+      <div className="ob-product-preview" aria-hidden="true">
+        <div className="ob-product-topbar">
+          <span className="ob-product-window-dot" />
+          <span className="ob-product-window-dot" />
+          <span className="ob-product-window-dot" />
+          <span className="ob-product-title">Braid</span>
+        </div>
+        <div className="ob-product-body">
+          <div className="ob-product-sidebar">
+            <span className="ob-product-pill ob-product-pill--active">feature/onboarding</span>
+            <span className="ob-product-pill">fix/terminal-theme</span>
+            <span className="ob-product-pill">pr/review-101</span>
+          </div>
+          <div className="ob-product-main">
+            <div className="ob-product-tabs">
+              <span className="ob-product-tab ob-product-tab--active">Claude</span>
+              <span className="ob-product-tab">Codex</span>
+              <span className="ob-product-tab">Diff</span>
+            </div>
+            <div className="ob-product-grid">
+              <span className="ob-product-line ob-product-line--wide" />
+              <span className="ob-product-line" />
+              <span className="ob-product-status">PR #128 ready</span>
+              <span className="ob-product-line ob-product-line--short" />
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div className="ob-explore-preview">
         <div className="ob-explore-feature-list">
           <div className="ob-explore-feature">

--- a/src/renderer/components/Onboarding/steps/ModelStep.tsx
+++ b/src/renderer/components/Onboarding/steps/ModelStep.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useUIStore } from '@/store/ui'
+import { useDetectedAgents } from '@/lib/agentDetection'
+import { AGENT_CATALOG, type AgentCatalogEntry } from '@/lib/agentCatalog'
+import { AgentIcon } from '@/components/shared/icons/AgentIcons'
+import { IconCheckFill } from '@/components/shared/icons'
+
+function AgentCard({
+  agent,
+  isActive,
+  onSelect,
+}: {
+  agent: AgentCatalogEntry
+  isActive: boolean
+  onSelect: () => void
+}) {
+  return (
+    <button
+      className={`ob-agent-card${isActive ? ' ob-agent-card--active' : ''}`}
+      onClick={onSelect}
+      aria-pressed={isActive}
+    >
+      {isActive && (
+        <div className="ob-agent-check">
+          <IconCheckFill size={14} />
+        </div>
+      )}
+      <div className="ob-agent-icon">
+        <AgentIcon agentId={agent.id} size={20} />
+      </div>
+      <div className="ob-agent-info">
+        <span className="ob-agent-name">{agent.label}</span>
+        <span className="ob-agent-cmd">{agent.detectCmd}</span>
+      </div>
+    </button>
+  )
+}
+
+export function ModelStep() {
+  const { t } = useTranslation('common')
+  const defaultAgentId = useUIStore((s) => s.defaultAgentId)
+  const setDefaultAgentId = useUIStore((s) => s.setDefaultAgentId)
+  const detected = useDetectedAgents()
+  const [showAll, setShowAll] = useState(false)
+
+  const detectedIds = new Set(detected.map((a) => a.id))
+  const undetected = AGENT_CATALOG.filter((a) => !detectedIds.has(a.id))
+
+  return (
+    <div className="ob-step">
+      <span className="ob-eyebrow">{t('onboarding.welcome.eyebrow')}</span>
+      <h1 className="ob-heading">{t('onboarding.agent.title')}</h1>
+      <p className="ob-subtitle">{t('onboarding.agent.subtitle')}</p>
+
+      {detected.length > 0 && (
+        <>
+          <div className="ob-detected-label">
+            <span className="ob-detected-dot" />
+            {t('onboarding.agent.detected', { count: detected.length })}
+          </div>
+          <div className="ob-agent-grid">
+            {detected.map((agent) => (
+              <AgentCard
+                key={agent.id}
+                agent={agent}
+                isActive={agent.id === defaultAgentId}
+                onSelect={() => setDefaultAgentId(agent.id)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      {showAll && (
+        <div className="ob-agent-grid">
+          {undetected.map((agent) => (
+            <AgentCard
+              key={agent.id}
+              agent={agent}
+              isActive={agent.id === defaultAgentId}
+              onSelect={() => setDefaultAgentId(agent.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {!showAll && undetected.length > 0 && (
+        <button className="ob-show-more" onClick={() => setShowAll(true)}>
+          {t('onboarding.agent.showMore', { count: undetected.length })}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/Onboarding/steps/ModelStep.tsx
+++ b/src/renderer/components/Onboarding/steps/ModelStep.tsx
@@ -27,7 +27,7 @@ function AgentCard({
         </div>
       )}
       <div className="ob-agent-icon">
-        <AgentIcon agentId={agent.id} size={20} />
+        <AgentIcon agentId={agent.id} size={20} allowRemote={false} />
       </div>
       <div className="ob-agent-info">
         <span className="ob-agent-name">{agent.label}</span>

--- a/src/renderer/components/Onboarding/steps/NotificationStep.tsx
+++ b/src/renderer/components/Onboarding/steps/NotificationStep.tsx
@@ -4,6 +4,7 @@ import { Toggle } from '@/components/shared/Toggle'
 import { Button } from '@/components/ui/Button'
 import { shell } from '@/lib/ipc'
 import { IconSettings } from '@/components/shared/icons'
+import { flash } from '@/store/flash'
 
 export function NotificationStep() {
   const { t } = useTranslation('common')
@@ -15,9 +16,18 @@ export function NotificationStep() {
   }
 
   const sendTestNotification = () => {
-    new Notification('Braid', {
-      body: t('onboarding.notifications.testBody'),
-    })
+    if (!('Notification' in window) || Notification.permission !== 'granted') {
+      flash('warning', t('onboarding.notifications.permissionRequired'))
+      return
+    }
+
+    try {
+      new Notification('Braid', {
+        body: t('onboarding.notifications.testBody'),
+      })
+    } catch {
+      flash('warning', t('onboarding.notifications.permissionRequired'))
+    }
   }
 
   return (

--- a/src/renderer/components/Onboarding/steps/NotificationStep.tsx
+++ b/src/renderer/components/Onboarding/steps/NotificationStep.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from 'react-i18next'
+import { useUIStore } from '@/store/ui'
+import { Toggle } from '@/components/shared/Toggle'
+import { Button } from '@/components/ui/Button'
+import { shell } from '@/lib/ipc'
+import { IconSettings } from '@/components/shared/icons'
+
+export function NotificationStep() {
+  const { t } = useTranslation('common')
+  const notificationSound = useUIStore((s) => s.notificationSound)
+  const setNotificationSound = useUIStore((s) => s.setNotificationSound)
+
+  const openMacSettings = () => {
+    shell.openExternal('x-apple.systempreferences:com.apple.preference.notifications')
+  }
+
+  const sendTestNotification = () => {
+    new Notification('Braid', {
+      body: t('onboarding.notifications.testBody'),
+    })
+  }
+
+  return (
+    <div className="ob-step">
+      <h1 className="ob-heading">{t('onboarding.notifications.title')}</h1>
+      <p className="ob-subtitle">{t('onboarding.notifications.subtitle')}</p>
+
+      <div className="ob-notif-permission">
+        <div className="ob-notif-permission-icon">
+          <IconSettings size={18} />
+        </div>
+        <div className="ob-notif-permission-body">
+          <span className="ob-notif-permission-title">{t('onboarding.notifications.allowTitle')}</span>
+          <span className="ob-notif-permission-desc">{t('onboarding.notifications.allowDesc')}</span>
+        </div>
+        <Button onClick={openMacSettings}>
+          {t('onboarding.notifications.openMacSettings')}
+        </Button>
+      </div>
+
+      <div className="ob-notif-sound-section">
+        <h4 className="ob-notif-sound-heading">{t('onboarding.notifications.chooseSound')}</h4>
+        <p className="ob-notif-sound-hint">{t('onboarding.notifications.chooseSoundHint')}</p>
+
+        <div className="ob-notif-sound-row">
+          <div className="ob-notif-sound-toggle">
+            <span className="ob-notif-sound-label">{t('onboarding.notifications.sound')}</span>
+            <Toggle checked={notificationSound} onChange={setNotificationSound} />
+          </div>
+          <Button size="sm" onClick={sendTestNotification}>
+            {t('onboarding.notifications.sendTest')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Onboarding/steps/ProjectStep.tsx
+++ b/src/renderer/components/Onboarding/steps/ProjectStep.tsx
@@ -1,0 +1,108 @@
+import { useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useProjectsStore } from '@/store/projects'
+import { useUIStore } from '@/store/ui'
+import { Button } from '@/components/ui/Button'
+import { Spinner } from '@/components/ui/Spinner'
+import { IconGitFork } from '@/components/shared/icons'
+import * as ipc from '@/lib/ipc'
+
+export function ProjectStep() {
+  const { t } = useTranslation('common')
+  const addProject = useProjectsStore((s) => s.addProject)
+  const storagePath = useUIStore((s) => s.worktreeStoragePath)
+  const [cloneUrl, setCloneUrl] = useState('')
+  const [cloning, setCloning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [homePath, setHomePath] = useState('')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('braid:homePath')
+    if (stored) setHomePath(stored)
+  }, [])
+
+  const workspacePath = storagePath || homePath || '~/Braid/worktrees'
+
+  const handleBrowse = async () => {
+    setError(null)
+    const selected = await ipc.dialog.openDirectory()
+    if (!selected) return
+    try {
+      await addProject(selected)
+    } catch {
+      setError(t('onboarding.project.addError'))
+    }
+  }
+
+  const handleClone = async () => {
+    const url = cloneUrl.trim()
+    if (!url) return
+    setError(null)
+    setCloning(true)
+    try {
+      const clonedPath = await ipc.git.cloneRepo(url)
+      await addProject(clonedPath)
+    } catch {
+      setError(t('onboarding.project.cloneError'))
+    } finally {
+      setCloning(false)
+    }
+  }
+
+  return (
+    <div className="ob-step">
+      <h1 className="ob-heading">{t('onboarding.project.title')}</h1>
+      <p className="ob-subtitle">{t('onboarding.project.subtitle')}</p>
+
+      <div className="ob-project-cards">
+        <div className="ob-project-card">
+          <div className="ob-project-card-row">
+            <div className="ob-action-card-icon">
+              <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3">
+                <path d="M2 13V3a1 1 0 0 1 1-1h4l2 2h4a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1Z" />
+              </svg>
+            </div>
+            <div className="ob-action-card-body">
+              <span className="ob-action-card-title">{t('onboarding.project.openFolder')}</span>
+              <span className="ob-action-card-desc">{t('onboarding.project.openFolderDesc')}</span>
+            </div>
+            <Button onClick={handleBrowse}>{t('onboarding.project.browseBtn')}</Button>
+          </div>
+        </div>
+
+        <div className="ob-project-card">
+          <div className="ob-project-card-row">
+            <div className="ob-action-card-icon">
+              <IconGitFork size={20} />
+            </div>
+            <div className="ob-action-card-body">
+              <span className="ob-action-card-title">{t('onboarding.project.cloneRepo')}</span>
+              <span className="ob-action-card-desc">{t('onboarding.project.cloneRepoDesc')}</span>
+            </div>
+          </div>
+          <div className="ob-clone-input-row">
+            <input
+              className="ob-clone-input"
+              value={cloneUrl}
+              onChange={(e) => setCloneUrl(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter' && !cloning) handleClone() }}
+              placeholder="git@github.com:org/repo.git"
+              disabled={cloning}
+              spellCheck={false}
+            />
+            <Button onClick={handleClone} disabled={cloning || !cloneUrl.trim()}>
+              {cloning ? <Spinner size="sm" /> : t('onboarding.project.clone')}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {error && <p className="ob-error">{error}</p>}
+
+      <div className="ob-workspace-path">
+        <span className="ob-workspace-path-label">{t('onboarding.project.workspace')}</span>
+        <span className="ob-workspace-path-value">{workspacePath}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Onboarding/steps/ProjectStep.tsx
+++ b/src/renderer/components/Onboarding/steps/ProjectStep.tsx
@@ -5,6 +5,7 @@ import { useUIStore } from '@/store/ui'
 import { Button } from '@/components/ui/Button'
 import { Spinner } from '@/components/ui/Spinner'
 import { IconGitFork } from '@/components/shared/icons'
+import { SK } from '@/lib/storageKeys'
 import * as ipc from '@/lib/ipc'
 
 export function ProjectStep() {
@@ -17,7 +18,7 @@ export function ProjectStep() {
   const [homePath, setHomePath] = useState('')
 
   useEffect(() => {
-    const stored = localStorage.getItem('braid:homePath')
+    const stored = localStorage.getItem(SK.homePath)
     if (stored) setHomePath(stored)
   }, [])
 

--- a/src/renderer/components/Onboarding/steps/ThemeStep.tsx
+++ b/src/renderer/components/Onboarding/steps/ThemeStep.tsx
@@ -1,0 +1,85 @@
+import { useTranslation } from 'react-i18next'
+import { useUIStore } from '@/store/ui'
+import { builtinThemes, type ThemePalette } from '@/themes/palettes'
+import { applyTheme } from '@/themes/apply'
+import { IconCheckFill } from '@/components/shared/icons'
+
+const FEATURED_IDS = ['ocean-dark', 'ocean-light', 'amethyst']
+
+function ThemeCard({ theme, isActive, onSelect }: {
+  theme: ThemePalette
+  isActive: boolean
+  onSelect: () => void
+}) {
+  const c = theme.colors
+  return (
+    <button
+      className={`ob-theme-card${isActive ? ' ob-theme-card--active' : ''}`}
+      onClick={onSelect}
+      aria-pressed={isActive}
+    >
+      {isActive && (
+        <div className="ob-theme-check">
+          <IconCheckFill size={16} />
+        </div>
+      )}
+      <div className="ob-theme-preview" style={{ background: c.bgPrimary }}>
+        <div className="ob-theme-preview-sidebar" style={{ background: c.bgSecondary, borderRight: `1px solid ${c.border}` }}>
+          <div className="ob-theme-preview-line" style={{ background: c.textMuted, width: '60%' }} />
+          <div className="ob-theme-preview-line" style={{ background: c.accent, width: '80%' }} />
+          <div className="ob-theme-preview-line" style={{ background: c.textMuted, width: '50%' }} />
+        </div>
+        <div className="ob-theme-preview-main">
+          <div className="ob-theme-preview-topbar" style={{ borderBottom: `1px solid ${c.border}` }}>
+            <div className="ob-theme-preview-dot" style={{ background: c.accent }} />
+            <div className="ob-theme-preview-line" style={{ background: c.textMuted, width: '40%' }} />
+          </div>
+          <div className="ob-theme-preview-lines">
+            <div className="ob-theme-preview-line" style={{ background: c.textPrimary, width: '90%' }} />
+            <div className="ob-theme-preview-line" style={{ background: c.textSecondary, width: '70%' }} />
+            <div className="ob-theme-preview-line" style={{ background: c.textSecondary, width: '55%' }} />
+          </div>
+        </div>
+      </div>
+      <div className="ob-theme-card-label">
+        <span className="ob-theme-card-name">{theme.name}</span>
+        <span className="ob-theme-card-hint">
+          {theme.type === 'dark' ? 'Dark' : 'Light'}
+        </span>
+      </div>
+    </button>
+  )
+}
+
+export function ThemeStep() {
+  const { t } = useTranslation('common')
+  const activeThemeId = useUIStore((s) => s.activeThemeId)
+  const setTheme = useUIStore((s) => s.setTheme)
+
+  const featured = FEATURED_IDS.map((id) => builtinThemes.find((t) => t.id === id)!).filter(Boolean)
+
+  const handleSelect = (theme: ThemePalette) => {
+    setTheme(theme.id)
+    applyTheme(theme)
+  }
+
+  return (
+    <div className="ob-step">
+      <h1 className="ob-heading">{t('onboarding.theme.title')}</h1>
+      <p className="ob-subtitle">{t('onboarding.theme.subtitle')}</p>
+
+      <div className="ob-theme-grid">
+        {featured.map((theme) => (
+          <ThemeCard
+            key={theme.id}
+            theme={theme}
+            isActive={theme.id === activeThemeId}
+            onSelect={() => handleSelect(theme)}
+          />
+        ))}
+      </div>
+
+      <p className="ob-hint">{t('onboarding.theme.moreHint')}</p>
+    </div>
+  )
+}

--- a/src/renderer/components/Onboarding/steps/ThemeStep.tsx
+++ b/src/renderer/components/Onboarding/steps/ThemeStep.tsx
@@ -56,7 +56,9 @@ export function ThemeStep() {
   const activeThemeId = useUIStore((s) => s.activeThemeId)
   const setTheme = useUIStore((s) => s.setTheme)
 
-  const featured = FEATURED_IDS.map((id) => builtinThemes.find((t) => t.id === id)!).filter(Boolean)
+  const featured = FEATURED_IDS
+    .map((id) => builtinThemes.find((t) => t.id === id))
+    .filter((theme): theme is ThemePalette => Boolean(theme))
 
   const handleSelect = (theme: ThemePalette) => {
     setTheme(theme.id)

--- a/src/renderer/components/Onboarding/steps/WelcomeStep.tsx
+++ b/src/renderer/components/Onboarding/steps/WelcomeStep.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useUIStore } from '@/store/ui'
-import { IconSparkle } from '@/components/shared/icons'
 import type { SupportedLanguage } from '@/store/ui'
+import braidLogoUrl from '../../../../../build/icon.svg?url'
 
 const LANGUAGES: { id: SupportedLanguage; label: string; native: string }[] = [
   { id: 'en', label: 'English', native: 'English' },
@@ -18,7 +18,7 @@ export function WelcomeStep() {
   return (
     <div className="ob-step ob-step--welcome">
       <div className="ob-welcome-brand">
-        <IconSparkle size={44} />
+        <img src={braidLogoUrl} alt="" className="ob-welcome-logo" aria-hidden="true" />
       </div>
       <h1 className="ob-heading">{t('onboarding.welcome.title')}</h1>
       <p className="ob-welcome-story">{t('onboarding.welcome.story')}</p>

--- a/src/renderer/components/Onboarding/steps/WelcomeStep.tsx
+++ b/src/renderer/components/Onboarding/steps/WelcomeStep.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from 'react-i18next'
+import { useUIStore } from '@/store/ui'
+import { IconSparkle } from '@/components/shared/icons'
+import type { SupportedLanguage } from '@/store/ui'
+
+const LANGUAGES: { id: SupportedLanguage; label: string; native: string }[] = [
+  { id: 'en', label: 'English', native: 'English' },
+  { id: 'ja', label: 'Japanese', native: '日本語' },
+  { id: 'id', label: 'Indonesian', native: 'Bahasa Indonesia' },
+  { id: 'zh', label: 'Chinese', native: '中文' },
+]
+
+export function WelcomeStep() {
+  const { t } = useTranslation('common')
+  const language = useUIStore((s) => s.language)
+  const setLanguage = useUIStore((s) => s.setLanguage)
+
+  return (
+    <div className="ob-step ob-step--welcome">
+      <div className="ob-welcome-brand">
+        <IconSparkle size={44} />
+      </div>
+      <h1 className="ob-heading">{t('onboarding.welcome.title')}</h1>
+      <p className="ob-welcome-story">{t('onboarding.welcome.story')}</p>
+
+      <div className="ob-lang-section">
+        <span className="ob-lang-label">{t('onboarding.welcome.chooseLang')}</span>
+        <div className="ob-lang-grid">
+          {LANGUAGES.map((lang) => (
+            <button
+              key={lang.id}
+              className={`ob-lang-card${lang.id === language ? ' ob-lang-card--active' : ''}`}
+              onClick={() => setLanguage(lang.id)}
+              aria-pressed={lang.id === language}
+            >
+              <span className="ob-lang-native">{lang.native}</span>
+              {lang.native !== lang.label && (
+                <span className="ob-lang-english">{lang.label}</span>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Onboarding/steps/index.ts
+++ b/src/renderer/components/Onboarding/steps/index.ts
@@ -1,0 +1,8 @@
+export { WelcomeStep } from './WelcomeStep'
+export { ModelStep } from './ModelStep'
+export { ThemeStep } from './ThemeStep'
+export { NotificationStep } from './NotificationStep'
+export { EnvironmentStep } from './EnvironmentStep'
+export type { CheckKey, CheckStatus } from './EnvironmentStep'
+export { ProjectStep } from './ProjectStep'
+export { ExploreStep } from './ExploreStep'

--- a/src/renderer/components/shared/icons/AgentIcons.tsx
+++ b/src/renderer/components/shared/icons/AgentIcons.tsx
@@ -74,11 +74,31 @@ const DroidIcon = ({ size }: { size: number }) => (
   </svg>
 )
 
+/** Gemini - Google Gemini sparkle mark */
+const GeminiIcon = ({ size }: { size: number }) => (
+  <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
+    <path
+      d="M16 2C16 2 18.5 10.5 22 14s12 6 12 6-10.5 2.5-14 6-6 12-6 12-2.5-10.5-6-14S-2 18-2 18s10.5-2.5 14-6 6-12 6-12z"
+      fill="currentColor"
+      transform="translate(-1 -1) scale(1.03)"
+    />
+  </svg>
+)
+
+/** Antigravity - stylized "A" mark */
+const AntigravityIcon = ({ size }: { size: number }) => (
+  <svg width={size} height={size} viewBox="0 0 32 32" fill="currentColor">
+    <path d="M16 3L4 28h5l2.5-6h9l2.5 6h5L16 3zm0 9l3 7h-6l3-7z" />
+  </svg>
+)
+
 // ─── Agent icon map for inline SVG heroes ────────────────────────────────────
 
 const BRAND_ICON_MAP: Record<string, (props: { size: number }) => React.JSX.Element> = {
   claude: ({ size }) => <IconClaude size={size} />,
   codex: ({ size }) => <IconCodex size={size} />,
+  gemini: GeminiIcon,
+  antigravity: AntigravityIcon,
   copilot: CopilotIcon,
   pi: PiIcon,
   omp: OmpIcon,

--- a/src/renderer/components/shared/icons/AgentIcons.tsx
+++ b/src/renderer/components/shared/icons/AgentIcons.tsx
@@ -76,11 +76,9 @@ const DroidIcon = ({ size }: { size: number }) => (
 
 /** Gemini - Google Gemini sparkle mark */
 const GeminiIcon = ({ size }: { size: number }) => (
-  <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
+  <svg width={size} height={size} viewBox="0 0 32 32" fill="currentColor">
     <path
-      d="M16 2C16 2 18.5 10.5 22 14s12 6 12 6-10.5 2.5-14 6-6 12-6 12-2.5-10.5-6-14S-2 18-2 18s10.5-2.5 14-6 6-12 6-12z"
-      fill="currentColor"
-      transform="translate(-1 -1) scale(1.03)"
+      d="M16 3c1.6 6.2 4.8 9.4 11 11-6.2 1.6-9.4 4.8-11 11-1.6-6.2-4.8-9.4-11-11 6.2-1.6 9.4-4.8 11-11Z"
     />
   </svg>
 )
@@ -148,7 +146,15 @@ function AgentLetterIcon({ letter, size }: { letter: string; size: number }) {
 // ─── Main dispatch component ─────────────────────────────────────────────────
 
 /** Agent icon component - dispatches to brand SVG, Google favicon, or letter fallback. */
-export function AgentIcon({ agentId, size = 14 }: { agentId?: string; size?: number }) {
+export function AgentIcon({
+  agentId,
+  size = 14,
+  allowRemote = true,
+}: {
+  agentId?: string
+  size?: number
+  allowRemote?: boolean
+}) {
   if (!agentId) {
     return <AgentLetterIcon letter="?" size={size} />
   }
@@ -160,7 +166,7 @@ export function AgentIcon({ agentId, size = 14 }: { agentId?: string; size?: num
   // Tier 2: Google favicon via catalog domain
   const entry = getAgentEntry(agentId)
   const letter = (agentId.charAt(0) || '?').toUpperCase()
-  if (entry?.faviconDomain) {
+  if (allowRemote && entry?.faviconDomain) {
     return <AgentFaviconIcon domain={entry.faviconDomain} size={size} fallbackLetter={letter} />
   }
 

--- a/src/renderer/lib/storageKeys.ts
+++ b/src/renderer/lib/storageKeys.ts
@@ -45,6 +45,7 @@ export const SK = {
   activeCenterViewPrefix:     `${prefix}:activeCenterView:`,
 
   // ── Settings — AI ──────────────────────────────────────────────────────
+  defaultAgentId:             `${prefix}:defaultAgentId`,
   defaultModel:               `${prefix}:defaultModel`,
   defaultThinking:            `${prefix}:defaultThinking`,
   defaultExtendedContext:     `${prefix}:defaultExtendedContext`,

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -30,11 +30,69 @@
   "toastErrorCount": "{{count}} sessions need attention",
   "toastWaitingInputCount": "{{count}} sessions waiting for you",
   "onboarding": {
+    "of": "of",
+    "back": "Back",
+    "continue": "Continue",
+    "skipSetup": "Skip setup",
+    "skipConfirm": {
+      "title": "Skip onboarding?",
+      "desc": "It won't take long! You can always revisit from Settings.",
+      "skip": "Skip",
+      "keepGoing": "No, keep going"
+    },
+    "stepLabel": {
+      "welcome": "Welcome",
+      "agent": "Agent",
+      "theme": "Theme",
+      "notifications": "Notifications",
+      "integrations": "Integrations",
+      "project": "Project",
+      "explore": "Explore"
+    },
+    "agent": {
+      "title": "Pick your default agent",
+      "subtitle": "Braid works with every CLI agent. Choose the one you'll reach for most. Switch any time.",
+      "detected": "DETECTED ON YOUR SYSTEM  ·  {{count}}",
+      "showMore": "Show {{count}} more agents→"
+    },
     "welcome": {
+      "eyebrow": "WELCOME TO BRAID",
       "title": "Welcome to Braid",
-      "subtitle": "Your AI-powered Git workspace",
-      "description": "Braid combines Claude AI with Git worktrees so you can run multiple coding agents in parallel — each on its own branch.",
+      "story": "Braid weaves multiple AI coding agents together with Git worktrees - so you can run parallel tasks on separate branches, review diffs, manage PRs, and ship faster, all from one window.",
+      "chooseLang": "Choose your language",
+      "subtitle": "Run multiple coding agents in parallel, each on its own branch.",
+      "description": "Braid combines Claude AI with Git worktrees so you can manage multiple tasks at once - without context switching.",
       "getStarted": "Get Started"
+    },
+    "theme": {
+      "title": "Make it feel like home",
+      "subtitle": "Pick the look you want to stare at for hours.",
+      "moreHint": "More themes available in Settings > Appearance."
+    },
+    "notifications": {
+      "title": "Set up notifications",
+      "subtitle": "Braid will notify you when agents are done or need help.",
+      "allowTitle": "Allow Braid in macOS",
+      "allowDesc": "Open System Settings and make sure Braid is allowed to send notifications.",
+      "openMacSettings": "Open Mac Settings",
+      "chooseSound": "Choose a sound",
+      "chooseSoundHint": "Pick the alert Braid plays after a desktop notification is delivered.",
+      "sound": "Notification Sound",
+      "sendTest": "Send Test Notification",
+      "testBody": "Notifications are working!"
+    },
+    "integrations": {
+      "title": "Connect your integrations",
+      "subtitle": "Connect GitHub or Jira to get the most out of Braid.",
+      "benefit1": "See issue state, PR review status, and CI checks on every worktree",
+      "benefit2": "Read, comment on, and merge pull requests without leaving Braid",
+      "benefit3": "Track Jira issues, sprints, and assignees alongside your code",
+      "gitDesc": "Version control for your code",
+      "ghDesc": "Pull requests, issues, and check status.",
+      "jiraDesc": "Issues, sprints, and assignees.",
+      "connected": "Connected",
+      "connect": "Connect",
+      "recheck": "Re-check"
     },
     "doctor": {
       "title": "Environment Check",
@@ -44,20 +102,39 @@
       "continueAnyway": "Continue anyway",
       "optional": "optional",
       "install": "Install",
-      "installing": "Installing…",
+      "installing": "Installing...",
       "openDocs": "Open docs",
       "logIn": "Log in",
-      "progressGit": "Installing Xcode tools…",
-      "progressClaude": "Installing Claude Code…",
-      "progressGh": "Installing GitHub CLI…",
-      "progressGhAuth": "Waiting for browser authentication…",
-      "progressAcli": "Installing Atlassian CLI…"
+      "progressGit": "Installing Xcode tools...",
+      "progressGh": "Installing GitHub CLI...",
+      "progressGhAuth": "Waiting for browser authentication...",
+      "progressAcli": "Installing Atlassian CLI..."
     },
     "project": {
-      "title": "Add Your First Project",
-      "subtitle": "Open a local Git repo or clone one from GitHub",
+      "title": "Point Braid at some code",
+      "subtitle": "Open a folder or clone a repo to get started.",
+      "openFolder": "Open a folder",
+      "openFolderDesc": "Choose any local directory, git repo or not.",
+      "browseBtn": "Browse...",
+      "workspace": "Workspace",
+      "cloneRepo": "Clone a repo",
+      "cloneRepoDesc": "Paste an HTTPS or SSH URL.",
+      "clone": "Clone",
+      "notARepo": "That folder is not a Git repository.",
+      "addError": "Could not add project.",
+      "cloneError": "Failed to clone repository.",
       "openProject": "Open Project",
       "skip": "Skip for now"
+    },
+    "explore": {
+      "title": "Explore Braid",
+      "subtitle": "Take a quick tour of what Braid can do.",
+      "feature1": "Run multiple AI agents on separate branches",
+      "feature2": "Review diffs, PRs, and CI checks in one place",
+      "feature3": "Built-in terminal for every worktree",
+      "feature4": "Mission Control kanban for cross-branch oversight",
+      "takeTour": "Take the tour",
+      "finish": "Get started"
     }
   },
   "ghAuth": {

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -79,7 +79,8 @@
       "chooseSoundHint": "Pick the alert Braid plays after a desktop notification is delivered.",
       "sound": "Notification Sound",
       "sendTest": "Send Test Notification",
-      "testBody": "Notifications are working!"
+      "testBody": "Notifications are working!",
+      "permissionRequired": "Enable notifications in System Settings, then try again."
     },
     "integrations": {
       "title": "Connect your integrations",

--- a/src/renderer/locales/id/common.json
+++ b/src/renderer/locales/id/common.json
@@ -30,11 +30,69 @@
   "toastErrorCount": "{{count}} sesi membutuhkan perhatian",
   "toastWaitingInputCount": "{{count}} sesi menunggu Anda",
   "onboarding": {
+    "of": "dari",
+    "back": "Kembali",
+    "continue": "Lanjutkan",
+    "skipSetup": "Lewati pengaturan",
+    "skipConfirm": {
+      "title": "Lewati onboarding?",
+      "desc": "Tidak akan lama! Anda bisa kembali dari Pengaturan kapan saja.",
+      "skip": "Lewati",
+      "keepGoing": "Tidak, lanjutkan"
+    },
+    "stepLabel": {
+      "welcome": "Selamat Datang",
+      "agent": "Agen",
+      "theme": "Tema",
+      "notifications": "Notifikasi",
+      "integrations": "Integrasi",
+      "project": "Proyek",
+      "explore": "Jelajahi"
+    },
+    "agent": {
+      "title": "Pilih agen default Anda",
+      "subtitle": "Braid bekerja dengan semua agen CLI. Pilih yang paling sering Anda gunakan. Bisa diganti kapan saja.",
+      "detected": "TERDETEKSI DI SISTEM ANDA  ·  {{count}}",
+      "showMore": "Tampilkan {{count}} agen lainnya→"
+    },
     "welcome": {
+      "eyebrow": "SELAMAT DATANG DI BRAID",
       "title": "Selamat Datang di Braid",
-      "subtitle": "Ruang kerja Git bertenaga AI",
-      "description": "Braid menggabungkan Claude AI dengan Git worktree sehingga Anda bisa menjalankan beberapa agen coding secara paralel — masing-masing di cabangnya sendiri.",
+      "story": "Braid menjalin beberapa agen AI coding dengan Git worktree - sehingga Anda bisa menjalankan tugas paralel di cabang terpisah, meninjau diff, mengelola PR, dan deploy lebih cepat, semua dari satu jendela.",
+      "chooseLang": "Pilih bahasa Anda",
+      "subtitle": "Jalankan beberapa agen coding secara paralel, masing-masing di cabangnya sendiri.",
+      "description": "Braid menggabungkan Claude AI dengan Git worktree sehingga Anda bisa mengelola beberapa tugas sekaligus - tanpa beralih konteks.",
       "getStarted": "Mulai"
+    },
+    "theme": {
+      "title": "Buat terasa seperti rumah",
+      "subtitle": "Pilih tampilan yang akan Anda lihat berjam-jam.",
+      "moreHint": "Tema lainnya tersedia di Pengaturan > Tampilan."
+    },
+    "notifications": {
+      "title": "Atur notifikasi",
+      "subtitle": "Braid akan memberi tahu Anda saat agen selesai atau butuh bantuan.",
+      "allowTitle": "Izinkan Braid di macOS",
+      "allowDesc": "Buka Pengaturan Sistem dan pastikan Braid diizinkan mengirim notifikasi.",
+      "openMacSettings": "Buka Pengaturan Mac",
+      "chooseSound": "Pilih suara",
+      "chooseSoundHint": "Pilih suara yang diputar setelah notifikasi desktop dikirim.",
+      "sound": "Suara Notifikasi",
+      "sendTest": "Kirim Notifikasi Tes",
+      "testBody": "Notifikasi berfungsi!"
+    },
+    "integrations": {
+      "title": "Hubungkan integrasi Anda",
+      "subtitle": "Hubungkan GitHub atau Jira untuk memaksimalkan Braid.",
+      "benefit1": "Lihat status issue, review PR, dan CI check di setiap worktree",
+      "benefit2": "Baca, komentari, dan merge pull request tanpa meninggalkan Braid",
+      "benefit3": "Lacak issue, sprint, dan assignee Jira bersama kode Anda",
+      "gitDesc": "Kontrol versi untuk kode Anda",
+      "ghDesc": "Pull request, issue, dan status check.",
+      "jiraDesc": "Issue, sprint, dan assignee.",
+      "connected": "Terhubung",
+      "connect": "Hubungkan",
+      "recheck": "Periksa ulang"
     },
     "doctor": {
       "title": "Pemeriksaan Lingkungan",
@@ -44,20 +102,39 @@
       "continueAnyway": "Lanjutkan saja",
       "optional": "opsional",
       "install": "Instal",
-      "installing": "Menginstal…",
+      "installing": "Menginstal...",
       "openDocs": "Buka docs",
       "logIn": "Masuk",
-      "progressGit": "Menginstal Xcode tools…",
-      "progressClaude": "Menginstal Claude Code…",
-      "progressGh": "Menginstal GitHub CLI…",
-      "progressGhAuth": "Menunggu autentikasi browser…",
-      "progressAcli": "Menginstal Atlassian CLI…"
+      "progressGit": "Menginstal Xcode tools...",
+      "progressGh": "Menginstal GitHub CLI...",
+      "progressGhAuth": "Menunggu autentikasi browser...",
+      "progressAcli": "Menginstal Atlassian CLI..."
     },
     "project": {
-      "title": "Tambahkan Proyek Pertama",
-      "subtitle": "Buka repo Git lokal atau klon dari GitHub",
+      "title": "Arahkan Braid ke kode",
+      "subtitle": "Buka folder atau klon repo untuk memulai.",
+      "openFolder": "Buka folder",
+      "openFolderDesc": "Pilih direktori lokal mana saja, repo git atau bukan.",
+      "browseBtn": "Telusuri...",
+      "workspace": "Ruang kerja",
+      "cloneRepo": "Klon repo",
+      "cloneRepoDesc": "Tempel URL HTTPS atau SSH.",
+      "clone": "Klon",
+      "notARepo": "Folder tersebut bukan repositori Git.",
+      "addError": "Tidak dapat menambahkan proyek.",
+      "cloneError": "Gagal mengklon repositori.",
       "openProject": "Buka Proyek",
       "skip": "Lewati untuk sekarang"
+    },
+    "explore": {
+      "title": "Jelajahi Braid",
+      "subtitle": "Ikuti tur singkat tentang apa yang bisa dilakukan Braid.",
+      "feature1": "Jalankan beberapa agen AI di cabang terpisah",
+      "feature2": "Tinjau diff, PR, dan CI check di satu tempat",
+      "feature3": "Terminal bawaan untuk setiap worktree",
+      "feature4": "Mission Control kanban untuk pengawasan lintas cabang",
+      "takeTour": "Ikuti tur",
+      "finish": "Mulai"
     }
   },
   "ghAuth": {

--- a/src/renderer/locales/id/common.json
+++ b/src/renderer/locales/id/common.json
@@ -79,7 +79,8 @@
       "chooseSoundHint": "Pilih suara yang diputar setelah notifikasi desktop dikirim.",
       "sound": "Suara Notifikasi",
       "sendTest": "Kirim Notifikasi Tes",
-      "testBody": "Notifikasi berfungsi!"
+      "testBody": "Notifikasi berfungsi!",
+      "permissionRequired": "Aktifkan notifikasi di Pengaturan Sistem, lalu coba lagi."
     },
     "integrations": {
       "title": "Hubungkan integrasi Anda",

--- a/src/renderer/locales/ja/common.json
+++ b/src/renderer/locales/ja/common.json
@@ -30,11 +30,69 @@
   "toastErrorCount": "{{count}}件のセッションで問題が発生",
   "toastWaitingInputCount": "{{count}}件のセッションがあなたの対応待ち",
   "onboarding": {
+    "of": "/",
+    "back": "戻る",
+    "continue": "続ける",
+    "skipSetup": "セットアップをスキップ",
+    "skipConfirm": {
+      "title": "セットアップをスキップしますか?",
+      "desc": "すぐ終わります! 設定からいつでもやり直せます。",
+      "skip": "スキップ",
+      "keepGoing": "続ける"
+    },
+    "stepLabel": {
+      "welcome": "ようこそ",
+      "agent": "エージェント",
+      "theme": "テーマ",
+      "notifications": "通知",
+      "integrations": "連携",
+      "project": "プロジェクト",
+      "explore": "探索"
+    },
+    "agent": {
+      "title": "デフォルトエージェントを選択",
+      "subtitle": "Braidはすべてのコーディングエージェントで動作します。最もよく使うものを選択してください。いつでも変更できます。",
+      "detected": "お使いのシステムで検出  ·  {{count}}",
+      "showMore": "さらに{{count}}個のエージェントを表示→"
+    },
     "welcome": {
+      "eyebrow": "BRAID へようこそ",
       "title": "Braidへようこそ",
-      "subtitle": "AIを活用したGitワークスペース",
-      "description": "BraidはClaude AIとGitワークツリーを組み合わせ、複数のコーディングエージェントを並列実行できます。",
+      "story": "Braidは複数のAIコーディングエージェントとGitワークツリーを組み合わせ、別々のブランチで並列タスクを実行し、差分の確認、PRの管理、そして素早いデプロイを一つのウィンドウから行えます。",
+      "chooseLang": "言語を選択",
+      "subtitle": "複数のコーディングエージェントを並列実行、それぞれ独自のブランチで。",
+      "description": "BraidはClaude AIとGitワークツリーを組み合わせ、コンテキスト切り替えなしで複数のタスクを同時に管理できます。",
       "getStarted": "はじめる"
+    },
+    "theme": {
+      "title": "自分好みにカスタマイズ",
+      "subtitle": "長時間見つめることになるテーマを選びましょう。",
+      "moreHint": "他のテーマは 設定 > 外観 から選べます。"
+    },
+    "notifications": {
+      "title": "通知を設定",
+      "subtitle": "エージェントの完了やヘルプが必要な場合にBraidがお知らせします。",
+      "allowTitle": "macOSでBraidを許可",
+      "allowDesc": "システム設定を開き、Braidが通知を送信できることを確認してください。",
+      "openMacSettings": "Mac設定を開く",
+      "chooseSound": "サウンドを選択",
+      "chooseSoundHint": "デスクトップ通知の後に再生されるアラート音を選択します。",
+      "sound": "通知音",
+      "sendTest": "テスト通知を送信",
+      "testBody": "通知が正常に動作しています！"
+    },
+    "integrations": {
+      "title": "インテグレーションを接続",
+      "subtitle": "GitHubやJiraを接続してBraidを最大限に活用しましょう。",
+      "benefit1": "各ワークツリーでIssueの状態、PRレビュー状況、CIチェックを確認",
+      "benefit2": "Braidを離れずにプルリクエストの閲覧、コメント、マージが可能",
+      "benefit3": "コードと一緒にJiraのIssue、スプリント、担当者を追跡",
+      "gitDesc": "コードのバージョン管理",
+      "ghDesc": "プルリクエスト、Issue、チェックステータス。",
+      "jiraDesc": "Issue、スプリント、担当者。",
+      "connected": "接続済み",
+      "connect": "接続",
+      "recheck": "再確認"
     },
     "doctor": {
       "title": "環境チェック",
@@ -48,16 +106,35 @@
       "openDocs": "ドキュメントを開く",
       "logIn": "ログイン",
       "progressGit": "Xcodeツールをインストール中…",
-      "progressClaude": "Claude Codeをインストール中…",
       "progressGh": "GitHub CLIをインストール中…",
       "progressGhAuth": "ブラウザ認証を待っています…",
       "progressAcli": "Atlassian CLIをインストール中…"
     },
     "project": {
-      "title": "最初のプロジェクトを追加",
-      "subtitle": "ローカルのGitリポジトリを開くか、GitHubからクローンしてください",
+      "title": "コードを指定",
+      "subtitle": "フォルダを開くか、リポジトリをクローンして始めましょう。",
+      "openFolder": "フォルダを開く",
+      "openFolderDesc": "ローカルディレクトリを選択。Gitリポジトリでなくても可。",
+      "browseBtn": "参照...",
+      "workspace": "ワークスペース",
+      "cloneRepo": "リポジトリをクローン",
+      "cloneRepoDesc": "HTTPSまたはSSH URLを貼り付け。",
+      "clone": "クローン",
+      "notARepo": "そのフォルダはGitリポジトリではありません。",
+      "addError": "プロジェクトを追加できませんでした。",
+      "cloneError": "リポジトリのクローンに失敗しました。",
       "openProject": "プロジェクトを開く",
       "skip": "後で追加する"
+    },
+    "explore": {
+      "title": "Braidを探索",
+      "subtitle": "Braidでできることのクイックツアーを体験しましょう。",
+      "feature1": "複数のAIエージェントを別々のブランチで実行",
+      "feature2": "差分、PR、CIチェックを一箇所で確認",
+      "feature3": "各ワークツリーに組み込みターミナル",
+      "feature4": "ミッションコントロールでブランチ横断管理",
+      "takeTour": "ツアーを開始",
+      "finish": "使い始める"
     }
   },
   "ghAuth": {

--- a/src/renderer/locales/ja/common.json
+++ b/src/renderer/locales/ja/common.json
@@ -79,7 +79,8 @@
       "chooseSoundHint": "デスクトップ通知の後に再生されるアラート音を選択します。",
       "sound": "通知音",
       "sendTest": "テスト通知を送信",
-      "testBody": "通知が正常に動作しています！"
+      "testBody": "通知が正常に動作しています！",
+      "permissionRequired": "システム設定で通知を有効にしてから、もう一度お試しください。"
     },
     "integrations": {
       "title": "インテグレーションを接続",

--- a/src/renderer/locales/zh/common.json
+++ b/src/renderer/locales/zh/common.json
@@ -30,11 +30,69 @@
   "toastErrorCount": "{{count}} 个会话需要关注",
   "toastWaitingInputCount": "{{count}} 个会话等待你的回复",
   "onboarding": {
+    "of": "/",
+    "back": "返回",
+    "continue": "继续",
+    "skipSetup": "跳过设置",
+    "skipConfirm": {
+      "title": "跳过引导?",
+      "desc": "不会花太长时间! 你可以随时在设置中重新开始。",
+      "skip": "跳过",
+      "keepGoing": "继续设置"
+    },
+    "stepLabel": {
+      "welcome": "欢迎",
+      "agent": "Agent",
+      "theme": "主题",
+      "notifications": "通知",
+      "integrations": "集成",
+      "project": "项目",
+      "explore": "探索"
+    },
+    "agent": {
+      "title": "选择默认 Agent",
+      "subtitle": "Braid 支持所有 CLI Agent，选择你最常用的，随时可以切换。",
+      "detected": "在你的系统中检测到  ·  {{count}}",
+      "showMore": "显示其他 {{count}} 个 Agent→"
+    },
     "welcome": {
+      "eyebrow": "欢迎使用 BRAID",
       "title": "欢迎使用 Braid",
-      "subtitle": "AI 驱动的 Git 工作区",
-      "description": "Braid 将 Claude AI 与 Git worktree 结合，让你可以并行运行多个编程 Agent，每个 Agent 都在独立的分支上工作。",
+      "story": "Braid 将多个 AI 编程 Agent 与 Git worktree 编织在一起 - 你可以在不同分支上并行执行任务、审查差异、管理 PR，并在同一个窗口中更快地交付代码。",
+      "chooseLang": "选择你的语言",
+      "subtitle": "并行运行多个编程 Agent，每个都在独立的分支上。",
+      "description": "Braid 将 Claude AI 与 Git worktree 结合，让你无需切换上下文就能同时管理多个任务。",
       "getStarted": "开始使用"
+    },
+    "theme": {
+      "title": "个性化定制",
+      "subtitle": "选择你将长时间注视的外观主题。",
+      "moreHint": "更多主题可在 设置 > 外观 中选择。"
+    },
+    "notifications": {
+      "title": "设置通知",
+      "subtitle": "当 Agent 完成任务或需要帮助时，Braid 会通知你。",
+      "allowTitle": "在 macOS 中允许 Braid",
+      "allowDesc": "打开系统设置，确保 Braid 被允许发送通知。",
+      "openMacSettings": "打开 Mac 设置",
+      "chooseSound": "选择提示音",
+      "chooseSoundHint": "选择桌面通知发送后播放的提示音。",
+      "sound": "通知声音",
+      "sendTest": "发送测试通知",
+      "testBody": "通知正常工作！"
+    },
+    "integrations": {
+      "title": "连接你的集成",
+      "subtitle": "连接 GitHub 或 Jira，充分利用 Braid。",
+      "benefit1": "在每个 worktree 上查看 Issue 状态、PR 审核状况和 CI 检查",
+      "benefit2": "无需离开 Braid 即可阅读、评论和合并 Pull Request",
+      "benefit3": "在代码旁追踪 Jira Issue、Sprint 和负责人",
+      "gitDesc": "代码版本控制",
+      "ghDesc": "Pull request、Issue 和检查状态。",
+      "jiraDesc": "Issue、Sprint 和负责人。",
+      "connected": "已连接",
+      "connect": "连接",
+      "recheck": "重新检查"
     },
     "doctor": {
       "title": "环境检查",
@@ -44,20 +102,39 @@
       "continueAnyway": "仍然继续",
       "optional": "可选",
       "install": "安装",
-      "installing": "安装中…",
+      "installing": "安装中...",
       "openDocs": "查看文档",
       "logIn": "登录",
-      "progressGit": "正在安装 Xcode 工具…",
-      "progressClaude": "正在安装 Claude Code…",
-      "progressGh": "正在安装 GitHub CLI…",
-      "progressGhAuth": "等待浏览器认证…",
-      "progressAcli": "正在安装 Atlassian CLI…"
+      "progressGit": "正在安装 Xcode 工具...",
+      "progressGh": "正在安装 GitHub CLI...",
+      "progressGhAuth": "等待浏览器认证...",
+      "progressAcli": "正在安装 Atlassian CLI..."
     },
     "project": {
-      "title": "添加你的第一个项目",
-      "subtitle": "打开本地 Git 仓库或从 GitHub 克隆",
+      "title": "将 Braid 指向代码",
+      "subtitle": "打开文件夹或克隆仓库以开始。",
+      "openFolder": "打开文件夹",
+      "openFolderDesc": "选择任意本地目录，Git 仓库与否均可。",
+      "browseBtn": "浏览...",
+      "workspace": "工作区",
+      "cloneRepo": "克隆仓库",
+      "cloneRepoDesc": "粘贴 HTTPS 或 SSH URL。",
+      "clone": "克隆",
+      "notARepo": "该文件夹不是 Git 仓库。",
+      "addError": "无法添加项目。",
+      "cloneError": "克隆仓库失败。",
       "openProject": "打开项目",
       "skip": "稍后再说"
+    },
+    "explore": {
+      "title": "探索 Braid",
+      "subtitle": "快速了解 Braid 能做什么。",
+      "feature1": "在不同分支上运行多个 AI Agent",
+      "feature2": "在一个地方查看差异、PR 和 CI 检查",
+      "feature3": "每个 worktree 都有内置终端",
+      "feature4": "Mission Control 看板实现跨分支监管",
+      "takeTour": "开始导览",
+      "finish": "开始使用"
     }
   },
   "ghAuth": {

--- a/src/renderer/locales/zh/common.json
+++ b/src/renderer/locales/zh/common.json
@@ -79,7 +79,8 @@
       "chooseSoundHint": "选择桌面通知发送后播放的提示音。",
       "sound": "通知声音",
       "sendTest": "发送测试通知",
-      "testBody": "通知正常工作！"
+      "testBody": "通知正常工作！",
+      "permissionRequired": "请先在系统设置中启用通知，然后重试。"
     },
     "integrations": {
       "title": "连接你的集成",

--- a/src/renderer/store/ui/settings.ts
+++ b/src/renderer/store/ui/settings.ts
@@ -8,6 +8,7 @@ import { loadStr, loadBool, loadInt, loadFloat } from './helpers'
 const VALID_MODEL_IDS: readonly string[] = ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-opus-4-6', 'claude-haiku-4-5-20251001']
 const VALID_EFFORT_LEVELS = new Set<string>(EFFORT_LEVELS.map((l) => l.id))
 const DEFAULT_MODEL: ModelId = 'claude-sonnet-4-6'
+const DEFAULT_AGENT_ID = 'claude'
 function isValidNewTabAction(v: string): boolean {
   if (v === 'chat' || v === 'claudeCode' || v === 'terminal') return true
   return /^agent:[a-zA-Z0-9-]+$/.test(v)
@@ -46,6 +47,7 @@ export interface SettingsSlice {
   commandPaletteOpen: boolean
 
   // AI
+  defaultAgentId: string
   defaultModel: ModelId
   defaultThinking: boolean
   defaultExtendedContext: boolean
@@ -106,6 +108,7 @@ export interface SettingsSlice {
   closeQuickOpen: () => void
   openCommandPalette: () => void
   closeCommandPalette: () => void
+  setDefaultAgentId: (id: string) => void
   setDefaultModel: (model: ModelId) => void
   setDefaultThinking: (v: boolean) => void
   setDefaultExtendedContext: (v: boolean) => void
@@ -149,6 +152,7 @@ export const createSettingsSlice: StateCreator<UIState, [], [], SettingsSlice> =
   quickOpenOpen: false,
   commandPaletteOpen: false,
 
+  defaultAgentId: loadStr(SK.defaultAgentId, DEFAULT_AGENT_ID),
   defaultModel: loadDefaultModel(),
   defaultThinking: loadBool(SK.defaultThinking, false),
   defaultExtendedContext: loadBool(SK.defaultExtendedContext, false),
@@ -228,6 +232,10 @@ export const createSettingsSlice: StateCreator<UIState, [], [], SettingsSlice> =
   openCommandPalette: () => set({ commandPaletteOpen: true }),
   closeCommandPalette: () => set({ commandPaletteOpen: false }),
 
+  setDefaultAgentId: (id) => {
+    localStorage.setItem(SK.defaultAgentId, id)
+    set({ defaultAgentId: id })
+  },
   setDefaultModel: (model) => {
     localStorage.setItem(SK.defaultModel, model)
     set({ defaultModel: model })

--- a/src/renderer/styles/onboarding.css
+++ b/src/renderer/styles/onboarding.css
@@ -376,7 +376,7 @@
 .ob-kbd {
   display: inline-flex;
   align-items: center;
-  font-family: var(--font-system);
+  font-family: var(--font-sans, system-ui);
   font-size: var(--text-xs);
   color: inherit;
   opacity: 0.5;

--- a/src/renderer/styles/onboarding.css
+++ b/src/renderer/styles/onboarding.css
@@ -1,4 +1,4 @@
-/* ── Onboarding Overlay (centered card, card layout) ───────────────────── */
+/* Onboarding overlay */
 
 .ob-overlay {
   position: fixed;
@@ -7,8 +7,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--overlay-backdrop, rgba(0, 0, 0, 0.55));
-  backdrop-filter: blur(6px);
+  padding: var(--space-24);
+  background: rgba(0, 0, 0, 0.58);
   -webkit-app-region: no-drag;
   animation: ob-fade-in var(--duration-slow) ease-out;
 }
@@ -18,50 +18,200 @@
   to { opacity: 1; }
 }
 
-/* ── Layout card ──────────────────────────────────────────────────────── */
+@keyframes ob-step-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ob-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Two-pane shell */
 
 .ob-layout {
   display: flex;
-  flex-direction: column;
-  width: 94vw;
-  max-width: 920px;
-  height: 88vh;
-  max-height: 680px;
+  width: min(96vw, 1040px);
+  height: min(86vh, 720px);
+  min-height: min(560px, calc(100vh - 48px));
   background: var(--bg-primary);
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-elevation-2xl);
-  padding: var(--space-28) var(--space-32);
   overflow: hidden;
 }
 
-.ob-layout-header {
-  flex-shrink: 0;
+.ob-sidebar {
+  position: relative;
+  flex: 0 0 258px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-28);
+  padding: var(--space-28) var(--space-24);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--accent) 8%, transparent), transparent 42%),
+    var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  -webkit-app-region: drag;
 }
 
-/* ── Brand ────────────────────────────────────────────────────────────── */
+.ob-sidebar::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  top: var(--space-24);
+  bottom: var(--space-24);
+  width: 1px;
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+}
 
 .ob-brand {
   display: flex;
   align-items: center;
-  gap: var(--space-8);
+  gap: var(--space-10);
   color: var(--text-primary);
+}
+
+.ob-brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.ob-brand-logo {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .ob-brand-name {
   font-size: var(--text-lg);
   font-weight: var(--weight-semibold);
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
 }
 
-/* ── Progress bar ─────────────────────────────────────────────────────── */
+.ob-rail-summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
 
-.ob-progress-row {
+.ob-rail-kicker {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0;
+  color: var(--text-muted);
+}
+
+.ob-rail-counter {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.ob-step-rail {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.ob-step-rail::before {
+  content: '';
+  position: absolute;
+  left: 13px;
+  top: 20px;
+  bottom: 20px;
+  width: 2px;
+  background: var(--border);
+  border-radius: var(--radius-pill);
+}
+
+.ob-rail-step {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: var(--space-12);
-  margin-top: var(--space-20);
+  gap: var(--space-10);
+  min-height: 38px;
+  color: var(--text-muted);
+}
+
+.ob-rail-node {
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
   flex-shrink: 0;
+  color: var(--text-muted);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums;
+}
+
+.ob-rail-label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+}
+
+.ob-rail-step--done .ob-rail-node,
+.ob-rail-step--active .ob-rail-node {
+  color: var(--bg-primary);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.ob-rail-step--done,
+.ob-rail-step--active {
+  color: var(--text-primary);
+}
+
+.ob-rail-step--active .ob-rail-label {
+  font-weight: var(--weight-semibold);
+}
+
+.ob-panel {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+}
+
+.ob-mobile-progress {
+  display: none;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--space-12);
+  padding: var(--space-16) var(--space-20) 0;
 }
 
 .ob-progress-bar {
@@ -93,21 +243,20 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* ── Content area ─────────────────────────────────────────────────────── */
-
 .ob-content {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
-  padding-top: var(--space-28);
-  padding-right: var(--space-4);
+  scrollbar-gutter: stable;
+  padding: var(--space-36, 36px) var(--space-40, 40px) var(--space-24);
 }
-
-/* ── Step container ───────────────────────────────────────────────────── */
 
 .ob-step {
   display: flex;
   flex-direction: column;
   gap: var(--space-14);
+  max-width: 660px;
+  animation: ob-step-in var(--duration-normal) ease-out;
 }
 
 .ob-step--welcome {
@@ -115,89 +264,38 @@
 }
 
 .ob-welcome-brand {
-  color: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
   margin-bottom: var(--space-4);
+}
+
+.ob-welcome-logo {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .ob-welcome-story {
   font-size: var(--text-md);
   color: var(--text-muted);
   line-height: var(--leading-relaxed);
-  max-width: 520px;
+  max-width: 560px;
   margin: 0;
-}
-
-/* ── Language picker ──────────────────────────────────────────────────── */
-
-.ob-lang-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-10);
-  margin-top: var(--space-8);
-}
-
-.ob-lang-label {
-  font-size: var(--text-sm);
-  font-weight: var(--weight-medium);
-  color: var(--text-secondary);
-}
-
-.ob-lang-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: var(--space-8);
-}
-
-.ob-lang-card {
-  all: unset;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-12) var(--space-10);
-  background: var(--bg-secondary);
-  border: 2px solid var(--border);
-  border-radius: var(--radius-lg);
-  transition: border-color var(--duration-normal);
-  text-align: center;
-}
-
-.ob-lang-card:hover {
-  border-color: var(--text-muted);
-}
-
-.ob-lang-card--active {
-  border-color: var(--accent);
-}
-
-.ob-lang-card:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.ob-lang-native {
-  font-size: var(--text-md);
-  font-weight: var(--weight-medium);
-  color: var(--text-primary);
-}
-
-.ob-lang-english {
-  font-size: var(--text-xs);
-  color: var(--text-muted);
 }
 
 .ob-eyebrow {
   font-size: var(--text-xs);
   font-weight: var(--weight-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0;
   color: var(--text-muted);
-}
-
-.ob-welcome-icon {
-  color: var(--accent);
-  margin-bottom: var(--space-4);
 }
 
 .ob-heading {
@@ -206,6 +304,7 @@
   color: var(--text-primary);
   margin: 0;
   line-height: var(--leading-tight);
+  letter-spacing: 0;
 }
 
 .ob-subtitle {
@@ -213,7 +312,7 @@
   color: var(--text-secondary);
   margin: 0;
   line-height: var(--leading-relaxed);
-  max-width: 520px;
+  max-width: 560px;
 }
 
 .ob-description {
@@ -221,7 +320,7 @@
   color: var(--text-muted);
   margin: 0;
   line-height: var(--leading-relaxed);
-  max-width: 480px;
+  max-width: 520px;
 }
 
 .ob-hint {
@@ -236,26 +335,26 @@
   margin: 0;
 }
 
-/* ── Footer / navigation ──────────────────────────────────────────────── */
+/* Footer */
 
 .ob-footer {
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-top: var(--space-16);
+  gap: var(--space-16);
+  padding: var(--space-16) var(--space-40, 40px);
   border-top: 1px solid var(--border);
-  margin-top: var(--space-12);
+  background: color-mix(in srgb, var(--bg-primary) 92%, var(--bg-secondary));
 }
 
-.ob-footer-left {
+.ob-footer-left,
+.ob-footer-right {
   display: flex;
   align-items: center;
 }
 
 .ob-footer-right {
-  display: flex;
-  align-items: center;
   gap: var(--space-8);
 }
 
@@ -264,13 +363,14 @@
   font-size: var(--text-sm);
   color: var(--text-muted);
   cursor: pointer;
-  padding: var(--space-4) var(--space-8);
+  padding: var(--space-6) var(--space-8);
   border-radius: var(--radius);
-  transition: color var(--duration-fast);
+  transition: color var(--duration-fast), background var(--duration-fast);
 }
 
 .ob-skip-link:hover {
   color: var(--text-secondary);
+  background: var(--bg-hover);
 }
 
 .ob-kbd {
@@ -284,17 +384,96 @@
   pointer-events: none;
 }
 
-/* ── Agent picker cards ───────────────────────────────────────────────── */
+/* Language picker */
+
+.ob-lang-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-10);
+  margin-top: var(--space-8);
+  width: 100%;
+}
+
+.ob-lang-label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+}
+
+.ob-lang-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-8);
+}
+
+.ob-lang-card {
+  all: unset;
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 58px;
+  padding: var(--space-12) var(--space-10);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  transition:
+    border-color var(--duration-fast),
+    background var(--duration-fast),
+    transform var(--duration-fast);
+  text-align: center;
+}
+
+.ob-lang-card:hover {
+  border-color: color-mix(in srgb, var(--accent) 36%, var(--border));
+  background: var(--bg-hover);
+}
+
+.ob-lang-card--active {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-secondary));
+}
+
+.ob-lang-card--active::before {
+  content: '';
+  position: absolute;
+  left: var(--space-8);
+  right: var(--space-8);
+  bottom: 0;
+  height: 3px;
+  background: var(--accent);
+  border-radius: var(--radius-pill) var(--radius-pill) 0 0;
+}
+
+.ob-lang-native {
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+}
+
+.ob-lang-english {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+/* Agent picker */
 
 .ob-detected-label {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: var(--space-6);
+  width: fit-content;
+  padding: var(--space-4) var(--space-10);
   font-size: var(--text-xs);
   font-weight: var(--weight-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
+  letter-spacing: 0;
+  color: var(--green);
+  background: color-mix(in srgb, var(--green) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--green) 22%, transparent);
+  border-radius: var(--radius-pill);
 }
 
 .ob-detected-dot {
@@ -306,7 +485,7 @@
 
 .ob-agent-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: var(--space-10);
 }
 
@@ -317,36 +496,62 @@
   display: flex;
   align-items: center;
   gap: var(--space-10);
+  min-height: 54px;
   padding: var(--space-12) var(--space-14);
   background: var(--bg-secondary);
-  border: 2px solid var(--border);
+  border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  transition: border-color var(--duration-normal);
+  overflow: hidden;
+  transition:
+    border-color var(--duration-fast),
+    background var(--duration-fast),
+    transform var(--duration-fast);
+}
+
+.ob-agent-card::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: var(--space-10);
+  bottom: var(--space-10);
+  width: 3px;
+  background: transparent;
+  border-radius: 0 var(--radius-pill) var(--radius-pill) 0;
 }
 
 .ob-agent-card:hover {
-  border-color: var(--text-muted);
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
+  background: var(--bg-hover);
 }
 
 .ob-agent-card--active {
   border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-secondary));
+}
+
+.ob-agent-card--active::before {
+  background: var(--accent);
 }
 
 .ob-agent-check {
   position: absolute;
   top: var(--space-6);
   right: var(--space-6);
+  display: inline-flex;
   color: var(--accent);
 }
 
 .ob-agent-icon {
   flex-shrink: 0;
-  width: 28px;
-  height: 28px;
+  width: 30px;
+  height: 30px;
   display: flex;
   align-items: center;
   justify-content: center;
   color: var(--text-secondary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
 }
 
 .ob-agent-info {
@@ -360,34 +565,44 @@
   font-size: var(--text-md);
   font-weight: var(--weight-medium);
   color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ob-agent-cmd {
   font-size: var(--text-xs);
   color: var(--text-muted);
   font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ob-show-more {
   all: unset;
   cursor: pointer;
   font-size: var(--text-sm);
-  color: var(--text-muted);
+  font-weight: var(--weight-medium);
+  color: var(--accent);
   display: inline-flex;
   align-items: center;
   gap: var(--space-4);
-  transition: color var(--duration-fast);
+  width: fit-content;
+  padding: var(--space-8) var(--space-10);
+  border-radius: var(--radius);
+  transition: background var(--duration-fast), color var(--duration-fast);
 }
 
 .ob-show-more:hover {
-  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
-/* ── Theme cards ──────────────────────────────────────────────────────── */
+/* Theme picker */
 
 .ob-theme-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: var(--space-12);
   margin-top: var(--space-4);
 }
@@ -396,18 +611,23 @@
   all: unset;
   cursor: pointer;
   position: relative;
-  border: 2px solid var(--border);
+  border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   overflow: hidden;
-  transition: border-color var(--duration-normal);
+  background: var(--bg-secondary);
+  transition:
+    border-color var(--duration-fast),
+    transform var(--duration-fast),
+    box-shadow var(--duration-fast);
 }
 
 .ob-theme-card:hover {
-  border-color: var(--text-muted);
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
 }
 
 .ob-theme-card--active {
   border-color: var(--accent);
+  box-shadow: inset 0 -3px 0 var(--accent);
 }
 
 .ob-theme-check {
@@ -415,8 +635,8 @@
   top: var(--space-8);
   right: var(--space-8);
   z-index: 2;
-  color: var(--accent);
-  background: var(--bg-primary);
+  color: var(--bg-primary);
+  background: var(--accent);
   border-radius: var(--radius-full);
   width: 22px;
   height: 22px;
@@ -426,7 +646,7 @@
 }
 
 .ob-theme-preview {
-  height: 110px;
+  height: 118px;
   display: flex;
   overflow: hidden;
 }
@@ -476,7 +696,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--space-8) var(--space-10);
+  gap: var(--space-8);
+  padding: var(--space-10) var(--space-12);
 }
 
 .ob-theme-card-name {
@@ -490,7 +711,7 @@
   color: var(--text-muted);
 }
 
-/* ── Notification step (card layout) ───────────────────────────────────── */
+/* Notifications */
 
 .ob-notif-permission {
   display: flex;
@@ -504,12 +725,15 @@
 
 .ob-notif-permission-icon {
   flex-shrink: 0;
-  width: 36px;
-  height: 36px;
+  width: 38px;
+  height: 38px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-muted);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  border-radius: var(--radius-lg);
 }
 
 .ob-notif-permission-body {
@@ -517,6 +741,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  min-width: 0;
 }
 
 .ob-notif-permission-title {
@@ -534,6 +759,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-8);
+  padding-top: var(--space-4);
 }
 
 .ob-notif-sound-heading {
@@ -559,6 +785,10 @@
   display: flex;
   align-items: center;
   gap: var(--space-8);
+  padding: var(--space-8) var(--space-10);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
 }
 
 .ob-notif-sound-label {
@@ -566,7 +796,7 @@
   color: var(--text-primary);
 }
 
-/* ── Card group (generic) ─────────────────────────────────────────────── */
+/* Generic rows */
 
 .ob-card-group {
   display: flex;
@@ -612,18 +842,25 @@
   background: var(--border);
 }
 
-/* ── Integration cards (card layout) ───────────────────────────────────── */
+/* Integrations */
 
 .ob-int-benefits {
-  list-style: disc;
-  padding-left: var(--space-20);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-8);
+  padding: 0;
+  margin: var(--space-2) 0 var(--space-2);
+  list-style: none;
+}
+
+.ob-int-benefits li {
+  padding: var(--space-10) var(--space-12);
   color: var(--text-muted);
-  font-size: var(--text-md);
+  font-size: var(--text-sm);
   line-height: var(--leading-relaxed);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-6);
-  margin: 0;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
 }
 
 .ob-int-list {
@@ -636,7 +873,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-14);
-  padding: var(--space-16) var(--space-20);
+  padding: var(--space-14) var(--space-16);
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -649,8 +886,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--bg-hover);
-  border-radius: var(--radius);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
   color: var(--text-secondary);
 }
 
@@ -725,7 +963,7 @@
   padding: var(--space-12) var(--space-16);
 }
 
-/* ── Project step ─────────────────────────────────────────────────────── */
+/* Project step */
 
 .ob-project-cards {
   display: flex;
@@ -754,7 +992,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--bg-hover);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   color: var(--text-secondary);
 }
@@ -764,6 +1003,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  min-width: 0;
 }
 
 .ob-action-card-title {
@@ -785,6 +1025,7 @@
 
 .ob-clone-input {
   flex: 1;
+  min-width: 0;
   background: var(--bg-primary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -807,40 +1048,176 @@
   display: flex;
   align-items: center;
   gap: var(--space-6);
+  min-width: 0;
   font-size: var(--text-sm);
 }
 
 .ob-workspace-path-label {
+  flex-shrink: 0;
   color: var(--text-muted);
 }
 
 .ob-workspace-path-value {
   color: var(--text-secondary);
   font-family: var(--font-mono);
+  overflow-wrap: anywhere;
 }
 
-/* ── Explore step ─────────────────────────────────────────────────────── */
+/* Explore step */
 
-.ob-explore-preview {
+.ob-product-preview {
+  overflow: hidden;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: var(--space-20) var(--space-24);
+  border-radius: var(--radius-xl);
+  margin-top: var(--space-4);
+}
+
+.ob-product-topbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  padding: var(--space-10) var(--space-14);
+  border-bottom: 1px solid var(--border);
+}
+
+.ob-product-window-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--text-muted);
+  opacity: 0.55;
+}
+
+.ob-product-title {
+  margin-left: var(--space-8);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--text-secondary);
+}
+
+.ob-product-body {
+  display: grid;
+  grid-template-columns: 190px 1fr;
+  min-height: 178px;
+}
+
+.ob-product-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  padding: var(--space-16);
+  border-right: 1px solid var(--border);
+}
+
+.ob-product-pill {
+  display: block;
+  padding: var(--space-8) var(--space-10);
+  color: var(--text-muted);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ob-product-pill--active {
+  color: var(--text-primary);
+  border-color: color-mix(in srgb, var(--accent) 36%, var(--border));
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.ob-product-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.ob-product-tabs {
+  display: flex;
+  gap: var(--space-6);
+  padding: var(--space-12) var(--space-14);
+  border-bottom: 1px solid var(--border);
+}
+
+.ob-product-tab {
+  padding: var(--space-6) var(--space-10);
+  color: var(--text-muted);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+}
+
+.ob-product-tab--active {
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
+
+.ob-product-grid {
+  display: grid;
+  grid-template-columns: 1fr 120px;
+  gap: var(--space-12);
+  padding: var(--space-18, 18px) var(--space-16);
+}
+
+.ob-product-line {
+  display: block;
+  height: 10px;
+  background: color-mix(in srgb, var(--text-muted) 22%, transparent);
+  border-radius: var(--radius-pill);
+}
+
+.ob-product-line--wide {
+  grid-column: 1 / -1;
+}
+
+.ob-product-line--short {
+  width: 62%;
+}
+
+.ob-product-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 0 var(--space-10);
+  color: var(--green);
+  background: color-mix(in srgb, var(--green) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--green) 22%, transparent);
+  border-radius: var(--radius);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+}
+
+.ob-explore-preview {
+  background: transparent;
+  border: 0;
+  padding: 0;
   margin-top: var(--space-4);
 }
 
 .ob-explore-feature-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-12);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-10);
 }
 
 .ob-explore-feature {
   display: flex;
   align-items: center;
   gap: var(--space-10);
-  font-size: var(--text-md);
+  min-width: 0;
+  padding: var(--space-10) var(--space-12);
+  font-size: var(--text-sm);
   color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
 }
 
 .ob-explore-feature-dot {
@@ -860,18 +1237,19 @@
   font-weight: var(--weight-medium);
   color: var(--accent);
   cursor: pointer;
-  padding: var(--space-8) var(--space-16);
-  border: 1px solid var(--border);
+  padding: var(--space-8) var(--space-14);
+  border: 1px solid color-mix(in srgb, var(--accent) 34%, var(--border));
   border-radius: var(--radius);
-  transition: border-color var(--duration-fast);
+  transition: background var(--duration-fast), border-color var(--duration-fast);
   align-self: flex-start;
 }
 
 .ob-tour-btn:hover {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
   border-color: var(--accent);
 }
 
-/* ── Skip confirmation dialog ─────────────────────────────────────────── */
+/* Skip confirmation dialog */
 
 .ob-skip-dialog-backdrop {
   position: fixed;
@@ -880,7 +1258,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.35);
+  padding: var(--space-20);
+  background: rgba(0, 0, 0, 0.42);
   animation: ob-fade-in var(--duration-fast) ease-out;
 }
 
@@ -890,8 +1269,8 @@
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-elevation-2xl);
   padding: var(--space-24) var(--space-28);
-  max-width: 360px;
-  width: 90%;
+  max-width: 380px;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: var(--space-12);
@@ -917,29 +1296,185 @@
   margin-top: var(--space-4);
 }
 
-/* ── Focus & accessibility ────────────────────────────────────────────── */
+/* Focus and motion */
 
-.ob-agent-card:focus-visible,
-.ob-theme-card:focus-visible {
+.ob-layout button:focus-visible,
+.ob-skip-dialog button:focus-visible,
+.ob-clone-input:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
-/* ── Reduced motion ───────────────────────────────────────────────────── */
-
 @media (prefers-reduced-motion: reduce) {
   .ob-overlay,
   .ob-skip-dialog-backdrop,
+  .ob-step,
   .ob-progress-segment,
   .ob-theme-card,
-  .ob-agent-card {
+  .ob-agent-card,
+  .ob-lang-card,
+  .ob-tour-btn,
+  .ob-show-more {
     animation: none !important;
     transition: none !important;
   }
 }
 
-/* ── macOS drag region ────────────────────────────────────────────────── */
+/* Responsive */
 
-.ob-layout-header {
-  -webkit-app-region: drag;
+@media (max-width: 900px) {
+  .ob-layout {
+    width: min(96vw, 900px);
+  }
+
+  .ob-sidebar {
+    flex-basis: 226px;
+    padding: var(--space-24) var(--space-20);
+  }
+
+  .ob-content {
+    padding: var(--space-28) var(--space-28) var(--space-20);
+  }
+
+  .ob-footer {
+    padding-inline: var(--space-28);
+  }
+
+  .ob-agent-grid,
+  .ob-theme-grid,
+  .ob-int-benefits {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ob-lang-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .ob-overlay {
+    padding: var(--space-12);
+    align-items: stretch;
+  }
+
+  .ob-layout {
+    width: 100%;
+    height: calc(100vh - 24px);
+    min-height: 0;
+    max-height: 760px;
+  }
+
+  .ob-sidebar {
+    display: none;
+  }
+
+  .ob-panel {
+    min-height: 0;
+  }
+
+  .ob-mobile-progress {
+    display: flex;
+  }
+
+  .ob-content {
+    padding: var(--space-24) var(--space-20) var(--space-20);
+  }
+
+  .ob-heading {
+    font-size: var(--text-3xl, 30px);
+  }
+
+  .ob-subtitle {
+    font-size: var(--text-md);
+  }
+
+  .ob-footer {
+    padding: var(--space-14) var(--space-20);
+  }
+
+  .ob-notif-permission,
+  .ob-int-card,
+  .ob-project-card-row {
+    align-items: flex-start;
+  }
+
+  .ob-int-card-actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .ob-product-body {
+    grid-template-columns: 1fr;
+  }
+
+  .ob-product-sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+}
+
+@media (max-width: 560px) {
+  .ob-overlay {
+    padding: var(--space-8);
+  }
+
+  .ob-layout {
+    height: calc(100vh - 16px);
+    max-height: calc(100vh - 16px);
+    border-radius: var(--radius-lg);
+  }
+
+  .ob-content {
+    padding: var(--space-20) var(--space-16) var(--space-16);
+  }
+
+  .ob-heading {
+    font-size: var(--text-2xl, 24px);
+  }
+
+  .ob-lang-grid,
+  .ob-agent-grid,
+  .ob-theme-grid,
+  .ob-int-benefits,
+  .ob-explore-feature-list {
+    grid-template-columns: 1fr;
+  }
+
+  .ob-notif-permission,
+  .ob-project-card-row {
+    flex-direction: column;
+  }
+
+  .ob-notif-sound-row,
+  .ob-clone-input-row,
+  .ob-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .ob-footer-left,
+  .ob-footer-right {
+    justify-content: stretch;
+  }
+
+  .ob-footer-right > *,
+  .ob-footer .btn,
+  .ob-clone-input-row .btn,
+  .ob-notif-permission .btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .ob-skip-link {
+    text-align: center;
+  }
+
+  .ob-workspace-path {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .ob-skip-dialog-actions {
+    flex-direction: column-reverse;
+  }
 }

--- a/src/renderer/styles/onboarding.css
+++ b/src/renderer/styles/onboarding.css
@@ -1,69 +1,206 @@
-/* ── Onboarding Overlay ────────────────────────────────────────────────── */
+/* ── Onboarding Overlay (centered card, card layout) ───────────────────── */
 
-.onboarding-overlay {
+.ob-overlay {
   position: fixed;
   inset: 0;
   z-index: var(--z-modal);
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--overlay-backdrop, rgba(0, 0, 0, 0.6));
-  backdrop-filter: blur(4px);
+  background: var(--overlay-backdrop, rgba(0, 0, 0, 0.55));
+  backdrop-filter: blur(6px);
   -webkit-app-region: no-drag;
+  animation: ob-fade-in var(--duration-slow) ease-out;
 }
 
-.onboarding-card {
+@keyframes ob-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ── Layout card ──────────────────────────────────────────────────────── */
+
+.ob-layout {
+  display: flex;
+  flex-direction: column;
+  width: 94vw;
+  max-width: 920px;
+  height: 88vh;
+  max-height: 680px;
   background: var(--bg-primary);
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-elevation-2xl);
-  width: 100%;
-  max-width: 480px;
-  padding: var(--space-40) var(--space-40) var(--space-32);
+  padding: var(--space-28) var(--space-32);
+  overflow: hidden;
+}
+
+.ob-layout-header {
+  flex-shrink: 0;
+}
+
+/* ── Brand ────────────────────────────────────────────────────────────── */
+
+.ob-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  color: var(--text-primary);
+}
+
+.ob-brand-name {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  letter-spacing: -0.01em;
+}
+
+/* ── Progress bar ─────────────────────────────────────────────────────── */
+
+.ob-progress-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-12);
+  margin-top: var(--space-20);
+  flex-shrink: 0;
+}
+
+.ob-progress-bar {
+  display: flex;
+  gap: var(--space-4);
+  flex: 1;
+}
+
+.ob-progress-segment {
+  height: 3px;
+  flex: 1;
+  border-radius: var(--radius-pill);
+  background: var(--border);
+  transition: background var(--duration-normal);
+}
+
+.ob-progress-segment--done {
+  background: var(--accent);
+}
+
+.ob-progress-segment--active {
+  background: var(--text-primary);
+}
+
+.ob-progress-counter {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Content area ─────────────────────────────────────────────────────── */
+
+.ob-content {
+  flex: 1;
+  overflow-y: auto;
+  padding-top: var(--space-28);
+  padding-right: var(--space-4);
+}
+
+/* ── Step container ───────────────────────────────────────────────────── */
+
+.ob-step {
   display: flex;
   flex-direction: column;
-  gap: var(--space-0);
+  gap: var(--space-14);
 }
 
-/* ── Step dots ─────────────────────────────────────────────────────────── */
+.ob-step--welcome {
+  align-items: flex-start;
+}
 
-.onboarding-step-dots {
+.ob-welcome-brand {
+  color: var(--accent);
+  margin-bottom: var(--space-4);
+}
+
+.ob-welcome-story {
+  font-size: var(--text-md);
+  color: var(--text-muted);
+  line-height: var(--leading-relaxed);
+  max-width: 520px;
+  margin: 0;
+}
+
+/* ── Language picker ──────────────────────────────────────────────────── */
+
+.ob-lang-section {
   display: flex;
-  gap: var(--space-6);
-  justify-content: center;
-  margin-bottom: var(--space-32);
+  flex-direction: column;
+  gap: var(--space-10);
+  margin-top: var(--space-8);
 }
 
-.onboarding-step-dot {
-  width: var(--space-6);
-  height: var(--space-6);
-  border-radius: var(--radius-full);
-  background: var(--border);
-  transition: background var(--duration-normal), width var(--duration-normal);
+.ob-lang-label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
 }
 
-.onboarding-step-dot--active {
-  background: var(--accent);
-  width: var(--space-16);
-  border-radius: var(--radius-pill);
+.ob-lang-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-8);
 }
 
-/* ── Step container ────────────────────────────────────────────────────── */
-
-.onboarding-step {
+.ob-lang-card {
+  all: unset;
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-12) var(--space-10);
+  background: var(--bg-secondary);
+  border: 2px solid var(--border);
+  border-radius: var(--radius-lg);
+  transition: border-color var(--duration-normal);
   text-align: center;
-  gap: var(--space-16);
 }
 
-.onboarding-welcome-icon {
+.ob-lang-card:hover {
+  border-color: var(--text-muted);
+}
+
+.ob-lang-card--active {
+  border-color: var(--accent);
+}
+
+.ob-lang-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.ob-lang-native {
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+}
+
+.ob-lang-english {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.ob-eyebrow {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.ob-welcome-icon {
   color: var(--accent);
-  margin-bottom: var(--space-8);
+  margin-bottom: var(--space-4);
 }
 
-.onboarding-title {
+.ob-heading {
   font-size: var(--text-4xl);
   font-weight: var(--weight-bold);
   color: var(--text-primary);
@@ -71,194 +208,58 @@
   line-height: var(--leading-tight);
 }
 
-.onboarding-subtitle {
+.ob-subtitle {
   font-size: var(--text-lg);
-  font-weight: var(--weight-medium);
-  color: var(--text-primary);
-  margin: 0;
-}
-
-.onboarding-description {
-  font-size: var(--text-md);
   color: var(--text-secondary);
+  margin: 0;
   line-height: var(--leading-relaxed);
-  margin: 0;
-  max-width: 360px;
+  max-width: 520px;
 }
 
-/* ── Doctor checks ─────────────────────────────────────────────────────── */
-
-.onboarding-checks {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-  margin: var(--space-8) 0;
-  text-align: left;
-}
-
-.onboarding-check-row {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-12);
-  padding: var(--space-10) var(--space-12);
-  border-radius: var(--radius);
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  min-height: var(--space-40);
-}
-
-.onboarding-check-info {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  flex: 1;
-  min-width: 0;
-}
-
-.onboarding-check-label {
+.ob-description {
   font-size: var(--text-md);
-  font-weight: var(--weight-medium);
-  color: var(--text-primary);
-  display: flex;
-  align-items: center;
-  gap: var(--space-6);
-}
-
-.onboarding-check-optional {
-  font-size: var(--text-xs);
-  font-weight: var(--weight-normal);
   color: var(--text-muted);
-  background: var(--bg-hover);
-  border-radius: var(--radius-pill);
-  padding: 1px var(--space-6);
+  margin: 0;
+  line-height: var(--leading-relaxed);
+  max-width: 480px;
 }
 
-.onboarding-check-hint {
+.ob-hint {
   font-size: var(--text-sm);
   color: var(--text-muted);
+  margin: 0;
 }
 
-.onboarding-check-link {
-  all: unset;
-  color: var(--accent);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-3);
+.ob-error {
   font-size: var(--text-sm);
-}
-
-.onboarding-check-link:hover {
-  text-decoration: underline;
-}
-
-.onboarding-check-code {
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  background: var(--bg-hover);
-  border-radius: var(--radius-sm);
-  padding: 1px var(--space-4);
-  color: var(--text-secondary);
-}
-
-.onboarding-check-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-6);
-  margin-top: var(--space-2);
-}
-
-.onboarding-install-btn {
-  all: unset;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-4);
-  font-size: var(--text-sm);
-  font-weight: var(--weight-medium);
-  color: var(--accent);
-  border: 1px solid var(--accent);
-  border-radius: var(--radius-sm);
-  padding: var(--space-2) var(--space-8);
-  cursor: pointer;
-  line-height: var(--leading-normal);
-  transition: background var(--duration-fast);
-}
-
-.onboarding-install-btn:hover:not(:disabled) {
-  background: var(--accent-tint-10);
-}
-
-.onboarding-install-btn:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
-.onboarding-check-progress {
-  font-size: var(--text-sm);
-  color: var(--text-muted);
-  margin-top: var(--space-2);
-}
-
-.onboarding-check-row--ok {
-  border-color: var(--green);
-  opacity: 0.7;
-}
-
-.onboarding-check-status {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: var(--space-20);
-  height: var(--space-20);
-  margin-top: 1px;
-}
-
-.onboarding-check-ok {
-  color: var(--green);
-}
-
-.onboarding-check-fail {
   color: var(--red);
+  margin: 0;
 }
 
-.onboarding-check-pending {
-  width: var(--space-6);
-  height: var(--space-6);
-  border-radius: var(--radius-full);
-  background: var(--border);
-}
+/* ── Footer / navigation ──────────────────────────────────────────────── */
 
-/* ── Actions row ───────────────────────────────────────────────────────── */
-
-.onboarding-actions {
+.ob-footer {
+  flex-shrink: 0;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
+  padding-top: var(--space-16);
+  border-top: 1px solid var(--border);
+  margin-top: var(--space-12);
+}
+
+.ob-footer-left {
+  display: flex;
+  align-items: center;
+}
+
+.ob-footer-right {
+  display: flex;
+  align-items: center;
   gap: var(--space-8);
-  margin-top: var(--space-8);
-  flex-wrap: wrap;
 }
 
-.onboarding-retry-btn {
-  display: flex;
-  align-items: center;
-  gap: var(--space-4);
-}
-
-/* ── Project step ──────────────────────────────────────────────────────── */
-
-.onboarding-project-actions {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-12);
-  margin-top: var(--space-8);
-}
-
-.onboarding-skip-link {
+.ob-skip-link {
   all: unset;
   font-size: var(--text-sm);
   color: var(--text-muted);
@@ -268,6 +269,677 @@
   transition: color var(--duration-fast);
 }
 
-.onboarding-skip-link:hover {
+.ob-skip-link:hover {
   color: var(--text-secondary);
+}
+
+.ob-kbd {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-system);
+  font-size: var(--text-xs);
+  color: inherit;
+  opacity: 0.5;
+  margin-left: var(--space-6);
+  pointer-events: none;
+}
+
+/* ── Agent picker cards ───────────────────────────────────────────────── */
+
+.ob-detected-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.ob-detected-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: var(--green);
+}
+
+.ob-agent-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-10);
+}
+
+.ob-agent-card {
+  all: unset;
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-10);
+  padding: var(--space-12) var(--space-14);
+  background: var(--bg-secondary);
+  border: 2px solid var(--border);
+  border-radius: var(--radius-lg);
+  transition: border-color var(--duration-normal);
+}
+
+.ob-agent-card:hover {
+  border-color: var(--text-muted);
+}
+
+.ob-agent-card--active {
+  border-color: var(--accent);
+}
+
+.ob-agent-check {
+  position: absolute;
+  top: var(--space-6);
+  right: var(--space-6);
+  color: var(--accent);
+}
+
+.ob-agent-icon {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+}
+
+.ob-agent-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.ob-agent-name {
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+}
+
+.ob-agent-cmd {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.ob-show-more {
+  all: unset;
+  cursor: pointer;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-4);
+  transition: color var(--duration-fast);
+}
+
+.ob-show-more:hover {
+  color: var(--text-secondary);
+}
+
+/* ── Theme cards ──────────────────────────────────────────────────────── */
+
+.ob-theme-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-12);
+  margin-top: var(--space-4);
+}
+
+.ob-theme-card {
+  all: unset;
+  cursor: pointer;
+  position: relative;
+  border: 2px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: border-color var(--duration-normal);
+}
+
+.ob-theme-card:hover {
+  border-color: var(--text-muted);
+}
+
+.ob-theme-card--active {
+  border-color: var(--accent);
+}
+
+.ob-theme-check {
+  position: absolute;
+  top: var(--space-8);
+  right: var(--space-8);
+  z-index: 2;
+  color: var(--accent);
+  background: var(--bg-primary);
+  border-radius: var(--radius-full);
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ob-theme-preview {
+  height: 110px;
+  display: flex;
+  overflow: hidden;
+}
+
+.ob-theme-preview-sidebar {
+  width: 30%;
+  padding: var(--space-10) var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.ob-theme-preview-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.ob-theme-preview-topbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  padding: var(--space-6) var(--space-8);
+}
+
+.ob-theme-preview-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.ob-theme-preview-lines {
+  padding: var(--space-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.ob-theme-preview-line {
+  height: 4px;
+  border-radius: 2px;
+  opacity: 0.6;
+}
+
+.ob-theme-card-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-8) var(--space-10);
+}
+
+.ob-theme-card-name {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+}
+
+.ob-theme-card-hint {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+/* ── Notification step (card layout) ───────────────────────────────────── */
+
+.ob-notif-permission {
+  display: flex;
+  align-items: center;
+  gap: var(--space-14);
+  padding: var(--space-16) var(--space-20);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+.ob-notif-permission-icon {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+
+.ob-notif-permission-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ob-notif-permission-title {
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.ob-notif-permission-desc {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+.ob-notif-sound-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.ob-notif-sound-heading {
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.ob-notif-sound-hint {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.ob-notif-sound-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-12);
+}
+
+.ob-notif-sound-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+}
+
+.ob-notif-sound-label {
+  font-size: var(--text-md);
+  color: var(--text-primary);
+}
+
+/* ── Card group (generic) ─────────────────────────────────────────────── */
+
+.ob-card-group {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  margin-top: var(--space-4);
+}
+
+.ob-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-12);
+  padding: var(--space-12) var(--space-16);
+}
+
+.ob-toggle-row + .ob-toggle-row {
+  border-top: 1px solid var(--border);
+}
+
+.ob-toggle-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ob-toggle-label {
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+}
+
+.ob-toggle-hint {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+.ob-divider {
+  height: 1px;
+  background: var(--border);
+}
+
+/* ── Integration cards (card layout) ───────────────────────────────────── */
+
+.ob-int-benefits {
+  list-style: disc;
+  padding-left: var(--space-20);
+  color: var(--text-muted);
+  font-size: var(--text-md);
+  line-height: var(--leading-relaxed);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  margin: 0;
+}
+
+.ob-int-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-10);
+}
+
+.ob-int-card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-14);
+  padding: var(--space-16) var(--space-20);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+.ob-int-card-icon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-hover);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+}
+
+.ob-int-card-icon--jira {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-bold);
+  color: var(--accent);
+}
+
+.ob-int-card-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.ob-int-card-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+}
+
+.ob-int-card-name {
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.ob-int-card-desc {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+.ob-int-card-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  flex-shrink: 0;
+}
+
+.ob-int-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-4);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  padding: var(--space-2) var(--space-8);
+  border-radius: var(--radius-pill);
+}
+
+.ob-int-badge--connected {
+  color: var(--green);
+  background: color-mix(in srgb, var(--green) 12%, transparent);
+}
+
+.ob-int-badge--checking {
+  color: var(--text-muted);
+}
+
+.ob-int-badge-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+}
+
+.ob-int-badge-dot--green {
+  background: var(--green);
+}
+
+.ob-int-card--compact {
+  padding: var(--space-12) var(--space-16);
+}
+
+/* ── Project step ─────────────────────────────────────────────────────── */
+
+.ob-project-cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-10);
+}
+
+.ob-project-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.ob-project-card-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-14);
+  padding: var(--space-16) var(--space-20);
+}
+
+.ob-action-card-icon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-hover);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+}
+
+.ob-action-card-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ob-action-card-title {
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.ob-action-card-desc {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+.ob-clone-input-row {
+  display: flex;
+  gap: var(--space-8);
+  padding: 0 var(--space-20) var(--space-16);
+}
+
+.ob-clone-input {
+  flex: 1;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-10) var(--space-12);
+  font-size: var(--text-md);
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.ob-clone-input:focus {
+  border-color: var(--accent);
+}
+
+.ob-clone-input::placeholder {
+  color: var(--text-muted);
+}
+
+.ob-workspace-path {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  font-size: var(--text-sm);
+}
+
+.ob-workspace-path-label {
+  color: var(--text-muted);
+}
+
+.ob-workspace-path-value {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+
+/* ── Explore step ─────────────────────────────────────────────────────── */
+
+.ob-explore-preview {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-20) var(--space-24);
+  margin-top: var(--space-4);
+}
+
+.ob-explore-feature-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.ob-explore-feature {
+  display: flex;
+  align-items: center;
+  gap: var(--space-10);
+  font-size: var(--text-md);
+  color: var(--text-secondary);
+}
+
+.ob-explore-feature-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: var(--accent);
+  flex-shrink: 0;
+}
+
+.ob-tour-btn {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-4);
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  color: var(--accent);
+  cursor: pointer;
+  padding: var(--space-8) var(--space-16);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: border-color var(--duration-fast);
+  align-self: flex-start;
+}
+
+.ob-tour-btn:hover {
+  border-color: var(--accent);
+}
+
+/* ── Skip confirmation dialog ─────────────────────────────────────────── */
+
+.ob-skip-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: calc(var(--z-modal) + 10);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+  animation: ob-fade-in var(--duration-fast) ease-out;
+}
+
+.ob-skip-dialog {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-elevation-2xl);
+  padding: var(--space-24) var(--space-28);
+  max-width: 360px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.ob-skip-dialog-title {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.ob-skip-dialog-desc {
+  font-size: var(--text-md);
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.ob-skip-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+/* ── Focus & accessibility ────────────────────────────────────────────── */
+
+.ob-agent-card:focus-visible,
+.ob-theme-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ── Reduced motion ───────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .ob-overlay,
+  .ob-skip-dialog-backdrop,
+  .ob-progress-segment,
+  .ob-theme-card,
+  .ob-agent-card {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+/* ── macOS drag region ────────────────────────────────────────────────── */
+
+.ob-layout-header {
+  -webkit-app-region: drag;
 }


### PR DESCRIPTION
## Summary

- Redesign onboarding as a two-pane setup flow with a step rail, responsive layout, and stronger final product preview.
- Split onboarding into focused steps for agent selection, theme, notifications, integrations, project setup, and exploration.
- Use the real Braid SVG mark in onboarding and make onboarding agent icons deterministic without remote favicon dependency.

## Layers touched

- [ ] **Main process** (`src/main/`) — services, IPC handlers
- [ ] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`src/renderer/styles/onboarding.css`)

## Changes

**Onboarding:**
- Replaces the old centered onboarding card with a setup cockpit layout and left-side step rail.
- Adds dedicated step components for welcome, agent selection, theme, notifications, integrations, project setup, and explore.
- Adds responsive mobile behavior, focus-visible states, reduced-motion handling, and accessible dialog labels.

**Shared icons / branding:**
- Uses the committed Braid SVG app mark in onboarding.
- Adds a deterministic local fallback mode for onboarding agent icons and fixes the Gemini icon path bounds.

**Stores** (`ui.ts`):
- Adds default agent selection state used by the onboarding agent picker.

## How to test

1. `npm run typecheck:web`
2. `./node_modules/.bin/electron-vite build`
3. Open onboarding in the app and verify desktop/mobile layout, step navigation, skip confirmation, agent picker icons, and the final preview.

Note: `npm test` is currently blocked by the existing Vite resolver issue for `@xterm/addon-ligatures` from `src/renderer/components/Right/terminalCache.ts`; 1067 tests pass before that resolver failure.

## Screenshots

Not attached.

## Checklist

- [x] Self-reviewed the diff
- [ ] Tested locally with `yarn dev`
- [x] Types pass — `npm run typecheck:web`
- [ ] No console errors or warnings in DevTools
- [x] IPC changes are threaded through all 3 layers (main → preload → renderer) — N/A, no IPC changes
- [x] New state is added to the correct Zustand store
