### PR TITLE
Preserve file tree expansion on refresh

### DIFF
--- a/src/renderer/components/Right/FileTree.tsx
+++ b/src/renderer/components/Right/FileTree.tsx
@@ -134,7 +134,7 @@ const createInitialFileTreeState = (): FileTreeState => ({
 type FileTreeAction =
   | { type: 'RESET_FOR_WORKTREE' }
   | { type: 'LOAD_START' }
-  | { type: 'LOAD_DONE'; entries: FileEntry[] }
+  | { type: 'LOAD_DONE'; entries: FileEntry[] | null | undefined }
   | { type: 'LOAD_ERROR' }
   | { type: 'TOGGLE_DIRECTORY'; path: string }
   | { type: 'SET_CHILDREN'; path: string; children: FileEntry[] }
@@ -148,7 +148,7 @@ const fileTreeReducer: Reducer<FileTreeState, FileTreeAction> = (state, action) 
   switch (action.type) {
     case 'RESET_FOR_WORKTREE': return { ...createInitialFileTreeState(), apps: state.apps }
     case 'LOAD_START': return { ...state, refreshing: true }
-    case 'LOAD_DONE': return { ...state, refreshing: false, entries: action.entries }
+    case 'LOAD_DONE': return { ...state, refreshing: false, entries: action.entries ?? [] }
     case 'LOAD_ERROR': return { ...state, refreshing: false }
     case 'TOGGLE_DIRECTORY': {
       const expandedPaths = new Set(state.expandedPaths)
@@ -170,12 +170,17 @@ export function FileTree({ worktreePath, onFileSelect }: Props) {
   const [ftState, ftDispatch] = useReducer(fileTreeReducer, createInitialFileTreeState())
   const { entries, expandedPaths, childrenByPath, selectedPath, refreshing, menu, apps } = ftState
   const expandedPathsRef = useRef(expandedPaths)
+  const childrenByPathRef = useRef(childrenByPath)
   const rootLoadIdRef = useRef(0)
   const worktreePathRef = useRef(worktreePath)
 
   useEffect(() => {
     expandedPathsRef.current = expandedPaths
   }, [expandedPaths])
+
+  useEffect(() => {
+    childrenByPathRef.current = childrenByPath
+  }, [childrenByPath])
 
   useEffect(() => {
     worktreePathRef.current = worktreePath
@@ -185,7 +190,7 @@ export function FileTree({ worktreePath, onFileSelect }: Props) {
     async (dirPath: string, forceRefresh = false): Promise<FileEntry[]> => {
       const fullPath = `${worktreePath}/${dirPath}`
       const items = await ipc.git.getFileTree(fullPath, forceRefresh)
-      return items.map((item: FileEntry) => ({
+      return (items ?? []).map((item: FileEntry) => ({
         ...item,
         path: `${dirPath}/${item.name}`
       }))
@@ -249,6 +254,7 @@ export function FileTree({ worktreePath, onFileSelect }: Props) {
 
   const handleToggleDirectory = useCallback((dirPath: string) => {
     const requestWorktreePath = worktreePath
+    const requestLoadId = rootLoadIdRef.current
     const willExpand = !expandedPathsRef.current.has(dirPath)
     const nextExpandedPaths = new Set(expandedPathsRef.current)
     if (willExpand) nextExpandedPaths.add(dirPath)
@@ -256,15 +262,15 @@ export function FileTree({ worktreePath, onFileSelect }: Props) {
     expandedPathsRef.current = nextExpandedPaths
 
     ftDispatch({ type: 'TOGGLE_DIRECTORY', path: dirPath })
-    if (willExpand && !childrenByPath[dirPath]) {
+    if (willExpand && !childrenByPathRef.current[dirPath]) {
       loadDirectory(dirPath)
         .then((children) => {
-          if (worktreePathRef.current !== requestWorktreePath) return
+          if (rootLoadIdRef.current !== requestLoadId || worktreePathRef.current !== requestWorktreePath) return
           ftDispatch({ type: 'SET_CHILDREN', path: dirPath, children })
         })
         .catch((err: unknown) => console.warn('[FileTree] folder expand failed:', err))
     }
-  }, [childrenByPath, loadDirectory, worktreePath])
+  }, [loadDirectory, worktreePath])
 
   // Lazily fetch installed apps on first context menu open
   useEffect(() => {

--- a/src/renderer/components/Right/FileTree.tsx
+++ b/src/renderer/components/Right/FileTree.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useReducer, useRef, type Reducer } from 'react'
+import { useEffect, useCallback, useMemo, useReducer, useRef, type Reducer } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FileIcon, DefaultFolderOpenedIcon } from '@react-symbols/icons/utils'
 import { Folder } from '@react-symbols/icons/folders'
@@ -28,24 +28,30 @@ interface TreeNodeProps {
   entry: FileEntry
   worktreePath: string
   selectedPath: string | null
+  expandedPaths: Set<string>
+  childrenByPath: Record<string, FileEntry[]>
   onFileSelect: (filePath: string) => void
-  onExpand: (dirPath: string) => Promise<FileEntry[]>
+  onToggleDirectory: (dirPath: string) => void
   onContextMenu: (e: React.MouseEvent, fullPath: string, isDirectory: boolean) => void
 }
 
 // ─── TreeNode ────────────────────────────────────────────────────────────────
 
-function TreeNode({ entry, worktreePath, selectedPath, onFileSelect, onExpand, onContextMenu }: TreeNodeProps) {
-  const [expanded, setExpanded] = useState(false)
-  const [children, setChildren] = useState<FileEntry[]>([])
-
-  const handleClick = async () => {
+function TreeNode({
+  entry,
+  worktreePath,
+  selectedPath,
+  expandedPaths,
+  childrenByPath,
+  onFileSelect,
+  onToggleDirectory,
+  onContextMenu
+}: TreeNodeProps) {
+  const expanded = expandedPaths.has(entry.path)
+  const children = childrenByPath[entry.path] ?? []
+  const handleClick = () => {
     if (entry.isDirectory) {
-      if (!expanded && children.length === 0) {
-        const items = await onExpand(entry.path)
-        setChildren(items)
-      }
-      setExpanded(!expanded)
+      onToggleDirectory(entry.path)
     } else {
       onFileSelect(`${worktreePath}/${entry.path}`)
     }
@@ -90,8 +96,10 @@ function TreeNode({ entry, worktreePath, selectedPath, onFileSelect, onExpand, o
               entry={child}
               worktreePath={worktreePath}
               selectedPath={selectedPath}
+              expandedPaths={expandedPaths}
+              childrenByPath={childrenByPath}
               onFileSelect={onFileSelect}
-              onExpand={onExpand}
+              onToggleDirectory={onToggleDirectory}
               onContextMenu={onContextMenu}
             />
           ))}
@@ -105,29 +113,52 @@ function TreeNode({ entry, worktreePath, selectedPath, onFileSelect, onExpand, o
 
 type FileTreeState = {
   entries: FileEntry[]
+  expandedPaths: Set<string>
+  childrenByPath: Record<string, FileEntry[]>
   selectedPath: string | null
   refreshing: boolean
-  generation: number
   menu: { x: number; y: number; path: string; isDirectory: boolean } | null
   apps: InstalledApp[]
 }
+
+const createInitialFileTreeState = (): FileTreeState => ({
+  entries: [],
+  expandedPaths: new Set<string>(),
+  childrenByPath: {},
+  selectedPath: null,
+  refreshing: false,
+  menu: null,
+  apps: [],
+})
+
 type FileTreeAction =
+  | { type: 'RESET_FOR_WORKTREE' }
   | { type: 'LOAD_START' }
   | { type: 'LOAD_DONE'; entries: FileEntry[] }
   | { type: 'LOAD_ERROR' }
+  | { type: 'TOGGLE_DIRECTORY'; path: string }
+  | { type: 'SET_CHILDREN'; path: string; children: FileEntry[] }
+  | { type: 'SET_CHILDREN_MANY'; entries: Record<string, FileEntry[]> }
   | { type: 'SELECT'; path: string }
-  | { type: 'BUMP_GENERATION' }
   | { type: 'OPEN_MENU'; x: number; y: number; path: string; isDirectory: boolean }
   | { type: 'CLOSE_MENU' }
   | { type: 'SET_APPS'; apps: InstalledApp[] }
 
 const fileTreeReducer: Reducer<FileTreeState, FileTreeAction> = (state, action) => {
   switch (action.type) {
+    case 'RESET_FOR_WORKTREE': return { ...createInitialFileTreeState(), apps: state.apps }
     case 'LOAD_START': return { ...state, refreshing: true }
     case 'LOAD_DONE': return { ...state, refreshing: false, entries: action.entries }
     case 'LOAD_ERROR': return { ...state, refreshing: false }
+    case 'TOGGLE_DIRECTORY': {
+      const expandedPaths = new Set(state.expandedPaths)
+      if (expandedPaths.has(action.path)) expandedPaths.delete(action.path)
+      else expandedPaths.add(action.path)
+      return { ...state, expandedPaths }
+    }
+    case 'SET_CHILDREN': return { ...state, childrenByPath: { ...state.childrenByPath, [action.path]: action.children } }
+    case 'SET_CHILDREN_MANY': return { ...state, childrenByPath: { ...state.childrenByPath, ...action.entries } }
     case 'SELECT': return { ...state, selectedPath: action.path }
-    case 'BUMP_GENERATION': return { ...state, generation: state.generation + 1 }
     case 'OPEN_MENU': return { ...state, menu: { x: action.x, y: action.y, path: action.path, isDirectory: action.isDirectory } }
     case 'CLOSE_MENU': return { ...state, menu: null }
     case 'SET_APPS': return { ...state, apps: action.apps }
@@ -136,28 +167,74 @@ const fileTreeReducer: Reducer<FileTreeState, FileTreeAction> = (state, action) 
 
 export function FileTree({ worktreePath, onFileSelect }: Props) {
   const { t } = useTranslation('right')
-  const [ftState, ftDispatch] = useReducer(fileTreeReducer, { entries: [], selectedPath: null, refreshing: false, generation: 0, menu: null, apps: [] })
-  const { entries, selectedPath, refreshing, generation, menu, apps } = ftState
-  const inflightRef = useRef(false)
+  const [ftState, ftDispatch] = useReducer(fileTreeReducer, createInitialFileTreeState())
+  const { entries, expandedPaths, childrenByPath, selectedPath, refreshing, menu, apps } = ftState
+  const expandedPathsRef = useRef(expandedPaths)
+  const rootLoadIdRef = useRef(0)
+  const worktreePathRef = useRef(worktreePath)
 
-  const loadRoot = useCallback((forceRefresh = false) => {
-    if (inflightRef.current) return
-    inflightRef.current = true
-    ftDispatch({ type: 'LOAD_START' })
-    ipc.git.getFileTree(worktreePath, forceRefresh)
-      .then((items: FileEntry[]) => ftDispatch({ type: 'LOAD_DONE', entries: items }))
-      .catch((err: unknown) => { console.warn('[FileTree] refresh failed:', err); ftDispatch({ type: 'LOAD_ERROR' }) })
-      .finally(() => { inflightRef.current = false })
+  useEffect(() => {
+    expandedPathsRef.current = expandedPaths
+  }, [expandedPaths])
+
+  useEffect(() => {
+    worktreePathRef.current = worktreePath
   }, [worktreePath])
 
+  const loadDirectory = useCallback(
+    async (dirPath: string, forceRefresh = false): Promise<FileEntry[]> => {
+      const fullPath = `${worktreePath}/${dirPath}`
+      const items = await ipc.git.getFileTree(fullPath, forceRefresh)
+      return items.map((item: FileEntry) => ({
+        ...item,
+        path: `${dirPath}/${item.name}`
+      }))
+    },
+    [worktreePath]
+  )
+
+  const loadRoot = useCallback((forceRefresh = false, refreshExpanded = false) => {
+    const loadId = rootLoadIdRef.current + 1
+    rootLoadIdRef.current = loadId
+    ftDispatch({ type: 'LOAD_START' })
+    ipc.git.getFileTree(worktreePath, forceRefresh)
+      .then(async (items: FileEntry[]) => {
+        if (rootLoadIdRef.current !== loadId || worktreePathRef.current !== worktreePath) return
+        ftDispatch({ type: 'LOAD_DONE', entries: items })
+
+        if (!refreshExpanded || expandedPathsRef.current.size === 0) return
+        const expandedEntries = await Promise.all(
+          [...expandedPathsRef.current].map(async (dirPath) => {
+            try {
+              return [dirPath, await loadDirectory(dirPath, forceRefresh)] as const
+            } catch (err) {
+              console.warn('[FileTree] expanded folder refresh failed:', dirPath, err)
+              return null
+            }
+          })
+        )
+        if (rootLoadIdRef.current !== loadId || worktreePathRef.current !== worktreePath) return
+        const refreshedChildren = Object.fromEntries(expandedEntries.filter((entry): entry is readonly [string, FileEntry[]] => entry !== null))
+        ftDispatch({ type: 'SET_CHILDREN_MANY', entries: refreshedChildren })
+      })
+      .catch((err: unknown) => {
+        if (rootLoadIdRef.current !== loadId || worktreePathRef.current !== worktreePath) return
+        console.warn('[FileTree] refresh failed:', err)
+        ftDispatch({ type: 'LOAD_ERROR' })
+      })
+  }, [loadDirectory, worktreePath])
+
   // Load on mount + worktree change
-  useEffect(() => { loadRoot() }, [loadRoot])
+  useEffect(() => {
+    ftDispatch({ type: 'RESET_FOR_WORKTREE' })
+    expandedPathsRef.current = new Set()
+    loadRoot()
+  }, [loadRoot])
 
   // Auto-refresh when a per-worktree refresh is requested.
   useEffect(() => {
     return subscribeWorktreeRefresh(worktreePath, 'files', (event) => {
-      loadRoot(event.force)
-      ftDispatch({ type: 'BUMP_GENERATION' })
+      loadRoot(event.force, true)
     })
   }, [worktreePath, loadRoot])
 
@@ -170,17 +247,24 @@ export function FileTree({ worktreePath, onFileSelect }: Props) {
     onFileSelect(path)
   }
 
-  const handleExpand = useCallback(
-    async (dirPath: string): Promise<FileEntry[]> => {
-      const fullPath = `${worktreePath}/${dirPath}`
-      const items = await ipc.git.getFileTree(fullPath)
-      return items.map((item: FileEntry) => ({
-        ...item,
-        path: `${dirPath}/${item.name}`
-      }))
-    },
-    [worktreePath]
-  )
+  const handleToggleDirectory = useCallback((dirPath: string) => {
+    const requestWorktreePath = worktreePath
+    const willExpand = !expandedPathsRef.current.has(dirPath)
+    const nextExpandedPaths = new Set(expandedPathsRef.current)
+    if (willExpand) nextExpandedPaths.add(dirPath)
+    else nextExpandedPaths.delete(dirPath)
+    expandedPathsRef.current = nextExpandedPaths
+
+    ftDispatch({ type: 'TOGGLE_DIRECTORY', path: dirPath })
+    if (willExpand && !childrenByPath[dirPath]) {
+      loadDirectory(dirPath)
+        .then((children) => {
+          if (worktreePathRef.current !== requestWorktreePath) return
+          ftDispatch({ type: 'SET_CHILDREN', path: dirPath, children })
+        })
+        .catch((err: unknown) => console.warn('[FileTree] folder expand failed:', err))
+    }
+  }, [childrenByPath, loadDirectory, worktreePath])
 
   // Lazily fetch installed apps on first context menu open
   useEffect(() => {
@@ -249,12 +333,14 @@ export function FileTree({ worktreePath, onFileSelect }: Props) {
         <div className={`file-tree-body${refreshing ? ' refreshing' : ''}`}>
           {entries.map((entry) => (
             <TreeNode
-              key={`${entry.path}-${generation}`}
+              key={entry.path}
               entry={entry}
               worktreePath={worktreePath}
               selectedPath={selectedPath}
+              expandedPaths={expandedPaths}
+              childrenByPath={childrenByPath}
               onFileSelect={handleFileSelect}
-              onExpand={handleExpand}
+              onToggleDirectory={handleToggleDirectory}
               onContextMenu={handleContextMenu}
             />
           ))}

--- a/src/renderer/components/Right/__tests__/FileTree.test.tsx
+++ b/src/renderer/components/Right/__tests__/FileTree.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { FileTree } from '../FileTree'
 import type { WorktreeRefreshEvent } from '@/lib/worktreeRefresh'
 
@@ -56,6 +56,10 @@ vi.mock('react-i18next', () => ({
 }))
 
 describe('FileTree', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     refreshHandler = null
@@ -107,5 +111,65 @@ describe('FileTree', () => {
     await waitFor(() => {
       expect(screen.queryByText('stale.ts')).toBeNull()
     })
+  })
+
+  it('ignores stale directory loads after switching away and back to the same worktree', async () => {
+    const slowDirectory = deferred<Array<{ name: string; path: string; isDirectory: boolean }>>()
+    let srcLoadCount = 0
+    getFileTree.mockImplementation((path: string) => {
+      if (path === '/repo-a') return Promise.resolve([{ name: 'src', path: 'src', isDirectory: true }])
+      if (path === '/repo-b') return Promise.resolve([{ name: 'other.ts', path: 'other.ts', isDirectory: false }])
+      if (path === '/repo-a/src') {
+        srcLoadCount += 1
+        if (srcLoadCount === 1) return slowDirectory.promise
+        return Promise.resolve([{ name: 'current.ts', path: 'current.ts', isDirectory: false }])
+      }
+      return Promise.resolve([])
+    })
+
+    const { rerender } = render(<FileTree worktreePath="/repo-a" onFileSelect={vi.fn()} />)
+    fireEvent.click(await screen.findByText('src'))
+
+    rerender(<FileTree worktreePath="/repo-b" onFileSelect={vi.fn()} />)
+    await screen.findByText('other.ts')
+
+    rerender(<FileTree worktreePath="/repo-a" onFileSelect={vi.fn()} />)
+    await screen.findByText('src')
+
+    slowDirectory.resolve([{ name: 'stale.ts', path: 'stale.ts', isDirectory: false }])
+    await waitFor(() => {
+      expect(screen.queryByText('stale.ts')).toBeNull()
+    })
+
+    fireEvent.click(screen.getByText('src'))
+    await screen.findByText('current.ts')
+    expect(screen.queryByText('stale.ts')).toBeNull()
+  })
+
+  it('handles nullish root file tree responses defensively', async () => {
+    getFileTree.mockResolvedValue(undefined)
+
+    render(<FileTree worktreePath="/repo" onFileSelect={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(getFileTree).toHaveBeenCalledWith('/repo', false)
+    })
+    expect(screen.queryByText('fileCount')).toBeNull()
+  })
+
+  it('handles nullish directory file tree responses defensively', async () => {
+    getFileTree.mockImplementation((path: string) => {
+      if (path === '/repo') return Promise.resolve([{ name: 'src', path: 'src', isDirectory: true }])
+      if (path === '/repo/src') return Promise.resolve(null)
+      return Promise.resolve(undefined)
+    })
+
+    render(<FileTree worktreePath="/repo" onFileSelect={vi.fn()} />)
+    fireEvent.click(await screen.findByText('src'))
+
+    await waitFor(() => {
+      expect(getFileTree).toHaveBeenCalledWith('/repo/src', false)
+    })
+    expect(screen.queryByText('index.ts')).toBeNull()
   })
 })

--- a/src/renderer/components/Right/__tests__/FileTree.test.tsx
+++ b/src/renderer/components/Right/__tests__/FileTree.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FileTree } from '../FileTree'
+import type { WorktreeRefreshEvent } from '@/lib/worktreeRefresh'
+
+const getFileTree = vi.fn()
+let refreshHandler: ((event: WorktreeRefreshEvent) => void | Promise<void>) | null = null
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => { resolve = res })
+  return { promise, resolve }
+}
+
+vi.mock('@/lib/ipc', () => ({
+  git: {
+    getFileTree: (...args: unknown[]) => getFileTree(...args),
+  },
+  shell: {
+    platform: 'darwin',
+    getInstalledApps: vi.fn().mockResolvedValue([]),
+    openInApp: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/worktreeRefresh', () => ({
+  requestWorktreeRefresh: vi.fn((worktreePath: string, resource: string, options: { reason: string; force: boolean }) => {
+    refreshHandler?.({
+      worktreePath,
+      topic: resource,
+      resource,
+      topics: [resource],
+      resources: [resource],
+      resourceKey: `worktree:${worktreePath}:${resource}`,
+      resourceKeys: [`worktree:${worktreePath}:${resource}`],
+      reason: options.reason,
+      force: options.force,
+      requestedAt: Date.now(),
+    } as WorktreeRefreshEvent)
+  }),
+  subscribeWorktreeRefresh: vi.fn((_worktreePath: string, _resource: string, handler: typeof refreshHandler) => {
+    refreshHandler = handler
+    return () => {
+      refreshHandler = null
+    }
+  }),
+}))
+
+vi.mock('@/store/ui', () => ({
+  useUIStore: {
+    getState: () => ({ openQuickOpen: vi.fn() }),
+  },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+describe('FileTree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    refreshHandler = null
+    getFileTree.mockImplementation((path: string) => {
+      if (path === '/repo') return Promise.resolve([{ name: 'src', path: 'src', isDirectory: true }])
+      if (path === '/repo/src') return Promise.resolve([{ name: 'index.ts', path: 'index.ts', isDirectory: false }])
+      return Promise.resolve([])
+    })
+  })
+
+  it('preserves expanded folders when refreshing', async () => {
+    render(<FileTree worktreePath="/repo" onFileSelect={vi.fn()} />)
+
+    fireEvent.click(await screen.findByText('src'))
+    await screen.findByText('index.ts')
+
+    getFileTree.mockImplementation((path: string) => {
+      if (path === '/repo') return Promise.resolve([{ name: 'src', path: 'src', isDirectory: true }])
+      if (path === '/repo/src') return Promise.resolve([
+        { name: 'index.ts', path: 'index.ts', isDirectory: false },
+        { name: 'util.ts', path: 'util.ts', isDirectory: false },
+      ])
+      return Promise.resolve([])
+    })
+
+    fireEvent.click(screen.getByText('refresh'))
+
+    await screen.findByText('util.ts')
+    expect(screen.getByText('index.ts')).toBeTruthy()
+    await waitFor(() => {
+      expect(getFileTree).toHaveBeenCalledWith('/repo/src', true)
+    })
+  })
+
+  it('ignores stale root loads after switching worktrees', async () => {
+    const slowRepo = deferred<Array<{ name: string; path: string; isDirectory: boolean }>>()
+    getFileTree.mockImplementation((path: string) => {
+      if (path === '/repo-a') return slowRepo.promise
+      if (path === '/repo-b') return Promise.resolve([{ name: 'current.ts', path: 'current.ts', isDirectory: false }])
+      return Promise.resolve([])
+    })
+
+    const { rerender } = render(<FileTree worktreePath="/repo-a" onFileSelect={vi.fn()} />)
+    rerender(<FileTree worktreePath="/repo-b" onFileSelect={vi.fn()} />)
+
+    await screen.findByText('current.ts')
+    slowRepo.resolve([{ name: 'stale.ts', path: 'stale.ts', isDirectory: false }])
+
+    await waitFor(() => {
+      expect(screen.queryByText('stale.ts')).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- preserve opened folder state in the right sidebar file tree across refreshes
- reload already-expanded folder contents during refresh without remounting the tree
- guard against stale async file tree loads after switching worktrees

## Verification
- rtk yarn vitest run --project renderer src/renderer/components/Right/__tests__/FileTree.test.tsx
- rtk yarn typecheck:web