### PR TITLE
feat(code-review): add reply-to-review and enhanced review UI

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -241,6 +241,9 @@ export function registerIpcHandlers(): void {
   ipcMain.handle('github:getReviews', (_e, worktreePath: string, forceRefresh?: boolean) =>
     githubService.getReviews(worktreePath, forceRefresh)
   )
+  ipcMain.handle('github:replyToReviewComment', (_e, worktreePath: string, commentId: number, body: string) =>
+    githubService.replyToReviewComment(worktreePath, commentId, body)
+  )
   ipcMain.handle('github:openCheckLog', async (_e, worktreePath: string, checkUrl: string, checkName: string) => {
     const log = await githubService.getCheckRunLog(worktreePath, checkUrl)
     const safe = checkName.replace(/[^a-zA-Z0-9-_]/g, '_')

--- a/src/main/services/github.ts
+++ b/src/main/services/github.ts
@@ -298,6 +298,29 @@ class GitHubService {
     return await this.reviewsCache.get(worktreePath, () => this._fetchReviews(worktreePath), { forceRefresh })
   }
 
+  async replyToReviewComment(worktreePath: string, commentId: number, body: string): Promise<void> {
+    const trimmedBody = body.trim()
+    if (!trimmedBody) throw new Error('Reply body is required')
+
+    const nwo = await resolveNwo(worktreePath)
+    const pr = await this.getPrStatus(worktreePath)
+    if (!pr) throw new Error('No pull request found for this worktree')
+
+    await this.gh(
+      [
+        'api',
+        `repos/${nwo}/pulls/${pr.number}/comments/${commentId}/replies`,
+        '-X',
+        'POST',
+        '-f',
+        `body=${trimmedBody}`,
+      ],
+      worktreePath,
+      true,
+    )
+    this.reviewsCache.invalidate(worktreePath)
+  }
+
   private async _fetchReviews(worktreePath: string): Promise<PrReviewData> {
     const nwo = await resolveNwo(worktreePath)
     const pr = await this.getPrStatus(worktreePath)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -229,6 +229,8 @@ const api = {
       ipcRenderer.invoke('github:markPrReady', worktreePath),
     getReviews: (worktreePath: string, forceRefresh?: boolean) =>
       ipcRenderer.invoke('github:getReviews', worktreePath, forceRefresh),
+    replyToReviewComment: (worktreePath: string, commentId: number, body: string) =>
+      ipcRenderer.invoke('github:replyToReviewComment', worktreePath, commentId, body) as Promise<void>,
     startDeviceFlow: () =>
       ipcRenderer.invoke('github:startDeviceFlow') as Promise<{
         userCode: string; verificationUri: string; expiresIn: number

--- a/src/renderer/components/Center/CodeReviewView.tsx
+++ b/src/renderer/components/Center/CodeReviewView.tsx
@@ -13,7 +13,7 @@ import { formatRelativeTime } from '@/lib/relativeTime'
 import { resolveSafeExternalUrl } from '@/lib/safeExternalUrl'
 import { useUIStore } from '@/store/ui'
 import { EmptyState, Spinner } from '@/components/ui'
-import { IconArrowLeft, IconFile } from '@/components/shared/icons'
+import { IconFile } from '@/components/shared/icons'
 import { useShikiHighlight } from '@/hooks/useShikiHighlight'
 import type { PrReview, PrReviewComment, PrReviewData, ReviewState } from '@/types'
 
@@ -367,7 +367,6 @@ export function CodeReviewView({ worktreePath }: Props) {
   const [submittingReplyId, setSubmittingReplyId] = useState<number | null>(null)
   const [replyError, setReplyError] = useState<string | null>(null)
   const openFile = useUIStore((s) => s.openFile)
-  const closeCodeReview = useUIStore((s) => s.closeCodeReview)
 
   const load = useCallback(async (forceRefresh = false, showLoading = true) => {
     if (showLoading) dispatch({ type: 'LOAD_START' })
@@ -415,10 +414,6 @@ export function CodeReviewView({ worktreePath }: Props) {
     () => new Set(rootComments.map((c) => c.path)).size,
     [rootComments],
   )
-
-  const handleBack = useCallback(() => {
-    closeCodeReview()
-  }, [closeCodeReview])
 
   const handleOpenFile = useCallback((path: string) => {
     // File paths from GitHub are relative to repo root, which matches worktree
@@ -498,7 +493,7 @@ export function CodeReviewView({ worktreePath }: Props) {
   if (state.error || !state.data) {
     return (
       <div className="code-review-view">
-        <CodeReviewHeader onBack={handleBack} t={t} />
+        <CodeReviewHeader t={t} />
         <EmptyState title={t('center:codeReviewEmpty')} hint={t('center:codeReviewEmptyHint')} />
       </div>
     )
@@ -507,7 +502,7 @@ export function CodeReviewView({ worktreePath }: Props) {
   if (dedupedReviews.length === 0 && inlineCount === 0) {
     return (
       <div className="code-review-view">
-        <CodeReviewHeader onBack={handleBack} t={t} />
+        <CodeReviewHeader t={t} />
         <EmptyState title={t('center:codeReviewEmpty')} hint={t('center:codeReviewEmptyHint')} />
       </div>
     )
@@ -516,7 +511,6 @@ export function CodeReviewView({ worktreePath }: Props) {
   return (
     <div className="code-review-view">
       <CodeReviewHeader
-        onBack={handleBack}
         t={t}
         summary={t('center:codeReviewSummary', { reviewCount: dedupedReviews.length, commentCount: inlineCount })}
       />
@@ -637,17 +631,13 @@ function CodeReviewOverview({
 }
 
 function CodeReviewHeader({
-  onBack, t, summary,
+  t, summary,
 }: {
-  onBack: () => void
   t: (key: string, opts?: Record<string, unknown>) => string
   summary?: string
 }) {
   return (
     <div className="code-review-header">
-      <button className="code-review-header-back" onClick={onBack} aria-label={t('center:codeReviewBack')}>
-        <IconArrowLeft size={16} />
-      </button>
       <span className="code-review-header-title">{t('center:codeReviewTitle')}</span>
       {summary && <span className="code-review-header-summary">{summary}</span>}
     </div>

--- a/src/renderer/components/Center/CodeReviewView.tsx
+++ b/src/renderer/components/Center/CodeReviewView.tsx
@@ -9,6 +9,8 @@ import ReactMarkdown, { type Components } from 'react-markdown'
 import { useTranslation } from 'react-i18next'
 import remarkGfm from 'remark-gfm'
 import * as ipc from '@/lib/ipc'
+import { formatRelativeTime } from '@/lib/relativeTime'
+import { resolveSafeExternalUrl } from '@/lib/safeExternalUrl'
 import { useUIStore } from '@/store/ui'
 import { EmptyState, Spinner } from '@/components/ui'
 import { IconArrowLeft, IconFile } from '@/components/shared/icons'
@@ -45,15 +47,46 @@ function reducer(state: State, action: Action): State {
 
 const markdownPlugins = [remarkGfm]
 
-const markdownComponents: Components = {
-  a: ({ href, children }) => {
-    const onClick = (e: MouseEvent<HTMLAnchorElement>) => {
-      e.preventDefault()
-      e.stopPropagation()
-      if (href) ipc.shell.openExternal(href)
-    }
-    return <a href={href} onClick={onClick}>{children}</a>
-  },
+function createMarkdownComponents(baseUrl: string): Components {
+  return {
+    a: ({ href, children }) => {
+      const safeUrl = resolveSafeExternalUrl(href, baseUrl)
+      const onClick = (e: MouseEvent<HTMLAnchorElement>) => {
+        e.preventDefault()
+        e.stopPropagation()
+        if (safeUrl) ipc.shell.openExternal(safeUrl)
+      }
+      return <a href={safeUrl ?? undefined} onClick={onClick}>{children}</a>
+    },
+    img: () => null,
+  }
+}
+
+const getOpenCount = (comments: PrReviewComment[]) => comments.reduce(
+  (count, comment) => count + (comment.isResolved ? 0 : 1),
+  0,
+)
+
+function groupCommentsByFile(comments: PrReviewComment[]): Map<string, PrReviewComment[]> {
+  const rootComments = comments.filter((c) => c.inReplyToId === null)
+  const groups = new Map<string, PrReviewComment[]>()
+  for (const c of rootComments) {
+    const list = groups.get(c.path) ?? []
+    list.push(c)
+    groups.set(c.path, list)
+  }
+
+  const entries = Array.from(groups.entries()).map(([path, groupComments]) => {
+    groupComments.sort(compareComments)
+    return { path, comments: groupComments, openCount: getOpenCount(groupComments) }
+  })
+
+  entries.sort((a, b) => {
+    if (a.openCount !== b.openCount) return b.openCount - a.openCount
+    return a.path.localeCompare(b.path)
+  })
+
+  return new Map(entries.map(({ path, comments }) => [path, comments]))
 }
 
 function dedupeReviews(reviews: PrReview[]): PrReview[] {
@@ -78,48 +111,10 @@ function compareComments(a: PrReviewComment, b: PrReviewComment): number {
   return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
 }
 
-function groupCommentsByFile(comments: PrReviewComment[]): Map<string, PrReviewComment[]> {
-  const rootComments = comments.filter((c) => c.inReplyToId === null)
-  const groups = new Map<string, PrReviewComment[]>()
-  for (const c of rootComments) {
-    const list = groups.get(c.path) ?? []
-    list.push(c)
-    groups.set(c.path, list)
-  }
-  for (const list of groups.values()) {
-    list.sort(compareComments)
-  }
-  return new Map([...groups.entries()].sort(([aPath, aComments], [bPath, bComments]) => {
-    const aOpen = aComments.filter((c) => !c.isResolved).length
-    const bOpen = bComments.filter((c) => !c.isResolved).length
-    if (aOpen !== bOpen) return bOpen - aOpen
-    return aPath.localeCompare(bPath)
-  }))
-}
-
 function getReplies(comments: PrReviewComment[], parentId: number): PrReviewComment[] {
   return comments
     .filter((c) => c.inReplyToId === parentId)
     .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
-}
-
-const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'always', style: 'short' })
-
-function formatTime(iso: string): string {
-  try {
-    const d = new Date(iso)
-    const now = new Date()
-    const diffMs = now.getTime() - d.getTime()
-    const diffMinutes = Math.max(1, Math.round(diffMs / 60000))
-    const diffHours = Math.round(diffMs / (1000 * 60 * 60))
-    const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24))
-    if (diffMinutes < 60) return rtf.format(-diffMinutes, 'minute')
-    if (diffHours < 24) return rtf.format(-diffHours, 'hour')
-    if (diffDays < 7) return rtf.format(-diffDays, 'day')
-    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-  } catch {
-    return ''
-  }
 }
 
 function reviewStateClass(state: ReviewState): string {
@@ -141,11 +136,12 @@ function stateLabel(state: ReviewState, t: (key: string) => string): string {
   }
 }
 
-function CodeReviewMarkdown({ body }: { body: string }) {
+function CodeReviewMarkdown({ body, baseUrl }: { body: string; baseUrl: string }) {
+  const components = useMemo(() => createMarkdownComponents(baseUrl), [baseUrl])
   if (!body.trim()) return null
   return (
     <div className="code-review-markdown">
-      <ReactMarkdown remarkPlugins={markdownPlugins} components={markdownComponents}>
+      <ReactMarkdown skipHtml remarkPlugins={markdownPlugins} components={components}>
         {body}
       </ReactMarkdown>
     </div>
@@ -224,9 +220,9 @@ function ReviewCard({ review, t }: { review: PrReview; t: (key: string) => strin
           <span className={`review-state-badge ${reviewStateClass(review.state)}`}>
             {stateLabel(review.state, t)}
           </span>
-          <span className="code-review-card-time">{formatTime(review.submittedAt)}</span>
+          <span className="code-review-card-time">{formatRelativeTime(review.submittedAt)}</span>
         </div>
-        <CodeReviewMarkdown body={review.body} />
+        <CodeReviewMarkdown body={review.body} baseUrl={review.htmlUrl} />
       </div>
     </div>
   )
@@ -272,10 +268,10 @@ function CommentItem({
                 {comment.isResolved ? t('codeReviewResolved') : t('codeReviewOpen')}
               </span>
             )}
-            <span className="code-review-comment-time">{formatTime(comment.createdAt)}</span>
+            <span className="code-review-comment-time">{formatRelativeTime(comment.createdAt)}</span>
           </div>
           {comment.diffHunk && <DiffHunk raw={comment.diffHunk} filePath={comment.path} />}
-          <CodeReviewMarkdown body={comment.body} />
+          <CodeReviewMarkdown body={comment.body} baseUrl={comment.htmlUrl} />
         </div>
       </div>
       {replies.length > 0 && (
@@ -367,7 +363,7 @@ export function CodeReviewView({ worktreePath }: Props) {
   const { t } = useTranslation(['center', 'right'])
   const [state, dispatch] = useReducer(reducer, { data: null, loading: true, error: false, filter: 'all' })
   const [replyingToId, setReplyingToId] = useState<number | null>(null)
-  const [replyDraft, setReplyDraft] = useState('')
+  const [replyDrafts, setReplyDrafts] = useState<Record<number, string>>({})
   const [submittingReplyId, setSubmittingReplyId] = useState<number | null>(null)
   const [replyError, setReplyError] = useState<string | null>(null)
   const openFile = useUIStore((s) => s.openFile)
@@ -378,8 +374,10 @@ export function CodeReviewView({ worktreePath }: Props) {
     try {
       const data = await ipc.github.getReviews(worktreePath, forceRefresh) as PrReviewData
       dispatch({ type: 'LOAD_DONE', data })
+      return true
     } catch {
-      dispatch({ type: 'LOAD_ERROR' })
+      if (showLoading) dispatch({ type: 'LOAD_ERROR' })
+      return false
     }
   }, [worktreePath])
 
@@ -430,50 +428,60 @@ export function CodeReviewView({ worktreePath }: Props) {
 
   const handleStartReply = useCallback((commentId: number) => {
     setReplyingToId(commentId)
-    setReplyDraft('')
     setReplyError(null)
   }, [])
 
   const handleCancelReply = useCallback(() => {
     setReplyingToId(null)
-    setReplyDraft('')
     setReplyError(null)
   }, [])
 
+  const handleDraftChange = useCallback((value: string) => {
+    if (replyingToId === null) return
+    setReplyDrafts((prev) => ({ ...prev, [replyingToId]: value }))
+  }, [replyingToId])
+
   const handleSubmitReply = useCallback(async (commentId: number) => {
-    const body = replyDraft.trim()
+    const body = (replyDrafts[commentId] ?? '').trim()
     if (!body) return
 
     setSubmittingReplyId(commentId)
     setReplyError(null)
     try {
       await ipc.github.replyToReviewComment(worktreePath, commentId, body)
-      setReplyingToId(null)
-      setReplyDraft('')
-      await load(true, false)
     } catch {
       setReplyError(t('center:codeReviewReplyFailed'))
-    } finally {
       setSubmittingReplyId(null)
+      return
     }
-  }, [load, replyDraft, t, worktreePath])
+
+    setReplyingToId(null)
+    setReplyDrafts((prev) => {
+      const next = { ...prev }
+      delete next[commentId]
+      return next
+    })
+    setSubmittingReplyId(null)
+    void load(true, false)
+  }, [load, replyDrafts, t, worktreePath])
 
   const replyState = useMemo<ReplyState>(() => ({
     replyingToId,
-    draft: replyDraft,
+    draft: replyingToId !== null ? replyDrafts[replyingToId] ?? '' : '',
     submittingId: submittingReplyId,
     error: replyError,
     onStart: handleStartReply,
     onCancel: handleCancelReply,
-    onDraftChange: setReplyDraft,
+    onDraftChange: handleDraftChange,
     onSubmit: handleSubmitReply,
   }), [
     replyingToId,
-    replyDraft,
+    replyDrafts,
     submittingReplyId,
     replyError,
     handleStartReply,
     handleCancelReply,
+    handleDraftChange,
     handleSubmitReply,
   ])
 
@@ -556,36 +564,39 @@ export function CodeReviewView({ worktreePath }: Props) {
         )}
 
         {/* Inline comments grouped by file */}
-        {Array.from(fileGroups.entries()).map(([filePath, comments]) => (
-          <div key={filePath} className="code-review-file-group">
-            <div className="code-review-file-header">
-              <span className="code-review-file-icon"><IconFile size={14} /></span>
-              <span className="code-review-file-path" onClick={() => handleOpenFile(filePath)}>
-                {filePath}
-              </span>
-              {comments.some((c) => !c.isResolved) && (
-                <span className="code-review-file-open">
-                  {t('center:codeReviewFilterOpen', { count: comments.filter((c) => !c.isResolved).length })}
+        {Array.from(fileGroups.entries()).map(([filePath, comments]) => {
+          const openCount = getOpenCount(comments)
+          return (
+            <div key={filePath} className="code-review-file-group">
+              <div className="code-review-file-header">
+                <span className="code-review-file-icon"><IconFile size={14} /></span>
+                <span className="code-review-file-path" onClick={() => handleOpenFile(filePath)}>
+                  {filePath}
                 </span>
-              )}
-              <span className="code-review-file-count">
-                {t('right:reviewComments', { count: comments.filter((c) => c.inReplyToId === null).length })}
-              </span>
+                {openCount > 0 && (
+                  <span className="code-review-file-open">
+                    {t('center:codeReviewFilterOpen', { count: openCount })}
+                  </span>
+                )}
+                <span className="code-review-file-count">
+                  {t('right:reviewComments', { count: comments.length })}
+                </span>
+              </div>
+              <div className="code-review-comments">
+                {comments.map((comment) => (
+                  <CommentItem
+                    key={comment.id}
+                    comment={comment}
+                    allComments={filteredComments}
+                    isRoot
+                    replyState={replyState}
+                    t={(k, opts) => t(`center:${k}`, opts as Record<string, string>)}
+                  />
+                ))}
+              </div>
             </div>
-            <div className="code-review-comments">
-              {comments.filter((c) => c.inReplyToId === null).map((comment) => (
-                <CommentItem
-                  key={comment.id}
-                  comment={comment}
-                  allComments={filteredComments}
-                  isRoot
-                  replyState={replyState}
-                  t={(k, opts) => t(`center:${k}`, opts as Record<string, string>)}
-                />
-              ))}
-            </div>
-          </div>
-        ))}
+          )
+        })}
 
         {/* Empty filter state */}
         {state.filter !== 'all' && fileGroups.size === 0 && inlineCount > 0 && (

--- a/src/renderer/components/Center/CodeReviewView.tsx
+++ b/src/renderer/components/Center/CodeReviewView.tsx
@@ -4,8 +4,10 @@
  * Shows all PR reviews (summary cards) and inline comments grouped by file.
  * Accessed from the Checks tab "See all" button or clicking a review row.
  */
-import { useEffect, useReducer, useCallback, useMemo, memo } from 'react'
+import { useEffect, useReducer, useCallback, useMemo, memo, useState, type MouseEvent } from 'react'
+import ReactMarkdown, { type Components } from 'react-markdown'
 import { useTranslation } from 'react-i18next'
+import remarkGfm from 'remark-gfm'
 import * as ipc from '@/lib/ipc'
 import { useUIStore } from '@/store/ui'
 import { EmptyState, Spinner } from '@/components/ui'
@@ -41,6 +43,19 @@ function reducer(state: State, action: Action): State {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+const markdownPlugins = [remarkGfm]
+
+const markdownComponents: Components = {
+  a: ({ href, children }) => {
+    const onClick = (e: MouseEvent<HTMLAnchorElement>) => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (href) ipc.shell.openExternal(href)
+    }
+    return <a href={href} onClick={onClick}>{children}</a>
+  },
+}
+
 function dedupeReviews(reviews: PrReview[]): PrReview[] {
   const byAuthor = new Map<string, PrReview>()
   for (const r of reviews) {
@@ -54,6 +69,15 @@ function dedupeReviews(reviews: PrReview[]): PrReview[] {
     .sort((a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime())
 }
 
+function compareComments(a: PrReviewComment, b: PrReviewComment): number {
+  const resolution = Number(a.isResolved) - Number(b.isResolved)
+  if (resolution !== 0) return resolution
+  const aLine = a.line ?? a.originalLine ?? Number.MAX_SAFE_INTEGER
+  const bLine = b.line ?? b.originalLine ?? Number.MAX_SAFE_INTEGER
+  if (aLine !== bLine) return aLine - bLine
+  return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+}
+
 function groupCommentsByFile(comments: PrReviewComment[]): Map<string, PrReviewComment[]> {
   const rootComments = comments.filter((c) => c.inReplyToId === null)
   const groups = new Map<string, PrReviewComment[]>()
@@ -62,8 +86,15 @@ function groupCommentsByFile(comments: PrReviewComment[]): Map<string, PrReviewC
     list.push(c)
     groups.set(c.path, list)
   }
-  // Sort by file path
-  return new Map([...groups.entries()].sort(([a], [b]) => a.localeCompare(b)))
+  for (const list of groups.values()) {
+    list.sort(compareComments)
+  }
+  return new Map([...groups.entries()].sort(([aPath, aComments], [bPath, bComments]) => {
+    const aOpen = aComments.filter((c) => !c.isResolved).length
+    const bOpen = bComments.filter((c) => !c.isResolved).length
+    if (aOpen !== bOpen) return bOpen - aOpen
+    return aPath.localeCompare(bPath)
+  }))
 }
 
 function getReplies(comments: PrReviewComment[], parentId: number): PrReviewComment[] {
@@ -108,6 +139,17 @@ function stateLabel(state: ReviewState, t: (key: string) => string): string {
     case 'DISMISSED': return t('reviewDismissed')
     default: return ''
   }
+}
+
+function CodeReviewMarkdown({ body }: { body: string }) {
+  if (!body.trim()) return null
+  return (
+    <div className="code-review-markdown">
+      <ReactMarkdown remarkPlugins={markdownPlugins} components={markdownComponents}>
+        {body}
+      </ReactMarkdown>
+    </div>
+  )
 }
 
 // ─── Diff hunk renderer with Shiki syntax highlighting ───────────────────────
@@ -184,18 +226,19 @@ function ReviewCard({ review, t }: { review: PrReview; t: (key: string) => strin
           </span>
           <span className="code-review-card-time">{formatTime(review.submittedAt)}</span>
         </div>
-        {review.body && <div className="code-review-card-body">{review.body}</div>}
+        <CodeReviewMarkdown body={review.body} />
       </div>
     </div>
   )
 }
 
 function CommentItem({
-  comment, allComments, isRoot, t,
+  comment, allComments, isRoot, replyState, t,
 }: {
   comment: PrReviewComment
   allComments: PrReviewComment[]
   isRoot?: boolean
+  replyState?: ReplyState
   t: (key: string, opts?: Record<string, unknown>) => string
 }) {
   const openUrl = () => ipc.shell.openExternal(comment.htmlUrl)
@@ -232,7 +275,7 @@ function CommentItem({
             <span className="code-review-comment-time">{formatTime(comment.createdAt)}</span>
           </div>
           {comment.diffHunk && <DiffHunk raw={comment.diffHunk} filePath={comment.path} />}
-          <div className="code-review-comment-body">{comment.body}</div>
+          <CodeReviewMarkdown body={comment.body} />
         </div>
       </div>
       {replies.length > 0 && (
@@ -242,7 +285,75 @@ function CommentItem({
           ))}
         </div>
       )}
+      {isRoot && replyState && (
+        <ReplySlot commentId={comment.id} replyState={replyState} t={t} />
+      )}
     </>
+  )
+}
+
+interface ReplyState {
+  replyingToId: number | null
+  draft: string
+  submittingId: number | null
+  error: string | null
+  onStart: (commentId: number) => void
+  onCancel: () => void
+  onDraftChange: (value: string) => void
+  onSubmit: (commentId: number) => void
+}
+
+function ReplySlot({
+  commentId, replyState, t,
+}: {
+  commentId: number
+  replyState: ReplyState
+  t: (key: string, opts?: Record<string, unknown>) => string
+}) {
+  const isActive = replyState.replyingToId === commentId
+  const isSubmitting = replyState.submittingId === commentId
+
+  if (!isActive) {
+    return (
+      <div className="code-review-reply-slot">
+        <button className="code-review-reply-button" onClick={() => replyState.onStart(commentId)}>
+          {t('codeReviewReply')}
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="code-review-reply-slot">
+      <div className="code-review-reply-composer">
+        <textarea
+          className="code-review-reply-textarea"
+          value={replyState.draft}
+          onChange={(e) => replyState.onDraftChange(e.target.value)}
+          placeholder={t('codeReviewReplyPlaceholder')}
+          rows={4}
+          disabled={isSubmitting}
+          autoFocus
+        />
+        {replyState.error && <div className="code-review-reply-error">{replyState.error}</div>}
+        <div className="code-review-reply-actions">
+          <button
+            className="code-review-reply-cancel"
+            onClick={replyState.onCancel}
+            disabled={isSubmitting}
+          >
+            {t('codeReviewCancelReply')}
+          </button>
+          <button
+            className="code-review-reply-submit"
+            onClick={() => replyState.onSubmit(commentId)}
+            disabled={isSubmitting || !replyState.draft.trim()}
+          >
+            {isSubmitting ? t('codeReviewSendingReply') : t('codeReviewSendReply')}
+          </button>
+        </div>
+      </div>
+    </div>
   )
 }
 
@@ -255,13 +366,17 @@ interface Props {
 export function CodeReviewView({ worktreePath }: Props) {
   const { t } = useTranslation(['center', 'right'])
   const [state, dispatch] = useReducer(reducer, { data: null, loading: true, error: false, filter: 'all' })
+  const [replyingToId, setReplyingToId] = useState<number | null>(null)
+  const [replyDraft, setReplyDraft] = useState('')
+  const [submittingReplyId, setSubmittingReplyId] = useState<number | null>(null)
+  const [replyError, setReplyError] = useState<string | null>(null)
   const openFile = useUIStore((s) => s.openFile)
   const closeCodeReview = useUIStore((s) => s.closeCodeReview)
 
-  const load = useCallback(async () => {
-    dispatch({ type: 'LOAD_START' })
+  const load = useCallback(async (forceRefresh = false, showLoading = true) => {
+    if (showLoading) dispatch({ type: 'LOAD_START' })
     try {
-      const data = await ipc.github.getReviews(worktreePath) as PrReviewData
+      const data = await ipc.github.getReviews(worktreePath, forceRefresh) as PrReviewData
       dispatch({ type: 'LOAD_DONE', data })
     } catch {
       dispatch({ type: 'LOAD_ERROR' })
@@ -298,6 +413,10 @@ export function CodeReviewView({ worktreePath }: Props) {
   )
 
   const inlineCount = rootComments.length
+  const commentedFileCount = useMemo(
+    () => new Set(rootComments.map((c) => c.path)).size,
+    [rootComments],
+  )
 
   const handleBack = useCallback(() => {
     closeCodeReview()
@@ -308,6 +427,55 @@ export function CodeReviewView({ worktreePath }: Props) {
     const fullPath = worktreePath + '/' + path
     openFile(fullPath)
   }, [worktreePath, openFile])
+
+  const handleStartReply = useCallback((commentId: number) => {
+    setReplyingToId(commentId)
+    setReplyDraft('')
+    setReplyError(null)
+  }, [])
+
+  const handleCancelReply = useCallback(() => {
+    setReplyingToId(null)
+    setReplyDraft('')
+    setReplyError(null)
+  }, [])
+
+  const handleSubmitReply = useCallback(async (commentId: number) => {
+    const body = replyDraft.trim()
+    if (!body) return
+
+    setSubmittingReplyId(commentId)
+    setReplyError(null)
+    try {
+      await ipc.github.replyToReviewComment(worktreePath, commentId, body)
+      setReplyingToId(null)
+      setReplyDraft('')
+      await load(true, false)
+    } catch {
+      setReplyError(t('center:codeReviewReplyFailed'))
+    } finally {
+      setSubmittingReplyId(null)
+    }
+  }, [load, replyDraft, t, worktreePath])
+
+  const replyState = useMemo<ReplyState>(() => ({
+    replyingToId,
+    draft: replyDraft,
+    submittingId: submittingReplyId,
+    error: replyError,
+    onStart: handleStartReply,
+    onCancel: handleCancelReply,
+    onDraftChange: setReplyDraft,
+    onSubmit: handleSubmitReply,
+  }), [
+    replyingToId,
+    replyDraft,
+    submittingReplyId,
+    replyError,
+    handleStartReply,
+    handleCancelReply,
+    handleSubmitReply,
+  ])
 
   if (state.loading) {
     return (
@@ -343,6 +511,14 @@ export function CodeReviewView({ worktreePath }: Props) {
         onBack={handleBack}
         t={t}
         summary={t('center:codeReviewSummary', { reviewCount: dedupedReviews.length, commentCount: inlineCount })}
+      />
+
+      <CodeReviewOverview
+        reviewCount={dedupedReviews.length}
+        unresolvedCount={unresolvedCount}
+        resolvedCount={resolvedCount}
+        fileCount={commentedFileCount}
+        t={(key) => t(`center:${key}`)}
       />
 
       {/* Filter bar - only show when there are inline comments */}
@@ -387,6 +563,11 @@ export function CodeReviewView({ worktreePath }: Props) {
               <span className="code-review-file-path" onClick={() => handleOpenFile(filePath)}>
                 {filePath}
               </span>
+              {comments.some((c) => !c.isResolved) && (
+                <span className="code-review-file-open">
+                  {t('center:codeReviewFilterOpen', { count: comments.filter((c) => !c.isResolved).length })}
+                </span>
+              )}
               <span className="code-review-file-count">
                 {t('right:reviewComments', { count: comments.filter((c) => c.inReplyToId === null).length })}
               </span>
@@ -398,6 +579,7 @@ export function CodeReviewView({ worktreePath }: Props) {
                   comment={comment}
                   allComments={filteredComments}
                   isRoot
+                  replyState={replyState}
                   t={(k, opts) => t(`center:${k}`, opts as Record<string, string>)}
                 />
               ))}
@@ -412,6 +594,33 @@ export function CodeReviewView({ worktreePath }: Props) {
           />
         )}
       </div>
+    </div>
+  )
+}
+
+function CodeReviewOverview({
+  reviewCount, unresolvedCount, resolvedCount, fileCount, t,
+}: {
+  reviewCount: number
+  unresolvedCount: number
+  resolvedCount: number
+  fileCount: number
+  t: (key: string) => string
+}) {
+  const items = [
+    { label: t('codeReviewStatsReviews'), value: reviewCount, tone: 'neutral' },
+    { label: t('codeReviewStatsOpen'), value: unresolvedCount, tone: 'open' },
+    { label: t('codeReviewStatsResolved'), value: resolvedCount, tone: 'resolved' },
+    { label: t('codeReviewStatsFiles'), value: fileCount, tone: 'neutral' },
+  ]
+  return (
+    <div className="code-review-overview">
+      {items.map((item) => (
+        <div key={item.label} className={`code-review-overview-item code-review-overview-item--${item.tone}`}>
+          <span className="code-review-overview-value">{item.value}</span>
+          <span className="code-review-overview-label">{item.label}</span>
+        </div>
+      ))}
     </div>
   )
 }

--- a/src/renderer/components/Center/__tests__/CodeReviewView.test.tsx
+++ b/src/renderer/components/Center/__tests__/CodeReviewView.test.tsx
@@ -102,14 +102,31 @@ describe('CodeReviewView', () => {
     expect(screen.getByText('src/open.ts')).toBeDefined()
   })
 
-  it('opens markdown links externally without opening the comment URL', async () => {
-    vi.mocked(github.getReviews).mockResolvedValue(reviewData)
+  it('opens only safe markdown links and suppresses markdown images', async () => {
+    const dataWithLinks: PrReviewData = {
+      ...reviewData,
+      comments: reviewData.comments.map((comment) => comment.id === 2 ? {
+        ...comment,
+        body: [
+          'See [docs](https://example.com/docs).',
+          'Open [relative](/example/repo/issues/1).',
+          'Ignore [unsafe](file:///tmp/secret).',
+          '![tracking pixel](https://tracking.example/pixel.png)',
+        ].join('\n\n'),
+      } : comment),
+    }
+    vi.mocked(github.getReviews).mockResolvedValue(dataWithLinks)
 
-    render(<CodeReviewView worktreePath="/repo" />)
+    const { container } = render(<CodeReviewView worktreePath="/repo" />)
     fireEvent.click(await screen.findByRole('link', { name: 'docs' }))
+    fireEvent.click(screen.getByRole('link', { name: 'relative' }))
+    fireEvent.click(screen.getByText('unsafe'))
 
     expect(shell.openExternal).toHaveBeenCalledWith('https://example.com/docs')
+    expect(shell.openExternal).toHaveBeenCalledWith('https://github.com/example/repo/issues/1')
+    expect(shell.openExternal).not.toHaveBeenCalledWith('file:///tmp/secret')
     expect(shell.openExternal).not.toHaveBeenCalledWith('https://github.com/example/repo/pull/1#discussion_r2')
+    expect(container.querySelector('.code-review-markdown img')).toBeNull()
   })
 
   it('opens files from file headers', async () => {
@@ -139,6 +156,26 @@ describe('CodeReviewView', () => {
     expect(github.getReviews).toHaveBeenLastCalledWith('/repo', true)
   })
 
+  it('preserves reply drafts when switching between comment composers', async () => {
+    vi.mocked(github.getReviews).mockResolvedValue(reviewData)
+
+    render(<CodeReviewView worktreePath="/repo" />)
+    const replyButtons = await screen.findAllByRole('button', { name: 'codeReviewReply' })
+    fireEvent.click(replyButtons[0])
+    fireEvent.change(screen.getByPlaceholderText('codeReviewReplyPlaceholder'), {
+      target: { value: 'Draft for open comment' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'codeReviewReply' }))
+    fireEvent.change(screen.getByPlaceholderText('codeReviewReplyPlaceholder'), {
+      target: { value: 'Draft for resolved comment' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'codeReviewReply' }))
+
+    expect(screen.getByDisplayValue('Draft for open comment')).toBeDefined()
+  })
+
   it('keeps the composer open when posting a reply fails', async () => {
     vi.mocked(github.getReviews).mockResolvedValue(reviewData)
     vi.mocked(github.replyToReviewComment).mockRejectedValue(new Error('nope'))
@@ -153,5 +190,26 @@ describe('CodeReviewView', () => {
 
     expect(await screen.findByText('codeReviewReplyFailed')).toBeDefined()
     expect(screen.getByDisplayValue('Retry me')).toBeDefined()
+  })
+
+  it('does not report a failed reply when the post succeeds but refresh fails', async () => {
+    vi.mocked(github.getReviews)
+      .mockResolvedValueOnce(reviewData)
+      .mockRejectedValueOnce(new Error('refresh failed'))
+    vi.mocked(github.replyToReviewComment).mockResolvedValue(undefined)
+
+    render(<CodeReviewView worktreePath="/repo" />)
+    const replyButtons = await screen.findAllByRole('button', { name: 'codeReviewReply' })
+    fireEvent.click(replyButtons[0])
+    fireEvent.change(screen.getByPlaceholderText('codeReviewReplyPlaceholder'), {
+      target: { value: 'Posted already' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'codeReviewSendReply' }))
+
+    await waitFor(() => {
+      expect(github.getReviews).toHaveBeenCalledTimes(2)
+    })
+    expect(screen.queryByText('codeReviewReplyFailed')).toBeNull()
+    expect(screen.getByText('src/open.ts')).toBeDefined()
   })
 })

--- a/src/renderer/components/Center/__tests__/CodeReviewView.test.tsx
+++ b/src/renderer/components/Center/__tests__/CodeReviewView.test.tsx
@@ -100,6 +100,7 @@ describe('CodeReviewView', () => {
     expect(screen.getAllByText('const value = 1').length).toBeGreaterThan(0)
     expect(screen.getByText('summary')).toBeDefined()
     expect(screen.getByText('src/open.ts')).toBeDefined()
+    expect(screen.queryByRole('button', { name: 'codeReviewBack' })).toBeNull()
   })
 
   it('opens only safe markdown links and suppresses markdown images', async () => {

--- a/src/renderer/components/Center/__tests__/CodeReviewView.test.tsx
+++ b/src/renderer/components/Center/__tests__/CodeReviewView.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { PrReviewData } from '@/types'
+import { CodeReviewView } from '../CodeReviewView'
+import { github, shell } from '@/lib/ipc'
+
+const mockUi = vi.hoisted(() => ({
+  closeCodeReview: vi.fn(),
+  openFile: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { count?: number; reviewCount?: number; commentCount?: number }) => {
+      const label = key.includes(':') ? key.split(':').pop()! : key
+      if (opts?.reviewCount != null && opts?.commentCount != null) {
+        return `${label}:${opts.reviewCount}/${opts.commentCount}`
+      }
+      return opts?.count != null ? `${label}:${opts.count}` : label
+    },
+  }),
+}))
+
+vi.mock('@/lib/ipc', () => ({
+  github: { getReviews: vi.fn(), replyToReviewComment: vi.fn() },
+  shell: { openExternal: vi.fn() },
+}))
+
+vi.mock('@/store/ui', () => ({
+  useUIStore: (selector: (state: unknown) => unknown) => selector(mockUi),
+}))
+
+vi.mock('@/hooks/useShikiHighlight', () => ({
+  useShikiHighlight: () => null,
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const reviewData: PrReviewData = {
+  reviews: [
+    {
+      id: 10,
+      author: 'reviewer',
+      authorAvatarUrl: '',
+      state: 'APPROVED',
+      body: 'Review **summary**',
+      submittedAt: '2026-05-27T10:00:00Z',
+      htmlUrl: 'https://github.com/example/repo/pull/1#pullrequestreview-10',
+    },
+  ],
+  comments: [
+    {
+      id: 1,
+      reviewId: 10,
+      author: 'resolved-user',
+      authorAvatarUrl: '',
+      body: 'Resolved body',
+      path: 'src/resolved.ts',
+      line: 4,
+      originalLine: 4,
+      side: 'RIGHT',
+      diffHunk: '',
+      createdAt: '2026-05-27T09:00:00Z',
+      updatedAt: '2026-05-27T09:00:00Z',
+      htmlUrl: 'https://github.com/example/repo/pull/1#discussion_r1',
+      inReplyToId: null,
+      isResolved: true,
+    },
+    {
+      id: 2,
+      reviewId: 10,
+      author: 'open-user',
+      authorAvatarUrl: '',
+      body: 'See [docs](https://example.com/docs).\n\n```ts\nconst value = 1\n```',
+      path: 'src/open.ts',
+      line: 12,
+      originalLine: 12,
+      side: 'RIGHT',
+      diffHunk: '@@ -1,1 +1,1 @@\n-const value = 0\n+const value = 1',
+      createdAt: '2026-05-27T11:00:00Z',
+      updatedAt: '2026-05-27T11:00:00Z',
+      htmlUrl: 'https://github.com/example/repo/pull/1#discussion_r2',
+      inReplyToId: null,
+      isResolved: false,
+    },
+  ],
+}
+
+describe('CodeReviewView', () => {
+  it('renders overview stats and markdown comment bodies in the full review view', async () => {
+    vi.mocked(github.getReviews).mockResolvedValue(reviewData)
+
+    render(<CodeReviewView worktreePath="/repo" />)
+
+    expect(await screen.findByText('codeReviewStatsOpen')).toBeDefined()
+    expect(screen.getByText('codeReviewStatsResolved')).toBeDefined()
+    expect(screen.getAllByText('const value = 1').length).toBeGreaterThan(0)
+    expect(screen.getByText('summary')).toBeDefined()
+    expect(screen.getByText('src/open.ts')).toBeDefined()
+  })
+
+  it('opens markdown links externally without opening the comment URL', async () => {
+    vi.mocked(github.getReviews).mockResolvedValue(reviewData)
+
+    render(<CodeReviewView worktreePath="/repo" />)
+    fireEvent.click(await screen.findByRole('link', { name: 'docs' }))
+
+    expect(shell.openExternal).toHaveBeenCalledWith('https://example.com/docs')
+    expect(shell.openExternal).not.toHaveBeenCalledWith('https://github.com/example/repo/pull/1#discussion_r2')
+  })
+
+  it('opens files from file headers', async () => {
+    vi.mocked(github.getReviews).mockResolvedValue(reviewData)
+
+    render(<CodeReviewView worktreePath="/repo" />)
+    fireEvent.click(await screen.findByText('src/open.ts'))
+
+    expect(mockUi.openFile).toHaveBeenCalledWith('/repo/src/open.ts')
+  })
+
+  it('posts replies to top-level review comments and refreshes reviews', async () => {
+    vi.mocked(github.getReviews).mockResolvedValue(reviewData)
+    vi.mocked(github.replyToReviewComment).mockResolvedValue(undefined)
+
+    render(<CodeReviewView worktreePath="/repo" />)
+    const replyButtons = await screen.findAllByRole('button', { name: 'codeReviewReply' })
+    fireEvent.click(replyButtons[0])
+    fireEvent.change(screen.getByPlaceholderText('codeReviewReplyPlaceholder'), {
+      target: { value: 'Thanks, I fixed this.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'codeReviewSendReply' }))
+
+    await waitFor(() => {
+      expect(github.replyToReviewComment).toHaveBeenCalledWith('/repo', 2, 'Thanks, I fixed this.')
+    })
+    expect(github.getReviews).toHaveBeenLastCalledWith('/repo', true)
+  })
+
+  it('keeps the composer open when posting a reply fails', async () => {
+    vi.mocked(github.getReviews).mockResolvedValue(reviewData)
+    vi.mocked(github.replyToReviewComment).mockRejectedValue(new Error('nope'))
+
+    render(<CodeReviewView worktreePath="/repo" />)
+    const replyButtons = await screen.findAllByRole('button', { name: 'codeReviewReply' })
+    fireEvent.click(replyButtons[0])
+    fireEvent.change(screen.getByPlaceholderText('codeReviewReplyPlaceholder'), {
+      target: { value: 'Retry me' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'codeReviewSendReply' }))
+
+    expect(await screen.findByText('codeReviewReplyFailed')).toBeDefined()
+    expect(screen.getByDisplayValue('Retry me')).toBeDefined()
+  })
+})

--- a/src/renderer/components/Right/ReviewsSection.tsx
+++ b/src/renderer/components/Right/ReviewsSection.tsx
@@ -1,16 +1,15 @@
 /**
  * ReviewsSection - renders PR code reviews inline in the Checks tab.
  *
- * Shows up to 3 deduplicated review rows (latest per author), each with
- * avatar, author name, state badge, and optional body snippet. A "See all"
- * button appears when there are more reviews or inline comments to explore.
+ * Shows a compact PR review summary in the Checks tab.
+ * A "See all" button opens the full review panel for complete threads.
  */
+import type { KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SectionHeader } from '@/components/ui'
-import { ActionButton } from './ChecksSections'
-import type { PrReview, PrReviewData, ReviewState } from '@/types'
+import { SectionHeader } from '@/components/ui/SectionHeader'
+import type { PrReview, PrReviewComment, PrReviewData, ReviewState } from '@/types'
 
-const MAX_INLINE = 3
+const MAX_INLINE_REVIEWS = 3
 
 interface ReviewsSectionProps {
   reviews: PrReviewData
@@ -29,6 +28,24 @@ function dedupeReviews(reviews: PrReview[]): PrReview[] {
   }
   return Array.from(byAuthor.values())
     .sort((a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime())
+}
+
+const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto', style: 'short' })
+
+function formatTime(iso: string): string {
+  try {
+    const d = new Date(iso)
+    const diffMs = Date.now() - d.getTime()
+    const diffMinutes = Math.round(diffMs / 60000)
+    const diffHours = Math.round(diffMs / (1000 * 60 * 60))
+    const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24))
+    if (Math.abs(diffMinutes) < 60) return rtf.format(-diffMinutes, 'minute')
+    if (Math.abs(diffHours) < 24) return rtf.format(-diffHours, 'hour')
+    if (Math.abs(diffDays) < 7) return rtf.format(-diffDays, 'day')
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  } catch {
+    return ''
+  }
 }
 
 function reviewStateClass(state: ReviewState): string {
@@ -56,23 +73,45 @@ function ReviewStateBadge({ state }: { state: ReviewState }) {
   )
 }
 
-function ReviewRow({ review, onClick }: { review: PrReview; onClick: () => void }) {
+function ReviewActionButton({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button className="checks-action-btn checks-action-btn--secondary" onClick={onClick}>
+      {label}
+    </button>
+  )
+}
+
+function handleKeyboardActivate(e: KeyboardEvent<HTMLElement>, onClick: () => void) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    onClick()
+  }
+}
+
+function ReviewAvatar({ author, avatarUrl }: { author: string; avatarUrl: string }) {
+  if (avatarUrl) {
+    return <img className="review-avatar" src={avatarUrl} alt={author} />
+  }
+  return <span className="review-avatar-fallback">{author.trim().charAt(0) || '?'}</span>
+}
+
+function ReviewCard({ review, onClick }: { review: PrReview; onClick: () => void }) {
   return (
     <div
-      className="review-row"
+      className="review-summary-row"
       role="button"
       tabIndex={0}
       onClick={onClick}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } }}
+      onKeyDown={(e) => handleKeyboardActivate(e, onClick)}
     >
-      {review.authorAvatarUrl ? (
-        <img className="review-avatar" src={review.authorAvatarUrl} alt={review.author} />
-      ) : (
-        <span className="review-avatar-fallback">{review.author[0]}</span>
-      )}
-      <span className="review-author">{review.author}</span>
-      <ReviewStateBadge state={review.state} />
-      {review.body && <span className="review-snippet">{review.body}</span>}
+      <ReviewAvatar author={review.author} avatarUrl={review.authorAvatarUrl} />
+      <div className="review-preview-content">
+        <div className="review-preview-header">
+          <span className="review-author">{review.author}</span>
+          <ReviewStateBadge state={review.state} />
+          <span className="review-preview-time">{formatTime(review.submittedAt)}</span>
+        </div>
+      </div>
     </div>
   )
 }
@@ -81,13 +120,9 @@ export function ReviewsSection({ reviews, onOpenReview }: ReviewsSectionProps) {
   const { t } = useTranslation('right')
 
   const latestReviews = dedupeReviews(reviews.reviews)
-  if (latestReviews.length === 0 && reviews.comments.length === 0) return null
-
-  const displayReviews = latestReviews.slice(0, MAX_INLINE)
-  const hasMore = latestReviews.length > MAX_INLINE || reviews.comments.length > 0
-
-  // Count resolved/unresolved root comments
   const rootComments = reviews.comments.filter((c) => c.inReplyToId === null)
+  if (latestReviews.length === 0 && rootComments.length === 0) return null
+
   const resolvedCount = rootComments.filter((c) => c.isResolved).length
   const unresolvedCount = rootComments.length - resolvedCount
 
@@ -95,22 +130,20 @@ export function ReviewsSection({ reviews, onOpenReview }: ReviewsSectionProps) {
     <div className="checks-section">
       <SectionHeader
         title={t('codeReviews')}
-        count={latestReviews.length || undefined}
-        action={hasMore ? (
-          <ActionButton label={t('seeAllReviews')} onClick={onOpenReview} />
-        ) : undefined}
+        count={latestReviews.length + rootComments.length || undefined}
+        action={(
+          <ReviewActionButton label={t('seeAllReviews')} onClick={onOpenReview} />
+        )}
       />
-      <div className="checks-rows">
-        {displayReviews.map((review) => (
-          <ReviewRow key={review.id} review={review} onClick={onOpenReview} />
-        ))}
+
+      <div className="review-section-content">
         {rootComments.length > 0 && (
           <div
-            className="review-row"
+            className="review-summary-card"
             role="button"
             tabIndex={0}
             onClick={onOpenReview}
-            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenReview() } }}
+            onKeyDown={(e) => handleKeyboardActivate(e, onOpenReview)}
           >
             <span className="review-thread-counts">
               {unresolvedCount > 0 && (
@@ -124,6 +157,15 @@ export function ReviewsSection({ reviews, onOpenReview }: ReviewsSectionProps) {
                 </span>
               )}
             </span>
+          </div>
+        )}
+
+        {latestReviews.length > 0 && (
+          <div className="review-subsection">
+            <div className="review-subsection-title">{t('reviewLatestReviews')}</div>
+            {latestReviews.slice(0, MAX_INLINE_REVIEWS).map((review) => (
+              <ReviewCard key={review.id} review={review} onClick={onOpenReview} />
+            ))}
           </div>
         )}
       </div>

--- a/src/renderer/components/Right/ReviewsSection.tsx
+++ b/src/renderer/components/Right/ReviewsSection.tsx
@@ -7,7 +7,8 @@
 import type { KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SectionHeader } from '@/components/ui/SectionHeader'
-import type { PrReview, PrReviewComment, PrReviewData, ReviewState } from '@/types'
+import { formatRelativeTime } from '@/lib/relativeTime'
+import type { PrReview, PrReviewData, ReviewState } from '@/types'
 
 const MAX_INLINE_REVIEWS = 3
 
@@ -28,24 +29,6 @@ function dedupeReviews(reviews: PrReview[]): PrReview[] {
   }
   return Array.from(byAuthor.values())
     .sort((a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime())
-}
-
-const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto', style: 'short' })
-
-function formatTime(iso: string): string {
-  try {
-    const d = new Date(iso)
-    const diffMs = Date.now() - d.getTime()
-    const diffMinutes = Math.round(diffMs / 60000)
-    const diffHours = Math.round(diffMs / (1000 * 60 * 60))
-    const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24))
-    if (Math.abs(diffMinutes) < 60) return rtf.format(-diffMinutes, 'minute')
-    if (Math.abs(diffHours) < 24) return rtf.format(-diffHours, 'hour')
-    if (Math.abs(diffDays) < 7) return rtf.format(-diffDays, 'day')
-    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-  } catch {
-    return ''
-  }
 }
 
 function reviewStateClass(state: ReviewState): string {
@@ -109,7 +92,7 @@ function ReviewCard({ review, onClick }: { review: PrReview; onClick: () => void
         <div className="review-preview-header">
           <span className="review-author">{review.author}</span>
           <ReviewStateBadge state={review.state} />
-          <span className="review-preview-time">{formatTime(review.submittedAt)}</span>
+          <span className="review-preview-time">{formatRelativeTime(review.submittedAt)}</span>
         </div>
       </div>
     </div>

--- a/src/renderer/components/Right/__tests__/ReviewsSection.test.tsx
+++ b/src/renderer/components/Right/__tests__/ReviewsSection.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { PrReviewData } from '@/types'
+import { ReviewsSection } from '../ReviewsSection'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { count?: number }) => (
+      opts?.count != null ? `${key}:${opts.count}` : key
+    ),
+  }),
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const baseReviewData: PrReviewData = {
+  reviews: [
+    {
+      id: 10,
+      author: 'reviewer',
+      authorAvatarUrl: '',
+      state: 'COMMENTED',
+      body: 'Summary with **markdown**',
+      submittedAt: '2026-05-27T10:00:00Z',
+      htmlUrl: 'https://github.com/example/repo/pull/1#pullrequestreview-10',
+    },
+  ],
+  comments: [
+    {
+      id: 1,
+      reviewId: 10,
+      author: 'resolved-user',
+      authorAvatarUrl: '',
+      body: 'Resolved body',
+      path: 'src/resolved.ts',
+      line: 4,
+      originalLine: 4,
+      side: 'RIGHT',
+      diffHunk: '',
+      createdAt: '2026-05-27T09:00:00Z',
+      updatedAt: '2026-05-27T09:00:00Z',
+      htmlUrl: 'https://github.com/example/repo/pull/1#discussion_r1',
+      inReplyToId: null,
+      isResolved: true,
+    },
+    {
+      id: 2,
+      reviewId: 10,
+      author: 'open-user',
+      authorAvatarUrl: '',
+      body: 'Please check `value`.\n\n```ts\nconst value = 1\n```',
+      path: 'src/open.ts',
+      line: 12,
+      originalLine: 12,
+      side: 'RIGHT',
+      diffHunk: '',
+      createdAt: '2026-05-27T11:00:00Z',
+      updatedAt: '2026-05-27T11:00:00Z',
+      htmlUrl: 'https://github.com/example/repo/pull/1#discussion_r2',
+      inReplyToId: null,
+      isResolved: false,
+    },
+  ],
+}
+
+describe('ReviewsSection', () => {
+  it('renders a compact summary and latest review states', () => {
+    render(<ReviewsSection reviews={baseReviewData} onOpenReview={vi.fn()} />)
+
+    expect(screen.getByText('reviewUnresolved:1')).toBeDefined()
+    expect(screen.getByText('reviewResolved:1')).toBeDefined()
+    expect(screen.getByText('reviewLatestReviews')).toBeDefined()
+    expect(screen.getByText('reviewer')).toBeDefined()
+    expect(screen.getByText('reviewCommented')).toBeDefined()
+    expect(screen.queryByText('const value = 1')).toBeNull()
+    expect(screen.queryByText('src/open.ts')).toBeNull()
+  })
+
+  it('opens the full review panel from the summary', () => {
+    const onOpenReview = vi.fn()
+    render(<ReviewsSection reviews={baseReviewData} onOpenReview={onOpenReview} />)
+
+    fireEvent.click(screen.getByText('reviewUnresolved:1'))
+
+    expect(onOpenReview).toHaveBeenCalledTimes(1)
+  })
+
+  it('always exposes the full review action when activity exists', () => {
+    const onOpenReview = vi.fn()
+    render(<ReviewsSection reviews={baseReviewData} onOpenReview={onOpenReview} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'seeAllReviews' }))
+
+    expect(onOpenReview).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/lib/__tests__/safeExternalUrl.test.ts
+++ b/src/renderer/lib/__tests__/safeExternalUrl.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSafeExternalUrl } from '../safeExternalUrl'
+
+describe('resolveSafeExternalUrl', () => {
+  const baseUrl = 'https://github.com/example/repo/pull/1#discussion_r2'
+
+  it('allows web URLs and resolves relative GitHub links', () => {
+    expect(resolveSafeExternalUrl('https://example.com/docs', baseUrl)).toBe('https://example.com/docs')
+    expect(resolveSafeExternalUrl('/example/repo/issues/1', baseUrl)).toBe('https://github.com/example/repo/issues/1')
+  })
+
+  it('blocks unsafe or invalid URLs', () => {
+    expect(resolveSafeExternalUrl('file:///tmp/secret', baseUrl)).toBeNull()
+    expect(resolveSafeExternalUrl('javascript:alert(1)', baseUrl)).toBeNull()
+    expect(resolveSafeExternalUrl('http://[::1', baseUrl)).toBeNull()
+  })
+})

--- a/src/renderer/lib/ipc.ts
+++ b/src/renderer/lib/ipc.ts
@@ -182,6 +182,8 @@ export const github = {
     api().github.markPrReady(worktreePath),
   getReviews: (worktreePath: string, forceRefresh?: boolean) =>
     api().github.getReviews(worktreePath, forceRefresh),
+  replyToReviewComment: (worktreePath: string, commentId: number, body: string) =>
+    api().github.replyToReviewComment(worktreePath, commentId, body),
   startDeviceFlow: () =>
     api().github.startDeviceFlow(),
   cancelDeviceFlow: () =>

--- a/src/renderer/lib/relativeTime.ts
+++ b/src/renderer/lib/relativeTime.ts
@@ -1,0 +1,17 @@
+const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'always', style: 'short' })
+
+export function formatRelativeTime(iso: string): string {
+  try {
+    const date = new Date(iso)
+    const diffMs = Date.now() - date.getTime()
+    const diffMinutes = Math.max(1, Math.round(diffMs / 60000))
+    const diffHours = Math.round(diffMs / (1000 * 60 * 60))
+    const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24))
+    if (diffMinutes < 60) return rtf.format(-diffMinutes, 'minute')
+    if (diffHours < 24) return rtf.format(-diffHours, 'hour')
+    if (diffDays < 7) return rtf.format(-diffDays, 'day')
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  } catch {
+    return ''
+  }
+}

--- a/src/renderer/lib/safeExternalUrl.ts
+++ b/src/renderer/lib/safeExternalUrl.ts
@@ -1,0 +1,13 @@
+const SAFE_EXTERNAL_PROTOCOLS = new Set(['http:', 'https:'])
+
+export function resolveSafeExternalUrl(href: string | null | undefined, baseUrl?: string): string | null {
+  const raw = href?.trim()
+  if (!raw) return null
+
+  try {
+    const url = baseUrl ? new URL(raw, baseUrl) : new URL(raw)
+    return SAFE_EXTERNAL_PROTOCOLS.has(url.protocol) ? url.toString() : null
+  } catch {
+    return null
+  }
+}

--- a/src/renderer/locales/en/center.json
+++ b/src/renderer/locales/en/center.json
@@ -359,7 +359,6 @@
   "rateLimitWarning": "!",
   "codeReviewTitle": "Code Review",
   "codeReviewSummary": "{{reviewCount}} reviews, {{commentCount}} inline comments",
-  "codeReviewBack": "Back",
   "codeReviewOpenFile": "Open file",
   "codeReviewLine": "L{{line}}",
   "codeReviewNoReviews": "No reviews",

--- a/src/renderer/locales/en/center.json
+++ b/src/renderer/locales/en/center.json
@@ -372,5 +372,15 @@
   "codeReviewFilterOpen": "Open ({{count}})",
   "codeReviewFilterResolved": "Resolved ({{count}})",
   "codeReviewNoResolved": "No resolved comments",
-  "codeReviewNoOpen": "No open comments"
+  "codeReviewNoOpen": "No open comments",
+  "codeReviewStatsReviews": "Reviews",
+  "codeReviewStatsOpen": "Open",
+  "codeReviewStatsResolved": "Resolved",
+  "codeReviewStatsFiles": "Files",
+  "codeReviewReply": "Reply",
+  "codeReviewReplyPlaceholder": "Write a reply...",
+  "codeReviewSendReply": "Send reply",
+  "codeReviewSendingReply": "Sending...",
+  "codeReviewCancelReply": "Cancel",
+  "codeReviewReplyFailed": "Could not post reply"
 }

--- a/src/renderer/locales/en/right.json
+++ b/src/renderer/locales/en/right.json
@@ -340,6 +340,7 @@
   "reviewCommented": "Commented",
   "reviewDismissed": "Dismissed",
   "reviewNoReviews": "No reviews yet",
+  "reviewLatestReviews": "Latest reviews",
   "reviewComments_one": "{{count}} comment",
   "reviewComments_other": "{{count}} comments",
   "reviewUnresolved_one": "{{count}} open",

--- a/src/renderer/locales/id/center.json
+++ b/src/renderer/locales/id/center.json
@@ -354,5 +354,15 @@
   "codeReviewFilterOpen": "Terbuka ({{count}})",
   "codeReviewFilterResolved": "Terselesaikan ({{count}})",
   "codeReviewNoResolved": "Tidak ada komentar terselesaikan",
-  "codeReviewNoOpen": "Tidak ada komentar terbuka"
+  "codeReviewNoOpen": "Tidak ada komentar terbuka",
+  "codeReviewStatsReviews": "Ulasan",
+  "codeReviewStatsOpen": "Terbuka",
+  "codeReviewStatsResolved": "Terselesaikan",
+  "codeReviewStatsFiles": "File",
+  "codeReviewReply": "Balas",
+  "codeReviewReplyPlaceholder": "Tulis balasan...",
+  "codeReviewSendReply": "Kirim balasan",
+  "codeReviewSendingReply": "Mengirim...",
+  "codeReviewCancelReply": "Batal",
+  "codeReviewReplyFailed": "Tidak dapat mengirim balasan"
 }

--- a/src/renderer/locales/id/center.json
+++ b/src/renderer/locales/id/center.json
@@ -341,7 +341,6 @@
   "rateLimitWarning": "!",
   "codeReviewTitle": "Ulasan Kode",
   "codeReviewSummary": "{{reviewCount}} ulasan, {{commentCount}} komentar inline",
-  "codeReviewBack": "Kembali",
   "codeReviewOpenFile": "Buka file",
   "codeReviewLine": "L{{line}}",
   "codeReviewNoReviews": "Belum ada ulasan",

--- a/src/renderer/locales/id/right.json
+++ b/src/renderer/locales/id/right.json
@@ -340,6 +340,7 @@
   "reviewCommented": "Dikomentari",
   "reviewDismissed": "Ditolak",
   "reviewNoReviews": "Belum ada ulasan",
+  "reviewLatestReviews": "Ulasan terbaru",
   "reviewComments_one": "{{count}} komentar",
   "reviewComments_other": "{{count}} komentar",
   "reviewUnresolved_one": "{{count}} terbuka",

--- a/src/renderer/locales/ja/center.json
+++ b/src/renderer/locales/ja/center.json
@@ -342,7 +342,6 @@
   "rateLimitWarning": "!",
   "codeReviewTitle": "コードレビュー",
   "codeReviewSummary": "{{reviewCount}}件のレビュー、{{commentCount}}件のインラインコメント",
-  "codeReviewBack": "戻る",
   "codeReviewOpenFile": "ファイルを開く",
   "codeReviewLine": "L{{line}}",
   "codeReviewNoReviews": "レビューなし",

--- a/src/renderer/locales/ja/center.json
+++ b/src/renderer/locales/ja/center.json
@@ -355,5 +355,15 @@
   "codeReviewFilterOpen": "未解決 ({{count}})",
   "codeReviewFilterResolved": "解決済み ({{count}})",
   "codeReviewNoResolved": "解決済みのコメントはありません",
-  "codeReviewNoOpen": "未解決のコメントはありません"
+  "codeReviewNoOpen": "未解決のコメントはありません",
+  "codeReviewStatsReviews": "レビュー",
+  "codeReviewStatsOpen": "未解決",
+  "codeReviewStatsResolved": "解決済み",
+  "codeReviewStatsFiles": "ファイル",
+  "codeReviewReply": "返信",
+  "codeReviewReplyPlaceholder": "返信を書く...",
+  "codeReviewSendReply": "返信を送信",
+  "codeReviewSendingReply": "送信中...",
+  "codeReviewCancelReply": "キャンセル",
+  "codeReviewReplyFailed": "返信を投稿できませんでした"
 }

--- a/src/renderer/locales/ja/right.json
+++ b/src/renderer/locales/ja/right.json
@@ -340,6 +340,7 @@
   "reviewCommented": "コメント",
   "reviewDismissed": "却下",
   "reviewNoReviews": "レビューはまだありません",
+  "reviewLatestReviews": "最新のレビュー",
   "reviewComments_one": "{{count}}件のコメント",
   "reviewComments_other": "{{count}}件のコメント",
   "reviewUnresolved_one": "{{count}} 未解決",

--- a/src/renderer/locales/zh/center.json
+++ b/src/renderer/locales/zh/center.json
@@ -359,7 +359,6 @@
   "rateLimitWarning": "!",
   "codeReviewTitle": "代码审查",
   "codeReviewSummary": "{{reviewCount}} 个审查, {{commentCount}} 条内联评论",
-  "codeReviewBack": "返回",
   "codeReviewOpenFile": "打开文件",
   "codeReviewLine": "L{{line}}",
   "codeReviewNoReviews": "暂无审查",

--- a/src/renderer/locales/zh/center.json
+++ b/src/renderer/locales/zh/center.json
@@ -372,5 +372,15 @@
   "codeReviewFilterOpen": "未解决 ({{count}})",
   "codeReviewFilterResolved": "已解决 ({{count}})",
   "codeReviewNoResolved": "没有已解决的评论",
-  "codeReviewNoOpen": "没有未解决的评论"
+  "codeReviewNoOpen": "没有未解决的评论",
+  "codeReviewStatsReviews": "审查",
+  "codeReviewStatsOpen": "未解决",
+  "codeReviewStatsResolved": "已解决",
+  "codeReviewStatsFiles": "文件",
+  "codeReviewReply": "回复",
+  "codeReviewReplyPlaceholder": "写回复...",
+  "codeReviewSendReply": "发送回复",
+  "codeReviewSendingReply": "发送中...",
+  "codeReviewCancelReply": "取消",
+  "codeReviewReplyFailed": "无法发布回复"
 }

--- a/src/renderer/locales/zh/right.json
+++ b/src/renderer/locales/zh/right.json
@@ -340,6 +340,7 @@
   "reviewCommented": "已评论",
   "reviewDismissed": "已驳回",
   "reviewNoReviews": "暂无审查",
+  "reviewLatestReviews": "最新审查",
   "reviewComments_one": "{{count}} 条评论",
   "reviewComments_other": "{{count}} 条评论",
   "reviewUnresolved_one": "{{count}} 个未解决",

--- a/src/renderer/styles/code-review.css
+++ b/src/renderer/styles/code-review.css
@@ -187,28 +187,10 @@
 .code-review-header {
   display: flex;
   align-items: center;
-  gap: var(--space-12);
+  gap: var(--space-10);
   padding: var(--space-12) var(--space-16);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
-}
-
-.code-review-header-back {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-4);
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  border-radius: var(--radius);
-  transition: color var(--duration-fast), background var(--duration-fast);
-}
-
-.code-review-header-back:hover {
-  color: var(--text-primary);
-  background: var(--bg-hover);
 }
 
 .code-review-header-title {

--- a/src/renderer/styles/code-review.css
+++ b/src/renderer/styles/code-review.css
@@ -1,16 +1,57 @@
 /* ─── Reviews section in Checks tab ──────────────────────────────────────────── */
 
-.review-row {
+.review-section-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  padding: 0 var(--space-14) var(--space-6);
+}
+
+.review-summary-card {
+  display: flex;
+  align-items: center;
+  min-height: 30px;
+  padding: var(--space-4) 0;
+  cursor: pointer;
+  border-radius: var(--radius);
+}
+
+.review-summary-card:hover {
+  background: var(--bg-hover);
+}
+
+.review-summary-card:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.review-subsection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.review-subsection-title {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.review-summary-row {
   display: flex;
   align-items: center;
   gap: var(--space-8);
-  padding: var(--space-6) var(--space-14);
-  min-height: 32px;
+  min-width: 0;
+  min-height: 30px;
+  padding: var(--space-4) 0;
+  border-radius: var(--radius);
   cursor: pointer;
   transition: background var(--duration-fast);
 }
 
-.review-row:hover {
+.review-summary-row:hover {
   background: var(--bg-hover);
 }
 
@@ -37,25 +78,38 @@
   text-transform: uppercase;
 }
 
+.review-preview-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.review-preview-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  min-width: 0;
+}
+
 .review-author {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
   font-size: var(--text-md);
   font-weight: var(--weight-medium);
-  color: var(--text-primary);
-  flex-shrink: 0;
-  max-width: 100px;
-  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .review-state-badge {
-  font-size: var(--text-sm);
-  font-weight: var(--weight-medium);
+  flex-shrink: 0;
   padding: var(--space-1) var(--space-6);
   border-radius: var(--radius-lg);
-  white-space: nowrap;
-  flex-shrink: 0;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
   line-height: 1.5;
+  white-space: nowrap;
 }
 
 .review-state-badge--approved {
@@ -82,14 +136,11 @@
   border: 1px solid var(--amber-tint-30);
 }
 
-.review-snippet {
-  flex: 1;
-  font-size: var(--text-base);
+.review-preview-time {
+  margin-left: auto;
   color: var(--text-muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
+  font-size: var(--text-sm);
   white-space: nowrap;
-  min-width: 0;
 }
 
 /* ─── Thread count badges in Checks tab ────────────────────────────────────── */
@@ -97,7 +148,8 @@
 .review-thread-counts {
   display: flex;
   align-items: center;
-  gap: var(--space-8);
+  gap: var(--space-6);
+  flex-wrap: wrap;
 }
 
 .review-thread-badge {
@@ -171,6 +223,53 @@
   margin-left: auto;
 }
 
+/* ─── Overview stats ───────────────────────────────────────────────────────── */
+
+.code-review-overview {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-8);
+  padding: var(--space-10) var(--space-16);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+  flex-shrink: 0;
+}
+
+.code-review-overview-item {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-8) var(--space-10);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-primary);
+}
+
+.code-review-overview-value {
+  color: var(--text-primary);
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-none);
+}
+
+.code-review-overview-label {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  line-height: var(--leading-tight);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.code-review-overview-item--open .code-review-overview-value {
+  color: var(--amber);
+}
+
+.code-review-overview-item--resolved .code-review-overview-value {
+  color: var(--green);
+}
+
 /* ─── Filter bar ──────────────────────────────────────────────────────────── */
 
 .code-review-filter-bar {
@@ -226,7 +325,7 @@
 .code-review-body {
   flex: 1;
   overflow-y: auto;
-  padding: var(--space-4) 0;
+  padding: var(--space-4) 0 var(--space-16);
 }
 
 /* ─── Review summary cards ─────────────────────────────────────────────────── */
@@ -244,7 +343,7 @@
   gap: var(--space-10);
   padding: var(--space-10) var(--space-12);
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   background: var(--bg-secondary);
   transition: background var(--duration-fast);
   cursor: pointer;
@@ -288,20 +387,19 @@
   margin-left: auto;
 }
 
-.code-review-card-body {
-  font-size: var(--text-md);
-  color: var(--text-secondary);
-  line-height: var(--leading-relaxed);
+.code-review-card .code-review-markdown {
+  max-height: 112px;
   overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
 }
 
 /* ─── Inline comments grouped by file ──────────────────────────────────────── */
 
 .code-review-file-group {
-  border-top: 1px solid var(--border);
+  margin: var(--space-10) var(--space-16) 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-primary);
 }
 
 .code-review-file-header {
@@ -318,6 +416,8 @@
 }
 
 .code-review-file-path {
+  flex: 1;
+  min-width: 0;
   font-family: var(--font-mono);
   font-size: var(--text-base);
   color: var(--accent);
@@ -334,8 +434,19 @@
 .code-review-file-count {
   font-size: var(--text-sm);
   color: var(--text-muted);
-  margin-left: auto;
   flex-shrink: 0;
+}
+
+.code-review-file-open {
+  margin-left: auto;
+  padding: var(--space-1) var(--space-6);
+  border: 1px solid var(--amber-tint-30);
+  border-radius: var(--radius-pill);
+  background: var(--amber-tint-15);
+  color: var(--amber);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  white-space: nowrap;
 }
 
 .code-review-comments {
@@ -346,7 +457,7 @@
 .code-review-comment {
   display: flex;
   gap: var(--space-10);
-  padding: var(--space-10) var(--space-16) var(--space-10) var(--space-24);
+  padding: var(--space-12) var(--space-16);
   border-top: 1px solid var(--border);
   cursor: pointer;
   transition: background var(--duration-fast), opacity var(--duration-fast);
@@ -435,26 +546,90 @@
   margin-left: auto;
 }
 
-.code-review-comment-body {
+.code-review-markdown {
+  min-width: 0;
   font-size: var(--text-md);
   color: var(--text-secondary);
   line-height: var(--leading-relaxed);
+  word-break: break-word;
 }
 
-.code-review-comment-body p {
-  margin: 0 0 var(--space-4);
+.code-review-markdown p {
+  margin: 0 0 var(--space-8);
 }
 
-.code-review-comment-body p:last-child {
+.code-review-markdown p:last-child {
   margin-bottom: 0;
 }
 
-.code-review-comment-body code {
+.code-review-markdown ul,
+.code-review-markdown ol {
+  margin: var(--space-6) 0;
+  padding-left: var(--space-20);
+}
+
+.code-review-markdown li + li {
+  margin-top: var(--space-3);
+}
+
+.code-review-markdown code {
   font-family: var(--font-mono);
   font-size: var(--text-base);
   background: var(--bg-tertiary);
   padding: var(--space-1) var(--space-4);
   border-radius: var(--radius-sm);
+}
+
+.code-review-markdown pre {
+  max-height: 260px;
+  margin: var(--space-8) 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-tertiary);
+}
+
+.code-review-markdown pre code {
+  display: block;
+  min-width: max-content;
+  padding: var(--space-10);
+  background: transparent;
+  white-space: pre;
+}
+
+.code-review-markdown blockquote {
+  margin: var(--space-8) 0;
+  padding-left: var(--space-10);
+  border-left: 2px solid var(--border-strong, var(--border));
+  color: var(--text-muted);
+}
+
+.code-review-markdown a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.code-review-markdown a:hover {
+  text-decoration: underline;
+}
+
+.code-review-markdown table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+}
+
+.code-review-markdown th,
+.code-review-markdown td {
+  padding: var(--space-4) var(--space-6);
+  border: 1px solid var(--border);
+}
+
+.code-review-markdown img {
+  max-width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
 }
 
 /* ─── Syntax-highlighted diff hunk ─────────────────────────────────────────── */
@@ -465,30 +640,30 @@
   line-height: 1.5;
   border-radius: var(--radius);
   margin: var(--space-2) 0 var(--space-4);
-  overflow-x: auto;
+  max-width: 100%;
+  overflow: auto;
   border: 1px solid var(--border);
   max-height: 140px;
-  overflow-y: auto;
   background: var(--bg-secondary);
 }
 
 .cr-diff-line {
-  display: flex;
+  display: grid;
+  grid-template-columns: 20px max-content;
+  min-width: max-content;
   min-height: 20px;
 }
 
 .cr-diff-gutter {
-  width: 16px;
+  width: 20px;
   text-align: center;
-  flex-shrink: 0;
   user-select: none;
   color: var(--text-muted);
 }
 
 .cr-diff-content {
-  flex: 1;
   white-space: pre;
-  padding-right: var(--space-8);
+  padding-right: var(--space-12);
   tab-size: 4;
 }
 
@@ -517,7 +692,8 @@
 .cr-diff-range {
   background: var(--accent-tint-6);
   color: var(--accent);
-  padding-left: var(--space-4);
+  grid-template-columns: max-content;
+  padding: 0 var(--space-8);
 }
 .cr-diff-range .cr-diff-content {
   color: var(--text-muted);
@@ -529,6 +705,109 @@
   border-left: 2px solid var(--border);
   margin-left: var(--space-12);
   margin-top: var(--space-4);
+}
+
+.code-review-reply-slot {
+  margin: var(--space-6) var(--space-16) var(--space-10) 58px;
+}
+
+.code-review-reply-button {
+  padding: var(--space-3) var(--space-8);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+}
+
+.code-review-reply-button:hover {
+  border-color: var(--accent-tint-30);
+  background: var(--accent-tint-6);
+  color: var(--accent);
+}
+
+.code-review-reply-composer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  padding: var(--space-10);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+}
+
+.code-review-reply-textarea {
+  width: 100%;
+  min-height: 92px;
+  resize: vertical;
+  padding: var(--space-8);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: var(--text-md);
+  line-height: var(--leading-relaxed);
+}
+
+.code-review-reply-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--shadow-focus);
+}
+
+.code-review-reply-textarea:disabled {
+  opacity: 0.7;
+}
+
+.code-review-reply-error {
+  color: var(--red);
+  font-size: var(--text-base);
+}
+
+.code-review-reply-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-8);
+}
+
+.code-review-reply-cancel,
+.code-review-reply-submit {
+  padding: var(--space-4) var(--space-10);
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+}
+
+.code-review-reply-cancel {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.code-review-reply-cancel:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.code-review-reply-submit {
+  border: 1px solid var(--accent-tint-30);
+  background: var(--accent-tint-10);
+  color: var(--accent);
+}
+
+.code-review-reply-submit:hover:not(:disabled) {
+  border-color: var(--accent);
+  background: var(--accent-tint-18);
+}
+
+.code-review-reply-cancel:disabled,
+.code-review-reply-submit:disabled {
+  cursor: default;
+  opacity: 0.55;
 }
 
 /* ─── Empty state ──────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Add reply-to-review-comment functionality - users can reply to PR review comments directly from the code review panel, with the reply posted via the GitHub API and the review data refreshed automatically
- Render review comment bodies as Markdown (with GFM support for code blocks, tables, links, etc.) instead of plain text
- Redesign the ReviewsSection (Checks tab) and CodeReviewView (full review panel) with an overview stats bar, improved comment sorting, and a more polished layout

## Layers touched

- [x] **Main process** (`src/main/`) — services, IPC handlers
- [x] **Preload** (`src/preload/`) — context bridge API
- [x] **Renderer** (`src/renderer/`) — components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Center panel:**
- `CodeReviewView.tsx`: Added `ReplySlot` composer (textarea + send/cancel), `CodeReviewOverview` stats bar (reviews, open, resolved, files), `CodeReviewMarkdown` component using `react-markdown` + `remark-gfm`, improved comment sorting (unresolved first, then by line number), file groups sorted by open comment count
- New test suite `CodeReviewView.test.tsx` covering overview rendering, markdown links, file opening, reply submission, and error handling

**Right panel:**
- `ReviewsSection.tsx`: Redesigned to a compact summary card layout with thread count badges, relative timestamps, separated review cards subsection, extracted `ReviewAvatar` and `ReviewActionButton` components
- New test suite `ReviewsSection.test.tsx` covering compact summary, click-to-open, and action button behavior

**Services** (`github.ts`):
- Added `replyToReviewComment()` method using `gh api repos/{nwo}/pulls/{pr}/comments/{id}/replies` with cache invalidation

**IPC** (`main/ipc.ts` → `preload/index.ts` → `lib/ipc.ts`):
- Threaded `github:replyToReviewComment` through all 3 layers

**Styles** (`code-review.css`):
- Full markdown rendering styles (code blocks, blockquotes, tables, lists, images, links)
- Overview stats grid, reply composer, file group cards with open-count badges
- Diff hunk layout switched to CSS grid for consistent alignment

**i18n:**
- Added 10 new keys to `center.json` (reply UI, stats labels) and 1 to `right.json` across all 4 locales (en, ja, id, zh)

## How to test

1. `yarn dev`
2. Open a project with a PR that has review comments
3. Click the code reviews section in the Checks tab - verify the compact summary shows thread counts and reviewer avatars
4. Click "See all" to open the full review panel - verify the overview stats bar shows correct counts
5. Verify comment bodies render as Markdown (code blocks, links, bold/italic)
6. Click a Markdown link - verify it opens externally (not navigating the comment URL)
7. Click "Reply" on a review comment, type a reply, and send - verify it posts to GitHub and the view refreshes
8. Test reply error handling by disconnecting network before sending

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass — `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [x] IPC changes are threaded through all 3 layers (main → preload → renderer)
- [x] New state is added to the correct Zustand store