### PR TITLE
Fix Claude rate-limit CLI path bundling

### DIFF
--- a/src/main/services/rateLimits/claudeFetcher.ts
+++ b/src/main/services/rateLimits/claudeFetcher.ts
@@ -4,7 +4,7 @@ import { createHash } from 'node:crypto'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { net, session } from 'electron'
-import { resolveCliPath } from '../claudePath'
+import { AUTO_CLI_PATH } from '../claudePath'
 import type { ProviderRateLimits, RateLimitWindow } from '../../../shared/rate-limit-types'
 
 const OAUTH_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
@@ -266,7 +266,7 @@ const SETTLE_AFTER_STOP_MS = 2_000
 const SETTLE_AFTER_CLAUDE_21_USAGE_MS = 8_000
 
 function resolveClaudeCommand(): string {
-  return resolveCliPath() ?? 'claude'
+  return AUTO_CLI_PATH ?? 'claude'
 }
 
 function describeFailure(output: string): string {

--- a/src/main/services/rateLimits/claudeFetcher.ts
+++ b/src/main/services/rateLimits/claudeFetcher.ts
@@ -4,6 +4,7 @@ import { createHash } from 'node:crypto'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { net, session } from 'electron'
+import { resolveCliPath } from '../claudePath'
 import type { ProviderRateLimits, RateLimitWindow } from '../../../shared/rate-limit-types'
 
 const OAUTH_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
@@ -265,7 +266,6 @@ const SETTLE_AFTER_STOP_MS = 2_000
 const SETTLE_AFTER_CLAUDE_21_USAGE_MS = 8_000
 
 function resolveClaudeCommand(): string {
-  const { resolveCliPath } = require('../claudePath') as typeof import('../claudePath')
   return resolveCliPath() ?? 'claude'
 }
 


### PR DESCRIPTION
## Summary

- Fix Claude rate-limit PTY fallback bundling by statically importing `resolveCliPath`.
- Prevent the packaged app from retaining `require("../claudePath")`, which points at a missing ASAR path.

## Layers touched

- [x] **Main process** (`src/main/`) - services, IPC handlers
- [ ] **Preload** (`src/preload/`) - context bridge API
- [ ] **Renderer** (`src/renderer/`) - components, stores, lib
- [ ] **Styles** (`App.css`)

## Changes

**Services** (`git.ts` / `claude.ts` / `github.ts` / `pty.ts`):
- Updated `claudeFetcher.ts` to import `resolveCliPath` statically so electron-vite/Rollup can include and rewrite the `claudePath` chunk in production bundles.

## How to test

1. `yarn build`
2. `yarn typecheck:node`
3. Confirmed `out/main/index.js` no longer contains `require("../claudePath")`.

## Screenshots

Not applicable - main-process packaging fix only.

## Checklist

- [x] Self-reviewed the diff
- [ ] Tested locally with `yarn dev` - not applicable, no UI flow changed
- [ ] Types pass - `yarn typecheck` - ran `yarn typecheck:node`
- [ ] No console errors or warnings in DevTools - not applicable, no renderer changes
- [ ] IPC changes are threaded through all 3 layers (main -> preload -> renderer) - not applicable, no IPC changes
- [ ] New state is added to the correct Zustand store - not applicable, no state changes