### PR TITLE
Add sandboxed HTML file preview

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -40,6 +40,7 @@ process.stderr?.on?.('error', () => {})
 
 let mainWindow: BrowserWindow | null = null
 const htmlPreviewSessions = new WeakSet<import('electron').Session>()
+let htmlPreviewSession: import('electron').Session | null = null
 
 function isHttpUrl(url: string): boolean {
   try {
@@ -70,6 +71,14 @@ function configureHtmlPreviewSession(sess: import('electron').Session): void {
   sess.setDisplayMediaRequestHandler((_request, callback) => {
     callback({ video: undefined, audio: undefined })
   })
+}
+
+function getHtmlPreviewSession(): import('electron').Session {
+  if (!htmlPreviewSession) {
+    htmlPreviewSession = session.fromPartition(HTML_PREVIEW_PARTITION)
+    configureHtmlPreviewSession(htmlPreviewSession)
+  }
+  return htmlPreviewSession
 }
 
 function createWindow(): void {
@@ -134,7 +143,7 @@ function createWindow(): void {
 
     if (isHtmlPreview) {
       webPreferences.plugins = false
-      configureHtmlPreviewSession(session.fromPartition(HTML_PREVIEW_PARTITION))
+      configureHtmlPreviewSession(getHtmlPreviewSession())
     }
   })
 
@@ -161,8 +170,10 @@ function createWindow(): void {
 
     if (isHtmlPreview) {
       webviewContents.on('will-navigate', (event, url) => {
-        if (isFileUrl(url) || (!isHttpUrl(url) && url !== 'about:blank')) {
-          event.preventDefault()
+        if (url === 'about:blank') return
+        event.preventDefault()
+        if (isHttpUrl(url)) {
+          shell.openExternal(url)
         }
       })
     }
@@ -225,12 +236,17 @@ function configureWebAppSession(sess: import('electron').Session): void {
   })
 }
 
-app.on('session-created', (sess) => {
-  if (sess === session.defaultSession) return
-  configureWebAppSession(sess)
-})
-
 app.whenReady().then(async () => {
+  getHtmlPreviewSession()
+  app.on('session-created', (sess) => {
+    if (sess === session.defaultSession) return
+    if (sess === getHtmlPreviewSession()) {
+      configureHtmlPreviewSession(sess)
+      return
+    }
+    configureWebAppSession(sess)
+  })
+
   // Resolve login-shell PATH early so all CLI lookups see the user's full PATH.
   await waitForEnrichedEnv()
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,7 @@ import { ensureAllAgentHooks } from './services/agentHooks'
 import { startAgentHookServer, stopAgentHookServer } from './services/agentHookServer'
 import { ptyService } from './services/pty'
 import { mobileServer } from './services/mobileServer'
+import { HTML_PREVIEW_PARTITION } from '../shared/html-preview'
 
 // Prevent EPIPE errors from crashing the process when stdout/stderr pipes break
 // (common in Electron when the renderer detaches or during hot-reload).
@@ -38,6 +39,38 @@ process.stdout?.on?.('error', () => {})
 process.stderr?.on?.('error', () => {})
 
 let mainWindow: BrowserWindow | null = null
+const htmlPreviewSessions = new WeakSet<import('electron').Session>()
+
+function isHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function isFileUrl(url: string): boolean {
+  try {
+    return new URL(url).protocol === 'file:'
+  } catch {
+    return false
+  }
+}
+
+function isWebAppPartition(partition: string): boolean {
+  return /^persist:webapp-[A-Za-z0-9._-]+$/.test(partition)
+}
+
+function configureHtmlPreviewSession(sess: import('electron').Session): void {
+  if (htmlPreviewSessions.has(sess)) return
+  htmlPreviewSessions.add(sess)
+  sess.setPermissionRequestHandler((_wc, _permission, callback) => callback(false))
+  sess.setPermissionCheckHandler(() => false)
+  sess.setDisplayMediaRequestHandler((_request, callback) => {
+    callback({ video: undefined, audio: undefined })
+  })
+}
 
 function createWindow(): void {
   const iconPath = join(__dirname, '../../build/icon.png')
@@ -71,21 +104,68 @@ function createWindow(): void {
     return { action: 'deny' }
   })
 
+  mainWindow.webContents.on('will-attach-webview', (event, webPreferences, params) => {
+    const src = typeof params.src === 'string' ? params.src : ''
+    const partition =
+      typeof params.partition === 'string'
+        ? params.partition
+        : typeof webPreferences.partition === 'string'
+          ? webPreferences.partition
+          : ''
+    const isHtmlPreview =
+      partition === HTML_PREVIEW_PARTITION && isFileUrl(src)
+    const isEmbeddedWebApp =
+      isWebAppPartition(partition) && isHttpUrl(src)
+
+    if (!isHtmlPreview && !isEmbeddedWebApp) {
+      event.preventDefault()
+      return
+    }
+
+    delete webPreferences.preload
+    delete (webPreferences as Record<string, unknown>).preloadURL
+    webPreferences.nodeIntegration = false
+    webPreferences.nodeIntegrationInSubFrames = false
+    webPreferences.contextIsolation = true
+    webPreferences.sandbox = true
+    webPreferences.webSecurity = true
+    webPreferences.allowRunningInsecureContent = false
+    webPreferences.partition = partition
+
+    if (isHtmlPreview) {
+      webPreferences.plugins = false
+      configureHtmlPreviewSession(session.fromPartition(HTML_PREVIEW_PARTITION))
+    }
+  })
+
   // When a <webview> tries to open a new window (e.g. Slack auth, links),
   // navigate the webview in-place instead of spawning a popup.
   // Also enable native right-click context menu (copy, paste, etc.).
   mainWindow.webContents.on('did-attach-webview', (_event, webviewContents) => {
+    const isHtmlPreview = htmlPreviewSessions.has(webviewContents.session)
     // Belt-and-suspenders: also configure the webview's session here in case
     // session-created fires too late for some Electron/ASAR edge case.
-    configureWebAppSession(webviewContents.session)
+    if (isHtmlPreview) {
+      configureHtmlPreviewSession(webviewContents.session)
+    } else {
+      configureWebAppSession(webviewContents.session)
+    }
 
     // Auth flows (OAuth popups, SSO) should open in the system browser where
     // the user's session cookies already exist. Regular same-origin navigations
     // are handled in-place by the webview itself.
     webviewContents.setWindowOpenHandler(({ url }) => {
-      shell.openExternal(url)
+      if (!isHtmlPreview || isHttpUrl(url)) shell.openExternal(url)
       return { action: 'deny' }
     })
+
+    if (isHtmlPreview) {
+      webviewContents.on('will-navigate', (event, url) => {
+        if (isFileUrl(url) || (!isHttpUrl(url) && url !== 'about:blank')) {
+          event.preventDefault()
+        }
+      })
+    }
 
     // Suppress ERR_ABORTED (-3) from auth redirect chains — these are expected
     // when sites redirect through SSO (e.g. Notion → Google SSO → back).

--- a/src/renderer/components/Right/FileViewer.tsx
+++ b/src/renderer/components/Right/FileViewer.tsx
@@ -20,6 +20,8 @@ import { DiagnosticsPanel } from './DiagnosticsPanel'
 import { BinaryImagePreview, BinaryPlaceholder } from './BinaryFilePreview'
 import { isBinaryFile, isImageFile } from '@/lib/binaryFile'
 import { pendingReveal } from '@/lib/pendingReveal'
+import { HtmlFilePreview } from './HtmlFilePreview'
+import { isHtmlPreviewFile } from '@/lib/htmlPreview'
 
 interface Props {
   filePath: string | null
@@ -33,7 +35,7 @@ const EXT_TO_LANG: Record<string, string> = {
   ts: 'typescript', tsx: 'typescriptreact',
   js: 'javascript', jsx: 'javascriptreact',
   json: 'json', md: 'markdown', css: 'css', scss: 'scss',
-  html: 'html', yml: 'yaml', yaml: 'yaml', py: 'python',
+  html: 'html', htm: 'html', yml: 'yaml', yaml: 'yaml', py: 'python',
   rs: 'rust', go: 'go', swift: 'swift', kt: 'kotlin', kts: 'kotlin',
   java: 'java', m: 'objective-c', mm: 'objective-c', php: 'php',
   sh: 'shell', bash: 'shell', zsh: 'shell', toml: 'ini',
@@ -76,7 +78,7 @@ interface State {
 }
 
 type Action =
-  | { type: 'loadStart' }
+  | { type: 'loadStart'; showPreview?: boolean }
   | { type: 'loadDone'; content: string }
   | { type: 'loadFail' }
   | { type: 'change'; content: string; savedContent: string }
@@ -91,7 +93,15 @@ type Action =
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'loadStart':
-      return { ...state, loading: true, isDirty: false, saveError: null, diagnosticsOpen: false, markerCount: 0 }
+      return {
+        ...state,
+        loading: true,
+        isDirty: false,
+        saveError: null,
+        diagnosticsOpen: false,
+        markerCount: 0,
+        showPreview: action.showPreview ?? false,
+      }
     case 'loadDone':
       return { ...state, loading: false, savedContent: action.content, currentContent: action.content }
     case 'loadFail':
@@ -223,7 +233,7 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
       pendingRevealRef.current = target
       setRevealing(true)
     }
-    dispatch({ type: 'loadStart' })
+    dispatch({ type: 'loadStart', showPreview: isHtmlPreviewFile(filePath) })
     ipc.git
       .readFile(filePath)
       .then((text: string) => {
@@ -240,7 +250,7 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
 
   const handleSave = useCallback(async () => {
     if (!filePath || state.saving) return
-    const currentValue = editorRef.current?.getValue() ?? ''
+    const currentValue = editorRef.current?.getValue() ?? state.currentContent
     if (currentValue === state.savedContent) return
     dispatch({ type: 'saveStart' })
     try {
@@ -249,7 +259,7 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
     } catch {
       dispatch({ type: 'saveFail', error: t('fileSaveError') })
     }
-  }, [filePath, state.saving, state.savedContent, t])
+  }, [filePath, state.saving, state.currentContent, state.savedContent, t])
 
   useEffect(() => { handleSaveRef.current = handleSave }, [handleSave])
 
@@ -324,6 +334,8 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
   const fileName = filePath.split('/').slice(-2).join('/')
   const ext = filePath.split('.').pop()?.toLowerCase() ?? ''
   const isMarkdown = ext === 'md' || ext === 'mdx'
+  const isHtmlPreview = isHtmlPreviewFile(filePath)
+  const canPreview = isMarkdown || isHtmlPreview
   const isBinary = isBinaryFile(filePath)
 
   // Binary file rendering (images, fonts, etc.)
@@ -387,7 +399,7 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
           {state.saveError && (
             <span style={{ fontSize: 13, color: 'var(--red)' }}>{state.saveError}</span>
           )}
-          {isMarkdown && (
+          {canPreview && (
             <button
               className={`file-viewer-save-btn ${state.showPreview ? 'active' : ''}`}
               onClick={() => dispatch({ type: 'togglePreview' })}
@@ -416,6 +428,11 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
           <div className="md-preview">
             <StreamingMarkdown content={state.currentContent} enableAnimation={false} />
           </div>
+        ) : isHtmlPreview && state.showPreview ? (
+          <HtmlFilePreview
+            filePath={filePath}
+            title={`${fileName} preview`}
+          />
         ) : (
           // Wrap the Editor so we can toggle visibility from React state.
           // While `revealing` is true the user wouldn't see meaningful
@@ -425,7 +442,7 @@ export function FileViewer({ filePath, projectRoot = null, onDirtyChange }: Prop
             <Editor
               height="100%"
               language={toMonacoLanguage(languageId)}
-              defaultValue={state.savedContent}
+              defaultValue={state.currentContent}
               theme={MONACO_THEME_NAME}
               onMount={handleEditorMount}
               onChange={handleChange}

--- a/src/renderer/components/Right/HtmlFilePreview.tsx
+++ b/src/renderer/components/Right/HtmlFilePreview.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react'
+import { HTML_PREVIEW_PARTITION } from '@shared/html-preview'
+import { pathToFileUrl } from '@/lib/htmlPreview'
+
+interface HtmlFilePreviewProps {
+  filePath: string
+  title: string
+}
+
+export function HtmlFilePreview({ filePath, title }: HtmlFilePreviewProps) {
+  const src = useMemo(() => pathToFileUrl(filePath), [filePath])
+
+  return (
+    <div className="html-preview">
+      <webview
+        key={filePath}
+        className="html-preview-frame"
+        title={title}
+        src={src}
+        partition={HTML_PREVIEW_PARTITION}
+      />
+    </div>
+  )
+}

--- a/src/renderer/lib/__tests__/htmlPreview.test.ts
+++ b/src/renderer/lib/__tests__/htmlPreview.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isHtmlPreviewFile,
+  pathToFileUrl,
+} from '../htmlPreview'
+
+describe('htmlPreview', () => {
+  describe('isHtmlPreviewFile', () => {
+    it('detects HTML files case-insensitively', () => {
+      expect(isHtmlPreviewFile('/tmp/index.html')).toBe(true)
+      expect(isHtmlPreviewFile('/tmp/index.htm')).toBe(true)
+      expect(isHtmlPreviewFile('/tmp/INDEX.HTML')).toBe(true)
+    })
+
+    it('does not treat other text files as HTML previews', () => {
+      expect(isHtmlPreviewFile('/tmp/readme.md')).toBe(false)
+      expect(isHtmlPreviewFile('/tmp/component.tsx')).toBe(false)
+      expect(isHtmlPreviewFile('/tmp/vector.svg')).toBe(false)
+    })
+  })
+
+  describe('pathToFileUrl', () => {
+    it('builds a file URL for the file', () => {
+      expect(pathToFileUrl('/Users/me/site/index.html')).toBe('file:///Users/me/site/index.html')
+    })
+
+    it('encodes characters that are unsafe in URLs', () => {
+      expect(pathToFileUrl('/Users/me/my site/#demo/index.html')).toBe(
+        'file:///Users/me/my%20site/%23demo/index.html'
+      )
+    })
+
+    it('keeps Windows drive separators valid', () => {
+      expect(pathToFileUrl('C:\\Users\\me\\site\\index.html')).toBe(
+        'file:///C:/Users/me/site/index.html'
+      )
+    })
+  })
+})

--- a/src/renderer/lib/htmlPreview.ts
+++ b/src/renderer/lib/htmlPreview.ts
@@ -1,0 +1,26 @@
+const HTML_PREVIEW_EXTENSIONS = new Set(['html', 'htm'])
+
+function getExtension(filePath: string): string {
+  const dot = filePath.lastIndexOf('.')
+  if (dot === -1 || dot === filePath.length - 1) return ''
+  return filePath.slice(dot + 1).toLowerCase()
+}
+
+export function isHtmlPreviewFile(filePath: string): boolean {
+  return HTML_PREVIEW_EXTENSIONS.has(getExtension(filePath))
+}
+
+export function pathToFileUrl(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, '/')
+  const isWindowsDrivePath = /^[A-Za-z]:\//.test(normalized)
+  const encodedPath = normalized
+    .split('/')
+    .map((segment, index) => {
+      if (isWindowsDrivePath && index === 0 && /^[A-Za-z]:$/.test(segment)) {
+        return segment
+      }
+      return encodeURIComponent(segment)
+    })
+    .join('/')
+  return `${isWindowsDrivePath ? 'file:///' : 'file://'}${encodedPath}`
+}

--- a/src/renderer/styles/tabs.css
+++ b/src/renderer/styles/tabs.css
@@ -455,7 +455,7 @@
 .html-preview {
   height: 100%;
   overflow: hidden;
-  background: #fff;
+  background: var(--bg-primary);
 }
 
 .html-preview-frame {
@@ -463,5 +463,5 @@
   width: 100%;
   height: 100%;
   border: 0;
-  background: #fff;
+  background: var(--bg-primary);
 }

--- a/src/renderer/styles/tabs.css
+++ b/src/renderer/styles/tabs.css
@@ -450,3 +450,18 @@
   margin: 1.4em 0;
 }
 
+/* HTML preview pane */
+
+.html-preview {
+  height: 100%;
+  overflow: hidden;
+  background: #fff;
+}
+
+.html-preview-frame {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #fff;
+}

--- a/src/shared/html-preview.ts
+++ b/src/shared/html-preview.ts
@@ -1,0 +1,1 @@
+export const HTML_PREVIEW_PARTITION = 'persist:html-preview'


### PR DESCRIPTION
Summary:
- Adds rendered HTML and HTM previews in the center file viewer.
- Uses a dedicated sandboxed webview partition with main-process attach policy.
- Keeps source editing available through the existing preview toggle.

Tests:
- npx vitest run --project renderer src/renderer/lib/__tests__/htmlPreview.test.ts
- npm run typecheck:web
- npm run typecheck:node
- git diff --check