### PR TITLE
Centralize tool installation with typed results and prerequisite checks

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -28,6 +28,7 @@ import { jiraService } from './services/jira'
 import { githubAuthService } from './services/githubAuth'
 import { resolveCliPath } from './services/claudePath'
 import { enrichedEnv } from './lib/enrichedEnv'
+import { toolInstaller } from './services/toolInstaller'
 import { downloadUpdate, installUpdate, checkForUpdates } from './services/autoUpdate'
 import { ClaudeUsageStore } from './services/claudeUsage'
 import type { ClaudeUsageScope, ClaudeUsageRange, ClaudeUsageBreakdownKind } from '../shared/claude-usage-types'
@@ -297,63 +298,18 @@ export function registerIpcHandlers(): void {
   ipcMain.handle('shell:openExternal', (_e, url: string) => shell.openExternal(url))
   ipcMain.handle('shell:showItemInFolder', (_e, fullPath: string) => shell.showItemInFolder(fullPath))
 
-  // Uses the enriched PATH (hydrated once at startup from the user's login shell)
-  // so we can run bare `which` without spawning a login shell per check.
-  ipcMain.handle('shell:checkTool', (_e, tool: string) => {
-    if (!/^[a-zA-Z0-9-]+$/.test(tool)) return false
-    return new Promise<boolean>((resolve) => {
-      execFile('which', [tool], { timeout: 3000, env: enrichedEnv() }, (err, stdout) => {
-        // Verify output is an absolute path - filters out shell builtins
-        // like "continue: shell built-in command" which exit 0 but aren't real CLIs
-        const found = !err && stdout.split(/\r?\n/).some((line) => line.trim().startsWith('/'))
-        if (found) console.log('[checkTool] %s -> %s', tool, stdout.trim())
-        resolve(found)
-      })
-    })
-  })
+  // Uses the shared installer service so every CLI probe waits for PATH hydration.
+  ipcMain.handle('shell:checkTool', (_e, tool: string) => toolInstaller.checkCommand(tool))
 
-  ipcMain.handle('shell:checkGhAuth', () => {
+  ipcMain.handle('shell:checkGhAuth', async () => {
+    if (!(await toolInstaller.checkCommand('gh'))) return false
     return new Promise<boolean>((resolve) => {
       execFile('gh', ['auth', 'status'], { timeout: 8000, env: enrichedEnv() }, (err) => resolve(!err))
     })
   })
 
-  // Runs a known install command for a given check key via the user's login shell.
-  // Returns { success: boolean } — success means the command exited 0.
-  // The renderer re-checks the tool immediately after regardless of the result.
-  ipcMain.handle('shell:installTool', (_e, key: string) => {
-    const userShell = process.env.SHELL || defaultUserShell()
-
-    // For brew-based tools: bail early if brew isn't present so the UI
-    // surfaces the docs link instead of leaving the user stuck in a retry loop.
-    const brewInstalls: Record<string, string> = { gh: 'gh', mobilecli: 'nicklama/tap/mobilecli' }
-    if (key in brewInstalls) {
-      if (process.platform !== 'darwin') return { success: false }
-      const formula = brewInstalls[key]
-      return new Promise<{ success: boolean }>((resolve) => {
-        execFile(userShell, shellArgs(userShell, `which brew > /dev/null 2>&1 && brew install ${formula}`), { timeout: 180_000 }, (err) => resolve({ success: !err }))
-      })
-    }
-
-    const cmds: Record<string, string> = {
-      // Official Claude Code installer — handles PATH setup, shell completions, etc.
-      claude: 'curl -fsSL https://claude.ai/install.sh | bash',
-      acli: 'npm install -g @atlassian/acli',
-    }
-    if (process.platform === 'darwin') {
-      cmds.git = 'xcode-select --install'
-    }
-
-    // gh auth is now handled via Device Flow (github:startDeviceFlow IPC)
-    if (key === 'ghAuth') return { success: false }
-
-    const cmd = cmds[key]
-    if (!cmd) return { success: false }
-    const timeout = 180_000
-    return new Promise<{ success: boolean }>((resolve) => {
-      execFile(userShell, shellArgs(userShell, cmd), { timeout }, (err) => resolve({ success: !err }))
-    })
-  })
+  // Runs a known installer and returns a typed result with failure reason.
+  ipcMain.handle('shell:installTool', (_e, key: string, options?: import('../shared/tool-install').ToolInstallOptions) => toolInstaller.install(key, options))
 
   // Re-authenticate with Claude Code CLI (OAuth flow — opens browser)
   ipcMain.handle('agent:reAuth', () => {

--- a/src/main/lib/__tests__/enrichedEnv.test.ts
+++ b/src/main/lib/__tests__/enrichedEnv.test.ts
@@ -117,6 +117,29 @@ describe('enrichedEnv', () => {
     expect(mockExecFile).toHaveBeenCalledOnce()
   })
 
+  it('refreshEnrichedEnv reruns the shell PATH probe', async () => {
+    mockExecFile
+      .mockImplementationOnce(
+        (_bin: string, _args: string[], _opts: object, cb: (err: null, stdout: string) => void) => {
+          cb(null, `${DELIM_START}/first/bin${DELIM_END}\n`)
+        },
+      )
+      .mockImplementationOnce(
+        (_bin: string, _args: string[], _opts: object, cb: (err: null, stdout: string) => void) => {
+          cb(null, `${DELIM_START}/second/bin${DELIM_END}\n`)
+        },
+      )
+
+    const mod = await import('../enrichedEnv')
+    await mod.waitForEnrichedEnv()
+    expect(mod.enrichedEnv().PATH).toContain('/first/bin')
+
+    await mod.refreshEnrichedEnv()
+
+    expect(mod.enrichedEnv().PATH).toContain('/second/bin')
+    expect(mockExecFile).toHaveBeenCalledTimes(2)
+  })
+
   it('enrichedEnv returns process.env with the hydrated PATH', async () => {
     mockExecFile.mockImplementation(
       (_bin: string, _args: string[], _opts: object, cb: (err: null, stdout: string) => void) => {

--- a/src/main/lib/enrichedEnv.ts
+++ b/src/main/lib/enrichedEnv.ts
@@ -91,11 +91,21 @@ function probe(): Promise<void> {
 }
 
 // Kick off immediately so it's settled before first real CLI use.
-const _ready = probe()
+let ready = probe()
 
 /** Await this before the first CLI invocation to guarantee the probe has settled. */
 export function waitForEnrichedEnv(): Promise<void> {
-  return _ready
+  return ready
+}
+
+/**
+ * Re-run the shell PATH probe after an installer mutates shell config or adds
+ * a new global bin directory. Existing segments are kept and new segments are
+ * prepended by probe().
+ */
+export function refreshEnrichedEnv(): Promise<void> {
+  ready = probe()
+  return ready
 }
 
 /** Returns process.env (PATH is already mutated in-place by hydration). */

--- a/src/main/services/__tests__/jira.test.ts
+++ b/src/main/services/__tests__/jira.test.ts
@@ -9,6 +9,7 @@ vi.mock('fs/promises', () => ({
 }))
 vi.mock('../../lib/enrichedEnv', () => ({
   enrichedEnv: () => ({}),
+  waitForEnrichedEnv: () => Promise.resolve(),
 }))
 
 import { jiraService } from '../jira'

--- a/src/main/services/__tests__/toolInstaller.test.ts
+++ b/src/main/services/__tests__/toolInstaller.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockExecFile = vi.hoisted(() => vi.fn())
+const mockWaitForEnrichedEnv = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const mockRefreshEnrichedEnv = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const mockMkdirSync = vi.hoisted(() => vi.fn())
+const mockChmodSync = vi.hoisted(() => vi.fn())
+const mockExistsSync = vi.hoisted(() => vi.fn())
+const mockAccessSync = vi.hoisted(() => vi.fn())
+
+vi.mock('child_process', () => ({ execFile: mockExecFile }))
+vi.mock('fs', () => ({
+  accessSync: mockAccessSync,
+  chmodSync: mockChmodSync,
+  constants: { W_OK: 2 },
+  existsSync: mockExistsSync,
+  mkdirSync: mockMkdirSync,
+}))
+vi.mock('../../lib/enrichedEnv', () => ({
+  enrichedEnv: () => ({ PATH: '/mock/bin' }),
+  waitForEnrichedEnv: mockWaitForEnrichedEnv,
+  refreshEnrichedEnv: mockRefreshEnrichedEnv,
+}))
+
+import { toolInstaller } from '../toolInstaller'
+
+type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void
+
+function installExecMock(
+  handler: (file: string, args: string[]) => { error?: Error | null; stdout?: string; stderr?: string },
+): void {
+  mockExecFile.mockImplementation((file: string, args: string[], _opts: object, callback: ExecCallback) => {
+    const response = handler(file, args)
+    callback(response.error ?? null, response.stdout ?? '', response.stderr ?? '')
+  })
+}
+
+describe('toolInstaller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExistsSync.mockReturnValue(true)
+    mockAccessSync.mockReturnValue(undefined)
+  })
+
+  it('returns a typed failure for unknown tools', async () => {
+    await expect(toolInstaller.install('nope')).resolves.toMatchObject({
+      success: false,
+      installed: false,
+      reason: 'unknown_tool',
+    })
+    expect(mockExecFile).not.toHaveBeenCalled()
+  })
+
+  it('reports missing prerequisites before running an installer', async () => {
+    installExecMock((file, args) => {
+      if (file === 'which' && args[0] === 'acli') return { error: new Error('not found') }
+      if (file === 'which' && args[0] === 'brew') return { error: new Error('not found') }
+      if (file === 'which' && args[0] === 'curl') return { error: new Error('not found') }
+      throw new Error(`unexpected command: ${file} ${args.join(' ')}`)
+    })
+
+    await expect(toolInstaller.install('acli')).resolves.toMatchObject({
+      success: false,
+      installed: false,
+      reason: 'missing_prerequisite',
+    })
+    expect(mockExecFile).not.toHaveBeenCalledWith('npm', expect.any(Array), expect.any(Object), expect.any(Function))
+    expect(mockRefreshEnrichedEnv).not.toHaveBeenCalled()
+  })
+
+  it('prefers the official Homebrew ACLI installer on macOS when brew is available', async () => {
+    if (process.platform !== 'darwin') return
+
+    const calls: string[] = []
+    installExecMock((file, args) => {
+      calls.push(`${file} ${args.join(' ')}`)
+      if (calls.length === 1) return { error: new Error('not found') }
+      if (calls.length === 2) return { stdout: '/opt/homebrew/bin/brew\n' }
+      if (calls.length === 3) return { stdout: 'tapped\n' }
+      if (calls.length === 4) return { stdout: 'installed\n' }
+      if (calls.length === 5) return { stdout: '/opt/homebrew/bin/acli\n' }
+      throw new Error(`unexpected command: ${file} ${args.join(' ')}`)
+    })
+
+    await expect(toolInstaller.install('acli')).resolves.toMatchObject({
+      success: true,
+      installed: true,
+      reason: 'installed',
+    })
+    expect(calls).toEqual([
+      'which acli',
+      'which brew',
+      'brew tap atlassian/homebrew-acli',
+      'brew install acli',
+      'which acli',
+    ])
+    expect(mockExecFile).not.toHaveBeenCalledWith('npm', expect.any(Array), expect.any(Object), expect.any(Function))
+    expect(mockRefreshEnrichedEnv).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to direct ACLI download when Homebrew is unavailable', async () => {
+    const calls: string[] = []
+    installExecMock((file, args) => {
+      calls.push(`${file} ${args.join(' ')}`)
+      if (calls.length === 1) return { error: new Error('not found') }
+      if (process.platform === 'darwin' && calls.length === 2) return { error: new Error('not found') }
+      const curlCheckCall = process.platform === 'darwin' ? 3 : 2
+      const curlInstallCall = process.platform === 'darwin' ? 4 : 3
+      const postCheckCall = process.platform === 'darwin' ? 5 : 4
+      if (calls.length === curlCheckCall) return { stdout: '/mock/bin/curl\n' }
+      if (calls.length === curlInstallCall && file === 'curl') return { stdout: 'downloaded\n' }
+      if (calls.length === postCheckCall) return { stdout: '/mock/bin/acli\n' }
+      throw new Error(`unexpected command: ${file} ${args.join(' ')}`)
+    })
+
+    await expect(toolInstaller.install('acli')).resolves.toMatchObject({
+      success: true,
+      installed: true,
+      reason: 'installed',
+    })
+    expect(calls[0]).toBe('which acli')
+    if (process.platform === 'darwin') expect(calls[1]).toBe('which brew')
+    const curlCall = calls.find((call) => call.startsWith('curl '))
+    expect(curlCall).toContain('curl -fL https://acli.atlassian.com/')
+    expect(curlCall).toContain('/usr/local/bin/acli')
+    expect(calls.at(-1)).toBe('which acli')
+    expect(mockMkdirSync).toHaveBeenCalledWith('/usr/local/bin', { recursive: true })
+    expect(mockChmodSync).toHaveBeenCalledWith('/usr/local/bin/acli', 0o755)
+    expect(mockExecFile).not.toHaveBeenCalledWith('npm', expect.any(Array), expect.any(Object), expect.any(Function))
+    expect(mockRefreshEnrichedEnv).toHaveBeenCalledOnce()
+  })
+
+  it('returns admin_required before writing ACLI to /usr/local/bin without permission', async () => {
+    mockAccessSync.mockImplementation(() => { throw new Error('readonly') })
+
+    installExecMock((file, args) => {
+      if (file === 'which' && args[0] === 'acli') return { error: new Error('not found') }
+      if (file === 'which' && args[0] === 'brew') return { error: new Error('not found') }
+      if (file === 'which' && args[0] === 'curl') return { stdout: '/usr/bin/curl\n' }
+      throw new Error(`unexpected command: ${file} ${args.join(' ')}`)
+    })
+
+    await expect(toolInstaller.install('acli')).resolves.toMatchObject({
+      success: false,
+      installed: false,
+      reason: 'admin_required',
+      requiresAdmin: true,
+      targetPath: '/usr/local/bin/acli',
+    })
+    expect(mockExecFile).not.toHaveBeenCalledWith('osascript', expect.any(Array), expect.any(Object), expect.any(Function))
+  })
+
+  it('uses macOS administrator authorization after admin approval', async () => {
+    if (process.platform !== 'darwin') return
+
+    mockAccessSync.mockImplementation(() => { throw new Error('readonly') })
+    const calls: string[] = []
+    installExecMock((file, args) => {
+      calls.push(`${file} ${args.join(' ')}`)
+      if (calls.length === 1) return { error: new Error('not found') }
+      if (calls.length === 2) return { error: new Error('not found') }
+      if (calls.length === 3) return { stdout: '/usr/bin/curl\n' }
+      if (file === 'osascript') return { stdout: 'authorized\n' }
+      if (calls.at(-1) === 'which acli') return { stdout: '/usr/local/bin/acli\n' }
+      throw new Error(`unexpected command: ${file} ${args.join(' ')}`)
+    })
+
+    await expect(toolInstaller.install('acli', { allowAdmin: true })).resolves.toMatchObject({
+      success: true,
+      installed: true,
+      reason: 'installed',
+    })
+    const osascriptCall = mockExecFile.mock.calls.find(([file]) => file === 'osascript')
+    expect(osascriptCall?.[1]).toEqual(expect.arrayContaining([
+      expect.stringContaining('with administrator privileges'),
+    ]))
+    expect(String(osascriptCall?.[1])).toContain('/usr/local/bin/acli')
+  })
+
+  it('includes installer stderr in install failures', async () => {
+    installExecMock((file, args) => {
+      if (file === 'which' && args[0] === 'acli') return { error: new Error('not found') }
+      if (file === 'which' && args[0] === 'brew') return { error: new Error('not found') }
+      if (file === 'which' && args[0] === 'curl') return { stdout: '/mock/bin/curl\n' }
+      if (file === 'curl') return { error: new Error('exit 1'), stderr: 'permission denied' }
+      throw new Error(`unexpected command: ${file} ${args.join(' ')}`)
+    })
+
+    const response = await toolInstaller.install('acli')
+    expect(response).toMatchObject({
+      success: false,
+      installed: false,
+      reason: 'install_failed',
+    })
+    expect(response.message).toContain('permission denied')
+    expect(mockRefreshEnrichedEnv).not.toHaveBeenCalled()
+  })
+
+  it('reports post-check failures when the installer exits cleanly but the tool is still absent', async () => {
+    const calls: string[] = []
+    installExecMock((file, args) => {
+      calls.push(`${file} ${args.join(' ')}`)
+      if (calls.length === 1) return { error: new Error('not found') }
+      if (process.platform === 'darwin' && calls.length === 2) return { error: new Error('not found') }
+      const curlCheckCall = process.platform === 'darwin' ? 3 : 2
+      const curlInstallCall = process.platform === 'darwin' ? 4 : 3
+      const postCheckCall = process.platform === 'darwin' ? 5 : 4
+      if (calls.length === curlCheckCall) return { stdout: '/mock/bin/curl\n' }
+      if (calls.length === curlInstallCall && file === 'curl') return { stdout: 'downloaded\n' }
+      if (calls.length === postCheckCall) return { error: new Error('not found') }
+      throw new Error(`unexpected command: ${file} ${args.join(' ')}`)
+    })
+
+    await expect(toolInstaller.install('acli')).resolves.toMatchObject({
+      success: false,
+      installed: false,
+      reason: 'postcheck_failed',
+    })
+    expect(mockRefreshEnrichedEnv).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/services/jira.ts
+++ b/src/main/services/jira.ts
@@ -4,7 +4,7 @@ import { readFile } from 'fs/promises'
 import { homedir } from 'os'
 import { join } from 'path'
 import { ServiceCache } from '../lib/serviceCache'
-import { enrichedEnv } from '../lib/enrichedEnv'
+import { enrichedEnv, waitForEnrichedEnv } from '../lib/enrichedEnv'
 
 const exec = promisify(execFile)
 
@@ -39,6 +39,7 @@ class JiraService {
   async isAvailable(): Promise<boolean> {
     if (this._available !== null) return this._available
     try {
+      await waitForEnrichedEnv()
       await exec('which', ['acli'], { timeout: 3_000, env: enrichedEnv() })
       this._available = true
     } catch {

--- a/src/main/services/lsp/download.ts
+++ b/src/main/services/lsp/download.ts
@@ -8,6 +8,7 @@ import { join } from 'path'
 import { homedir } from 'os'
 import { findBinary, buildEnrichedPath } from './helpers'
 import { resolveConfigs, findInstallCandidate } from './detect'
+import { refreshEnrichedEnv } from '../../lib/enrichedEnv'
 import type { LspServerConfig } from './types'
 
 export async function installServer(
@@ -59,6 +60,7 @@ export async function installServer(
     })
   })
 
+  await refreshEnrichedEnv()
   return { newEnrichedPath: buildEnrichedPath() }
 }
 

--- a/src/main/services/toolInstaller.ts
+++ b/src/main/services/toolInstaller.ts
@@ -1,5 +1,6 @@
 import { execFile, type ExecFileOptionsWithStringEncoding } from 'child_process'
 import { accessSync, chmodSync, constants, existsSync, mkdirSync } from 'fs'
+import { homedir } from 'os'
 import { dirname, join } from 'path'
 import { enrichedEnv, refreshEnrichedEnv, waitForEnrichedEnv } from '../lib/enrichedEnv'
 import {
@@ -67,6 +68,9 @@ class CommandError extends Error {
 const DEFAULT_TIMEOUT_MS = 180_000
 const CHECK_TIMEOUT_MS = 3_000
 const SYSTEM_BIN_DIR = '/usr/local/bin'
+// Per-user fallback for non-system-wide downloads. process.cwd() is read-only
+// in a packaged Electron app (e.g. /Applications), so never write there.
+const USER_BIN_DIR = join(homedir(), '.local', 'bin')
 
 const TOOL_DEFINITIONS: Record<ToolInstallKey, ToolDefinition> = {
   git: {
@@ -138,13 +142,13 @@ const TOOL_DEFINITIONS: Record<ToolInstallKey, ToolDefinition> = {
   mobilecli: {
     label: 'mobilecli',
     detectCommand: 'mobilecli',
+    // Official distribution is npm (mobile-next/mobilecli). Works cross-platform.
     strategies: [
       {
         type: 'exec',
-        command: 'brew',
-        args: ['install', 'nicklama/tap/mobilecli'],
-        prerequisite: 'brew',
-        platforms: ['darwin'],
+        command: 'npm',
+        args: ['install', '-g', 'mobilecli@latest'],
+        prerequisite: 'npm',
       },
     ],
   },
@@ -349,9 +353,8 @@ class ToolInstallerService {
         throw new Error(`No download URL for ${process.platform}-${process.arch}`)
       }
 
-      const outputPath = strategy.systemWide
-        ? join(SYSTEM_BIN_DIR, strategy.outputName)
-        : join(process.cwd(), strategy.outputName)
+      const outputDir = strategy.systemWide ? SYSTEM_BIN_DIR : USER_BIN_DIR
+      const outputPath = join(outputDir, strategy.outputName)
 
       if (strategy.systemWide && !canInstallToDirectory(SYSTEM_BIN_DIR)) {
         if (process.platform === 'darwin' && options.allowAdmin) {
@@ -375,9 +378,7 @@ class ToolInstallerService {
         throw new Error(`${SYSTEM_BIN_DIR} is not writable. Install ${strategy.outputName} manually or approve administrator privileges.`)
       }
 
-      if (strategy.systemWide) {
-        mkdirSync(SYSTEM_BIN_DIR, { recursive: true })
-      }
+      mkdirSync(outputDir, { recursive: true })
       const download = await this.execFileText('curl', ['-fL', url, '-o', outputPath], {
         timeout: strategy.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         env: enrichedEnv(),

--- a/src/main/services/toolInstaller.ts
+++ b/src/main/services/toolInstaller.ts
@@ -1,0 +1,429 @@
+import { execFile, type ExecFileOptionsWithStringEncoding } from 'child_process'
+import { accessSync, chmodSync, constants, existsSync, mkdirSync } from 'fs'
+import { dirname, join } from 'path'
+import { enrichedEnv, refreshEnrichedEnv, waitForEnrichedEnv } from '../lib/enrichedEnv'
+import {
+  isToolInstallKey,
+  type ToolInstallKey,
+  type ToolInstallOptions,
+  type ToolInstallResult,
+} from '../../shared/tool-install'
+
+type InstallStrategy =
+  | {
+      type: 'exec'
+      command: string
+      args: string[]
+      prerequisite?: string
+      platforms?: NodeJS.Platform[]
+      timeoutMs?: number
+      manualCompletion?: boolean
+    }
+  | {
+      type: 'shell'
+      command: string
+      prerequisite?: string
+      platforms?: NodeJS.Platform[]
+      timeoutMs?: number
+    }
+  | {
+      type: 'download'
+      outputName: string
+      url: (platform: NodeJS.Platform, arch: NodeJS.Architecture) => string | null
+      prerequisite?: string
+      platforms?: NodeJS.Platform[]
+      timeoutMs?: number
+      systemWide?: boolean
+    }
+  | {
+      type: 'sequence'
+      steps: Array<{ command: string; args: string[] }>
+      prerequisite?: string
+      platforms?: NodeJS.Platform[]
+      timeoutMs?: number
+    }
+
+interface ToolDefinition {
+  label: string
+  detectCommand: string
+  strategies: InstallStrategy[]
+}
+
+interface ExecResult {
+  stdout: string
+  stderr: string
+}
+
+class CommandError extends Error {
+  constructor(
+    message: string,
+    readonly stdout: string,
+    readonly stderr: string,
+  ) {
+    super(message)
+  }
+}
+
+const DEFAULT_TIMEOUT_MS = 180_000
+const CHECK_TIMEOUT_MS = 3_000
+const SYSTEM_BIN_DIR = '/usr/local/bin'
+
+const TOOL_DEFINITIONS: Record<ToolInstallKey, ToolDefinition> = {
+  git: {
+    label: 'Git',
+    detectCommand: 'git',
+    strategies: [
+      {
+        type: 'exec',
+        command: 'xcode-select',
+        args: ['--install'],
+        platforms: ['darwin'],
+        timeoutMs: 30_000,
+        manualCompletion: true,
+      },
+    ],
+  },
+  gh: {
+    label: 'GitHub CLI',
+    detectCommand: 'gh',
+    strategies: [
+      {
+        type: 'exec',
+        command: 'brew',
+        args: ['install', 'gh'],
+        prerequisite: 'brew',
+        platforms: ['darwin'],
+      },
+    ],
+  },
+  claude: {
+    label: 'Claude Code',
+    detectCommand: 'claude',
+    strategies: [
+      {
+        type: 'shell',
+        command: 'curl -fsSL https://claude.ai/install.sh | bash',
+        prerequisite: 'curl',
+        timeoutMs: 300_000,
+      },
+    ],
+  },
+  acli: {
+    label: 'Atlassian CLI',
+    detectCommand: 'acli',
+    strategies: [
+      {
+        type: 'sequence',
+        prerequisite: 'brew',
+        platforms: ['darwin'],
+        steps: [
+          { command: 'brew', args: ['tap', 'atlassian/homebrew-acli'] },
+          { command: 'brew', args: ['install', 'acli'] },
+        ],
+      },
+      {
+        type: 'download',
+        outputName: 'acli',
+        prerequisite: 'curl',
+        platforms: ['darwin', 'linux'],
+        systemWide: true,
+        url: (platform, arch) => {
+          const os = platform === 'darwin' ? 'darwin' : platform === 'linux' ? 'linux' : null
+          const cpu = arch === 'arm64' ? 'arm64' : arch === 'x64' ? 'amd64' : null
+          return os && cpu ? `https://acli.atlassian.com/${os}/latest/acli_${os}_${cpu}/acli` : null
+        },
+      },
+    ],
+  },
+  mobilecli: {
+    label: 'mobilecli',
+    detectCommand: 'mobilecli',
+    strategies: [
+      {
+        type: 'exec',
+        command: 'brew',
+        args: ['install', 'nicklama/tap/mobilecli'],
+        prerequisite: 'brew',
+        platforms: ['darwin'],
+      },
+    ],
+  },
+}
+
+function defaultUserShell(): string {
+  return process.platform === 'darwin' ? '/bin/zsh' : '/bin/sh'
+}
+
+function shellArgs(shellPath: string, cmd: string): string[] {
+  const shellName = shellPath.split('/').pop() ?? ''
+  if (shellName === 'sh' || shellName === 'dash') return ['-c', cmd]
+  return ['-lic', cmd]
+}
+
+function isSupportedPlatform(strategy: InstallStrategy): boolean {
+  return !strategy.platforms || strategy.platforms.includes(process.platform)
+}
+
+function trimOutput(value: string): string {
+  const normalized = value.trim()
+  if (normalized.length <= 700) return normalized
+  return normalized.slice(-700)
+}
+
+function failureDetail(error: unknown): string {
+  if (error instanceof CommandError) {
+    return trimOutput(error.stderr) || trimOutput(error.stdout) || error.message
+  }
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+function result(
+  key: string,
+  success: boolean,
+  installed: boolean,
+  reason: ToolInstallResult['reason'],
+  message: string,
+  details: Pick<ToolInstallResult, 'prerequisite' | 'targetPath' | 'requiresAdmin'> = {},
+): ToolInstallResult {
+  return { key, success, installed, reason, message, ...details }
+}
+
+function canWriteDirectory(dir: string): boolean {
+  try {
+    accessSync(dir, constants.W_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function canInstallToDirectory(dir: string): boolean {
+  if (existsSync(dir)) return canWriteDirectory(dir)
+  const parent = dirname(dir)
+  return existsSync(parent) && canWriteDirectory(parent)
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+class ToolInstallerService {
+  async checkCommand(command: string): Promise<boolean> {
+    return (await this.resolveCommand(command)) !== null
+  }
+
+  async install(key: string, options: ToolInstallOptions = {}): Promise<ToolInstallResult> {
+    if (!isToolInstallKey(key)) {
+      return result(key, false, false, 'unknown_tool', `No installer is registered for ${key}.`)
+    }
+
+    const definition = TOOL_DEFINITIONS[key]
+    if (await this.checkCommand(definition.detectCommand)) {
+      return result(key, true, true, 'already_installed', `${definition.label} is already installed.`)
+    }
+
+    const supportedStrategies = definition.strategies.filter(isSupportedPlatform)
+    const missingPrerequisites: string[] = []
+    let strategy: InstallStrategy | null = null
+
+    for (const candidate of supportedStrategies) {
+      if (candidate.prerequisite && !(await this.checkCommand(candidate.prerequisite))) {
+        missingPrerequisites.push(candidate.prerequisite)
+        continue
+      }
+      strategy = candidate
+      break
+    }
+
+    if (!strategy) {
+      if (supportedStrategies.length > 0 && missingPrerequisites.length > 0) {
+        const uniquePrerequisites = [...new Set(missingPrerequisites)]
+        return result(
+          key,
+          false,
+          false,
+          'missing_prerequisite',
+          `${uniquePrerequisites.join(' or ')} is required to install ${definition.label} automatically.`,
+          { prerequisite: uniquePrerequisites[0] },
+        )
+      }
+
+      return result(
+        key,
+        false,
+        false,
+        'unsupported_platform',
+        `Automatic installation for ${definition.label} is not available on ${process.platform}.`,
+      )
+    }
+
+    const adminTargetPath = this.adminRequiredTargetPath(strategy)
+    if (adminTargetPath && !options.allowAdmin) {
+      return result(
+        key,
+        false,
+        false,
+        'admin_required',
+        `${definition.label} will be installed to ${adminTargetPath}. macOS needs administrator approval to write there.`,
+        { targetPath: adminTargetPath, requiresAdmin: true },
+      )
+    }
+
+    try {
+      await this.runStrategy(strategy, options)
+    } catch (error) {
+      const detail = failureDetail(error)
+      return result(
+        key,
+        false,
+        false,
+        'install_failed',
+        detail ? `Failed to install ${definition.label}: ${detail}` : `Failed to install ${definition.label}.`,
+        { prerequisite: strategy.prerequisite },
+      )
+    }
+
+    await refreshEnrichedEnv()
+    const installed = await this.checkCommand(definition.detectCommand)
+    if (installed) {
+      return result(key, true, true, 'installed', `${definition.label} installed successfully.`)
+    }
+
+    if ('manualCompletion' in strategy && strategy.manualCompletion) {
+      return result(
+        key,
+        false,
+        false,
+        'manual_completion_required',
+        `${definition.label} installer was opened. Finish the installer, then re-check.`,
+      )
+    }
+
+    return result(
+      key,
+      false,
+      false,
+      'postcheck_failed',
+      `${definition.label} installer completed, but ${definition.detectCommand} was not found on PATH.`,
+      { prerequisite: strategy.prerequisite },
+    )
+  }
+
+  private async resolveCommand(command: string): Promise<string | null> {
+    if (!/^[a-zA-Z0-9-]+$/.test(command)) return null
+    await waitForEnrichedEnv()
+    try {
+      const { stdout } = await this.execFileText('which', [command], {
+        timeout: CHECK_TIMEOUT_MS,
+        env: enrichedEnv(),
+        encoding: 'utf8',
+      })
+      return stdout.split(/\r?\n/).map((line) => line.trim()).find((line) => line.startsWith('/')) ?? null
+    } catch {
+      return null
+    }
+  }
+
+  private adminRequiredTargetPath(strategy: InstallStrategy): string | null {
+    if (strategy.type !== 'download' || !strategy.systemWide) return null
+    if (canInstallToDirectory(SYSTEM_BIN_DIR)) return null
+    if (process.platform === 'darwin') return join(SYSTEM_BIN_DIR, strategy.outputName)
+    return null
+  }
+
+  private async runStrategy(strategy: InstallStrategy, options: ToolInstallOptions): Promise<ExecResult> {
+    if (strategy.type === 'shell') {
+      const shellPath = process.env.SHELL || defaultUserShell()
+      return this.execFileText(shellPath, shellArgs(shellPath, strategy.command), {
+        timeout: strategy.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        env: enrichedEnv(),
+        encoding: 'utf8',
+        maxBuffer: 1024 * 1024,
+      })
+    }
+
+    if (strategy.type === 'download') {
+      const url = strategy.url(process.platform, process.arch)
+      if (!url) {
+        throw new Error(`No download URL for ${process.platform}-${process.arch}`)
+      }
+
+      const outputPath = strategy.systemWide
+        ? join(SYSTEM_BIN_DIR, strategy.outputName)
+        : join(process.cwd(), strategy.outputName)
+
+      if (strategy.systemWide && !canInstallToDirectory(SYSTEM_BIN_DIR)) {
+        if (process.platform === 'darwin' && options.allowAdmin) {
+          const command = [
+            `/bin/mkdir -p ${shellQuote(SYSTEM_BIN_DIR)}`,
+            `/usr/bin/curl -fL ${shellQuote(url)} -o ${shellQuote(outputPath)}`,
+            `/bin/chmod 755 ${shellQuote(outputPath)}`,
+            `/usr/sbin/chown root:wheel ${shellQuote(outputPath)}`,
+          ].join(' && ')
+          return this.execFileText('osascript', [
+            '-e',
+            `do shell script ${JSON.stringify(command)} with administrator privileges`,
+          ], {
+            timeout: strategy.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+            env: enrichedEnv(),
+            encoding: 'utf8',
+            maxBuffer: 1024 * 1024,
+          })
+        }
+
+        throw new Error(`${SYSTEM_BIN_DIR} is not writable. Install ${strategy.outputName} manually or approve administrator privileges.`)
+      }
+
+      if (strategy.systemWide) {
+        mkdirSync(SYSTEM_BIN_DIR, { recursive: true })
+      }
+      const download = await this.execFileText('curl', ['-fL', url, '-o', outputPath], {
+        timeout: strategy.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        env: enrichedEnv(),
+        encoding: 'utf8',
+        maxBuffer: 1024 * 1024,
+      })
+      chmodSync(outputPath, 0o755)
+      return download
+    }
+
+    if (strategy.type === 'sequence') {
+      let lastResult: ExecResult = { stdout: '', stderr: '' }
+      for (const step of strategy.steps) {
+        lastResult = await this.execFileText(step.command, step.args, {
+          timeout: strategy.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          env: enrichedEnv(),
+          encoding: 'utf8',
+          maxBuffer: 1024 * 1024,
+        })
+      }
+      return lastResult
+    }
+
+    return this.execFileText(strategy.command, strategy.args, {
+      timeout: strategy.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      env: enrichedEnv(),
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024,
+    })
+  }
+
+  private execFileText(
+    file: string,
+    args: string[],
+    options: ExecFileOptionsWithStringEncoding,
+  ): Promise<ExecResult> {
+    return new Promise((resolve, reject) => {
+      execFile(file, args, options, (error, stdout, stderr) => {
+        if (error) {
+          reject(new CommandError(error.message, stdout, stderr))
+          return
+        }
+        resolve({ stdout, stderr })
+      })
+    })
+  }
+}
+
+export const toolInstaller = new ToolInstallerService()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 import type { TemplateKind, CreateTemplateArgs, CreateTemplateResult, TemplateLogEntry } from '../shared/templates'
+import type { ToolInstallOptions, ToolInstallResult } from '../shared/tool-install'
 
 const api = {
   // Storage
@@ -274,7 +275,8 @@ const api = {
     openInApp: (appId: string, targetPath: string) => ipcRenderer.invoke('shell:openInApp', appId, targetPath),
     checkTool: (tool: string) => ipcRenderer.invoke('shell:checkTool', tool) as Promise<boolean>,
     checkGhAuth: () => ipcRenderer.invoke('shell:checkGhAuth') as Promise<boolean>,
-    installTool: (key: string) => ipcRenderer.invoke('shell:installTool', key) as Promise<{ success: boolean }>,
+    installTool: (key: string, options?: ToolInstallOptions) =>
+      ipcRenderer.invoke('shell:installTool', key, options) as Promise<ToolInstallResult>,
   },
 
   // Files

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 import type { TemplateKind, CreateTemplateArgs, CreateTemplateResult, TemplateLogEntry } from '../shared/templates'
-import type { ToolInstallOptions, ToolInstallResult } from '../shared/tool-install'
+import type { ToolInstallKey, ToolInstallOptions, ToolInstallResult } from '../shared/tool-install'
 
 const api = {
   // Storage
@@ -275,7 +275,7 @@ const api = {
     openInApp: (appId: string, targetPath: string) => ipcRenderer.invoke('shell:openInApp', appId, targetPath),
     checkTool: (tool: string) => ipcRenderer.invoke('shell:checkTool', tool) as Promise<boolean>,
     checkGhAuth: () => ipcRenderer.invoke('shell:checkGhAuth') as Promise<boolean>,
-    installTool: (key: string, options?: ToolInstallOptions) =>
+    installTool: (key: ToolInstallKey, options?: ToolInstallOptions) =>
       ipcRenderer.invoke('shell:installTool', key, options) as Promise<ToolInstallResult>,
   },
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -24,6 +24,7 @@ import { OnboardingOverlay } from '@/components/Onboarding/OnboardingOverlay'
 import { FeatureTour } from '@/components/Onboarding/FeatureTour'
 import { SimulatorTour } from '@/components/Onboarding/SimulatorTour'
 import { UpdateDialog } from '@/components/shared/UpdateDialog'
+import { AdminInstallDialog } from '@/components/shared/AdminInstallDialog'
 import { useAutoUpdate } from '@/hooks/useAutoUpdate'
 import { initUpdateListeners } from '@/store/updater'
 import * as actions from '@/lib/appActions'
@@ -251,6 +252,7 @@ export default function App() {
         onDismiss={autoUpdate.dismiss}
         onRetry={autoUpdate.retry}
       />
+      <AdminInstallDialog />
       <OnboardingOverlay />
       <FeatureTour />
       <SimulatorTour />

--- a/src/renderer/components/Onboarding/OnboardingOverlay.tsx
+++ b/src/renderer/components/Onboarding/OnboardingOverlay.tsx
@@ -6,6 +6,7 @@ import { useProjectsStore } from '@/store/projects'
 import { shell, jira } from '@/lib/ipc'
 import { Button } from '@/components/ui/Button'
 import { GhAuthDialog } from '@/components/shared/GhAuthDialog'
+import { installToolAndVerify } from '@/lib/toolInstall'
 import { OnboardingLayout } from './OnboardingLayout'
 import {
   WelcomeStep,
@@ -178,14 +179,8 @@ function OnboardingContent() {
       return
     }
     dispatch({ type: 'set_check', key, status: 'installing' })
-    try { await shell.installTool(key) } catch { /* recheck below */ }
-    dispatch({ type: 'set_check', key, status: 'checking' })
-    try {
-      const ok = await CHECK_FNS[key]()
-      dispatch({ type: 'set_check', key, status: ok ? 'ok' : 'fail' })
-    } catch {
-      dispatch({ type: 'set_check', key, status: 'fail' })
-    }
+    const { installed } = await installToolAndVerify(key, CHECK_FNS[key])
+    dispatch({ type: 'set_check', key, status: installed ? 'ok' : 'fail' })
   }, [])
 
   const handleGhAuthSuccess = useCallback(async () => {

--- a/src/renderer/components/Right/SimulatorView.tsx
+++ b/src/renderer/components/Right/SimulatorView.tsx
@@ -40,8 +40,8 @@ interface State {
   shuttingDownId: string | null
   /** True after at least one auto-setup attempt failed */
   cliInstallAttempted: boolean
-  /** True when Homebrew is missing — blocks auto-install, shows brew guidance */
-  needsBrew: boolean
+  /** True when Node.js/npm is missing — blocks auto-install, shows Node guidance */
+  needsNode: boolean
   /** Detected platform toolchains (populated on first device load) */
   platformTools: PlatformTools | null
 }
@@ -50,7 +50,7 @@ type Action =
   | { type: 'LOADING' }
   | { type: 'NO_CLI' }
   | { type: 'INSTALLING_CLI' }
-  | { type: 'CLI_INSTALL_FAILED'; needsBrew: boolean }
+  | { type: 'CLI_INSTALL_FAILED'; needsNode: boolean }
   | { type: 'DEVICES_LOADED'; devices: SimulatorDevice[]; platformTools: PlatformTools }
   | { type: 'BOOTING'; id: string }
   | { type: 'BOOT_DONE' }
@@ -67,18 +67,18 @@ type Action =
 const initialState: State = {
   phase: 'loading', devices: [], selectedId: null,
   screenSize: null, error: null, bootingId: null, shuttingDownId: null,
-  cliInstallAttempted: false, needsBrew: false, platformTools: null,
+  cliInstallAttempted: false, needsNode: false, platformTools: null,
 }
 
 const MOBILECLI_REPO = 'https://github.com/mobile-next/mobilecli'
-const HOMEBREW_URL = 'https://brew.sh'
+const NODEJS_URL = 'https://nodejs.org'
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'LOADING': return { ...state, phase: 'loading', error: null }
     case 'NO_CLI': return { ...state, phase: 'no-cli' }
     case 'INSTALLING_CLI': return { ...state, phase: 'installing-cli' }
-    case 'CLI_INSTALL_FAILED': return { ...state, phase: 'no-cli', cliInstallAttempted: true, needsBrew: action.needsBrew }
+    case 'CLI_INSTALL_FAILED': return { ...state, phase: 'no-cli', cliInstallAttempted: true, needsNode: action.needsNode }
     case 'DEVICES_LOADED': return { ...state, phase: 'device-list', devices: action.devices, platformTools: action.platformTools, error: null }
     case 'BOOTING': return { ...state, bootingId: action.id }
     case 'BOOT_DONE': return { ...state, bootingId: null }
@@ -172,12 +172,12 @@ export const SimulatorView = memo(function SimulatorView({ isActive, mobileFrame
   /** Attempt registered CLI install, then recheck. Linux uses manual setup. */
   const installCli = useCallback(async () => {
     if (hostPlatform === 'linux') {
-      dispatch({ type: 'CLI_INSTALL_FAILED', needsBrew: false })
+      dispatch({ type: 'CLI_INSTALL_FAILED', needsNode: false })
       return
     }
 
     dispatch({ type: 'INSTALLING_CLI' })
-    // notify: false — this view renders its own inline brew/install guidance,
+    // notify: false — this view renders its own inline Node/install guidance,
     // so the shared failure toast would be a redundant, contradictory message.
     const { installed, result } = await installToolAndVerify(
       'mobilecli',
@@ -189,7 +189,7 @@ export const SimulatorView = memo(function SimulatorView({ isActive, mobileFrame
     } else {
       dispatch({
         type: 'CLI_INSTALL_FAILED',
-        needsBrew: result?.reason === 'missing_prerequisite' && result.prerequisite === 'brew',
+        needsNode: result?.reason === 'missing_prerequisite' && result.prerequisite === 'npm',
       })
     }
   }, [hostPlatform, loadDevices])
@@ -376,16 +376,16 @@ export const SimulatorView = memo(function SimulatorView({ isActive, mobileFrame
         )
       }
 
-      // Homebrew missing → explain what to do, don't offer the auto-install button
-      if (state.needsBrew) {
+      // Node.js/npm missing → explain what to do, don't offer the auto-install button
+      if (state.needsNode) {
         return (
           <EmptyState
             title={t('simulatorCliMissing')}
-            hint={t('simulatorCliNeedsBrew')}
+            hint={t('simulatorCliNeedsNode')}
             action={
               <div className="simulator-cli-actions">
-                <Button size="sm" onClick={() => ipc.shell.openExternal(HOMEBREW_URL)}>
-                  Homebrew <IconExternalLink size={10} />
+                <Button size="sm" onClick={() => ipc.shell.openExternal(NODEJS_URL)}>
+                  Node.js <IconExternalLink size={10} />
                 </Button>
                 <button className="simulator-cli-docs-link" onClick={() => ipc.shell.openExternal(MOBILECLI_REPO)}>
                   {t('simulatorCliManual')} <IconExternalLink size={10} />

--- a/src/renderer/components/Right/SimulatorView.tsx
+++ b/src/renderer/components/Right/SimulatorView.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from '@/components/ui/EmptyState'
 import { Button } from '@/components/ui/Button'
 import { Spinner } from '@/components/ui/Spinner'
 import { IconExternalLink } from '@/components/shared/icons'
+import { installToolAndVerify } from '@/lib/toolInstall'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -168,26 +169,28 @@ export const SimulatorView = memo(function SimulatorView({ isActive, mobileFrame
     }
   }, [t])
 
-  /** Attempt macOS Homebrew install, then recheck. Linux uses manual setup. */
+  /** Attempt registered CLI install, then recheck. Linux uses manual setup. */
   const installCli = useCallback(async () => {
     if (hostPlatform === 'linux') {
       dispatch({ type: 'CLI_INSTALL_FAILED', needsBrew: false })
       return
     }
 
-    // Pre-check: is Homebrew even available?
-    const hasBrew = await ipc.shell.checkTool('brew')
-    if (!hasBrew) {
-      dispatch({ type: 'CLI_INSTALL_FAILED', needsBrew: true })
-      return
-    }
     dispatch({ type: 'INSTALLING_CLI' })
-    try { await ipc.shell.installTool('mobilecli') } catch { /* recheck below */ }
-    const hasCli = await ipc.simulator.checkCli()
-    if (hasCli) {
+    // notify: false — this view renders its own inline brew/install guidance,
+    // so the shared failure toast would be a redundant, contradictory message.
+    const { installed, result } = await installToolAndVerify(
+      'mobilecli',
+      () => ipc.simulator.checkCli(),
+      { notify: false },
+    )
+    if (installed) {
       loadDevices()
     } else {
-      dispatch({ type: 'CLI_INSTALL_FAILED', needsBrew: false })
+      dispatch({
+        type: 'CLI_INSTALL_FAILED',
+        needsBrew: result?.reason === 'missing_prerequisite' && result.prerequisite === 'brew',
+      })
     }
   }, [hostPlatform, loadDevices])
 

--- a/src/renderer/components/Settings/SettingsGitHub.tsx
+++ b/src/renderer/components/Settings/SettingsGitHub.tsx
@@ -1,11 +1,11 @@
 import { useReducer, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { shell } from '@/lib/ipc'
-import { flash } from '@/store/flash'
 import { Button } from '@/components/ui/Button'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { GhAuthDialog } from '@/components/shared/GhAuthDialog'
 import { IconExternalLink } from '@/components/shared/icons'
+import { installToolAndVerify } from '@/lib/toolInstall'
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -110,20 +110,8 @@ export function SettingsGitHub() {
 
   const handleInstall = useCallback(async () => {
     dispatch({ type: 'setGh', status: 'installing' })
-    try {
-      await shell.installTool('gh')
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Unknown error'
-      flash('error', `Failed to install gh: ${msg}`, 5000)
-    }
-    if (!mountedRef.current) return
-    dispatch({ type: 'setGh', status: 'checking' })
-    try {
-      const ok = await shell.checkTool('gh')
-      if (mountedRef.current) dispatch({ type: 'setGh', status: ok ? 'installed' : 'not_installed' })
-    } catch {
-      if (mountedRef.current) dispatch({ type: 'setGh', status: 'not_installed' })
-    }
+    const { installed } = await installToolAndVerify('gh', () => shell.checkTool('gh'))
+    if (mountedRef.current) dispatch({ type: 'setGh', status: installed ? 'installed' : 'not_installed' })
   }, [])
 
   const handleAuthSuccess = useCallback(() => {

--- a/src/renderer/components/Settings/SettingsJira.tsx
+++ b/src/renderer/components/Settings/SettingsJira.tsx
@@ -5,6 +5,7 @@ import { jira, shell } from '@/lib/ipc'
 import { Button } from '@/components/ui/Button'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { IconExternalLink } from '@/components/shared/icons'
+import { installToolAndVerify } from '@/lib/toolInstall'
 
 type AcliStatus = 'checking' | 'installed' | 'not_installed' | 'installing'
 type SaveState = 'idle' | 'saved'
@@ -52,14 +53,8 @@ export function SettingsJira() {
 
   const handleInstall = useCallback(async () => {
     dispatch({ type: 'setAcli', status: 'installing' })
-    try { await shell.installTool('acli') } catch { /* still recheck below */ }
-    dispatch({ type: 'setAcli', status: 'checking' })
-    try {
-      const ok = await jira.recheckAvailability()
-      dispatch({ type: 'setAcli', status: ok ? 'installed' : 'not_installed' })
-    } catch {
-      dispatch({ type: 'setAcli', status: 'not_installed' })
-    }
+    const { installed } = await installToolAndVerify('acli', () => jira.recheckAvailability())
+    dispatch({ type: 'setAcli', status: installed ? 'installed' : 'not_installed' })
   }, [])
 
   // ── Base URL save with brief "Saved" flash ──────────────────────────

--- a/src/renderer/components/shared/AdminInstallDialog.tsx
+++ b/src/renderer/components/shared/AdminInstallDialog.tsx
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
 import { Dialog } from '@/components/ui/Dialog'
 import { Button } from '@/components/ui/Button'
 import {
@@ -16,6 +17,7 @@ function displayToolName(key: string): string {
 }
 
 export function AdminInstallDialog() {
+  const { t } = useTranslation('common')
   const request = useSyncExternalStore(
     subscribeAdminInstallPrompt,
     getAdminInstallRequest,
@@ -31,26 +33,29 @@ export function AdminInstallDialog() {
     <Dialog
       isOpen
       onClose={() => resolveAdminInstallApproval(false)}
-      title={`Install ${toolName}`}
+      title={t('adminInstall.title', { tool: toolName })}
       width="460px"
       actions={(
         <>
           <Button onClick={() => resolveAdminInstallApproval(false)}>
-            Cancel
+            {t('adminInstall.cancel')}
           </Button>
           <Button variant="primary" onClick={() => resolveAdminInstallApproval(true)}>
-            Continue
+            {t('adminInstall.continue')}
           </Button>
         </>
       )}
     >
       <div className="admin-install-dialog">
         <p>
-          Braid will install {toolName} to <code>{targetPath}</code> so every shell and external app can find it.
+          <Trans
+            i18nKey="adminInstall.body"
+            ns="common"
+            values={{ tool: toolName, path: targetPath }}
+            components={{ code: <code /> }}
+          />
         </p>
-        <p>
-          macOS will ask for an administrator password before writing to this system location.
-        </p>
+        <p>{t('adminInstall.note')}</p>
       </div>
     </Dialog>
   )

--- a/src/renderer/components/shared/AdminInstallDialog.tsx
+++ b/src/renderer/components/shared/AdminInstallDialog.tsx
@@ -1,0 +1,57 @@
+import { useSyncExternalStore } from 'react'
+import { Dialog } from '@/components/ui/Dialog'
+import { Button } from '@/components/ui/Button'
+import {
+  getAdminInstallRequest,
+  resolveAdminInstallApproval,
+  subscribeAdminInstallPrompt,
+} from '@/lib/adminInstallPrompt'
+
+function displayToolName(key: string): string {
+  if (key === 'acli') return 'Atlassian CLI'
+  if (key === 'gh') return 'GitHub CLI'
+  if (key === 'mobilecli') return 'mobilecli'
+  if (key === 'claude') return 'Claude Code'
+  return key
+}
+
+export function AdminInstallDialog() {
+  const request = useSyncExternalStore(
+    subscribeAdminInstallPrompt,
+    getAdminInstallRequest,
+    getAdminInstallRequest,
+  )
+
+  if (!request) return null
+
+  const toolName = displayToolName(request.key)
+  const targetPath = request.result.targetPath ?? '/usr/local/bin'
+
+  return (
+    <Dialog
+      isOpen
+      onClose={() => resolveAdminInstallApproval(false)}
+      title={`Install ${toolName}`}
+      width="460px"
+      actions={(
+        <>
+          <Button onClick={() => resolveAdminInstallApproval(false)}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={() => resolveAdminInstallApproval(true)}>
+            Continue
+          </Button>
+        </>
+      )}
+    >
+      <div className="admin-install-dialog">
+        <p>
+          Braid will install {toolName} to <code>{targetPath}</code> so every shell and external app can find it.
+        </p>
+        <p>
+          macOS will ask for an administrator password before writing to this system location.
+        </p>
+      </div>
+    </Dialog>
+  )
+}

--- a/src/renderer/lib/adminInstallPrompt.ts
+++ b/src/renderer/lib/adminInstallPrompt.ts
@@ -1,0 +1,46 @@
+import type { ToolInstallKey, ToolInstallResult } from '@shared/tool-install'
+
+export interface AdminInstallRequest {
+  key: ToolInstallKey
+  result: ToolInstallResult
+}
+
+type Listener = () => void
+
+let currentRequest: AdminInstallRequest | null = null
+let resolver: ((approved: boolean) => void) | null = null
+const listeners = new Set<Listener>()
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+export function subscribeAdminInstallPrompt(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => { listeners.delete(listener) }
+}
+
+export function getAdminInstallRequest(): AdminInstallRequest | null {
+  return currentRequest
+}
+
+export function requestAdminInstallApproval(request: AdminInstallRequest): Promise<boolean> {
+  if (resolver) {
+    resolver(false)
+  }
+
+  currentRequest = request
+  emit()
+
+  return new Promise<boolean>((resolve) => {
+    resolver = resolve
+  })
+}
+
+export function resolveAdminInstallApproval(approved: boolean): void {
+  const resolve = resolver
+  currentRequest = null
+  resolver = null
+  emit()
+  resolve?.(approved)
+}

--- a/src/renderer/lib/adminInstallPrompt.ts
+++ b/src/renderer/lib/adminInstallPrompt.ts
@@ -25,8 +25,12 @@ export function getAdminInstallRequest(): AdminInstallRequest | null {
 }
 
 export function requestAdminInstallApproval(request: AdminInstallRequest): Promise<boolean> {
+  // Cancel any in-flight request first. Capture and clear the resolver before
+  // settling it so the rejected request can't observe the new resolver.
   if (resolver) {
-    resolver(false)
+    const prevResolver = resolver
+    resolver = null
+    prevResolver(false)
   }
 
   currentRequest = request

--- a/src/renderer/lib/ipc.ts
+++ b/src/renderer/lib/ipc.ts
@@ -210,7 +210,7 @@ export const shell = {
   openInApp: (appId: string, targetPath: string) => api().shell.openInApp(appId, targetPath),
   checkTool: (tool: string) => api().shell.checkTool(tool),
   checkGhAuth: () => api().shell.checkGhAuth(),
-  installTool: (key: string, options?: import('@shared/tool-install').ToolInstallOptions) =>
+  installTool: (key: import('@shared/tool-install').ToolInstallKey, options?: import('@shared/tool-install').ToolInstallOptions) =>
     api().shell.installTool(key, options) as Promise<import('@shared/tool-install').ToolInstallResult>,
 }
 

--- a/src/renderer/lib/ipc.ts
+++ b/src/renderer/lib/ipc.ts
@@ -210,7 +210,8 @@ export const shell = {
   openInApp: (appId: string, targetPath: string) => api().shell.openInApp(appId, targetPath),
   checkTool: (tool: string) => api().shell.checkTool(tool),
   checkGhAuth: () => api().shell.checkGhAuth(),
-  installTool: (key: string) => api().shell.installTool(key),
+  installTool: (key: string, options?: import('@shared/tool-install').ToolInstallOptions) =>
+    api().shell.installTool(key, options) as Promise<import('@shared/tool-install').ToolInstallResult>,
 }
 
 export const scripts = {

--- a/src/renderer/lib/toolInstall.ts
+++ b/src/renderer/lib/toolInstall.ts
@@ -1,0 +1,62 @@
+import { shell } from './ipc'
+import { flash } from '@/store/flash'
+import { requestAdminInstallApproval } from './adminInstallPrompt'
+import type { ToolInstallKey, ToolInstallResult } from '@shared/tool-install'
+
+export interface ToolInstallOutcome {
+  installed: boolean
+  result: ToolInstallResult | null
+}
+
+interface InstallOptions {
+  notify?: boolean
+}
+
+async function verifySafely(verify: () => Promise<boolean>): Promise<boolean> {
+  try {
+    return await verify()
+  } catch {
+    return false
+  }
+}
+
+function notifyFailure(key: ToolInstallKey, result: ToolInstallResult | null, error?: unknown): void {
+  const fallback = `Failed to install ${key}.`
+  const message = result?.message
+    || (error instanceof Error ? error.message : null)
+    || fallback
+  flash('error', message, 7000)
+}
+
+export async function installToolAndVerify(
+  key: ToolInstallKey,
+  verify: () => Promise<boolean>,
+  options: InstallOptions = {},
+): Promise<ToolInstallOutcome> {
+  const shouldNotify = options.notify ?? true
+
+  let installResult: ToolInstallResult
+  try {
+    installResult = await shell.installTool(key)
+  } catch (error) {
+    if (shouldNotify) notifyFailure(key, null, error)
+    return { installed: false, result: null }
+  }
+
+  if (installResult.reason === 'admin_required') {
+    const approved = await requestAdminInstallApproval({ key, result: installResult })
+    if (!approved) return { installed: false, result: installResult }
+
+    try {
+      installResult = await shell.installTool(key, { allowAdmin: true })
+    } catch (error) {
+      if (shouldNotify) notifyFailure(key, null, error)
+      return { installed: false, result: null }
+    }
+  }
+
+  const installed = installResult.installed || await verifySafely(verify)
+  if (!installed && shouldNotify) notifyFailure(key, installResult)
+
+  return { installed, result: installResult }
+}

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -178,6 +178,13 @@
     "checking": "Checking...",
     "upToDate": "Braid is up to date"
   },
+  "adminInstall": {
+    "title": "Install {{tool}}",
+    "body": "Braid will install {{tool}} to <code>{{path}}</code> so every shell and external app can find it.",
+    "note": "macOS will ask for an administrator password before writing to this system location.",
+    "cancel": "Cancel",
+    "continue": "Continue"
+  },
   "tour": {
     "next": "Next",
     "back": "Back",

--- a/src/renderer/locales/en/right.json
+++ b/src/renderer/locales/en/right.json
@@ -236,7 +236,7 @@
   "simulatorCliMissingHint": "A small helper tool is needed to stream simulator screens into Braid.",
   "simulatorCliInstall": "Set up now",
   "simulatorCliInstalling": "Setting up…",
-  "simulatorCliNeedsBrew": "Automatic setup requires Homebrew. Install Homebrew first, then try again.",
+  "simulatorCliNeedsNode": "Automatic setup requires Node.js (npm). Install Node.js first, then try again.",
   "simulatorCliManualLinux": "Automatic setup is unavailable on Linux. Install mobilecli manually, then refresh.",
   "simulatorCliManual": "Manual setup guide",
   "simulatorStreamError": "Failed to capture device screen",

--- a/src/renderer/locales/id/common.json
+++ b/src/renderer/locales/id/common.json
@@ -178,6 +178,13 @@
     "checking": "Memeriksa...",
     "upToDate": "Braid sudah terbaru"
   },
+  "adminInstall": {
+    "title": "Pasang {{tool}}",
+    "body": "Braid akan memasang {{tool}} ke <code>{{path}}</code> agar setiap shell dan aplikasi eksternal dapat menemukannya.",
+    "note": "macOS akan meminta kata sandi administrator sebelum menulis ke lokasi sistem ini.",
+    "cancel": "Batal",
+    "continue": "Lanjutkan"
+  },
   "tour": {
     "next": "Berikutnya",
     "back": "Kembali",

--- a/src/renderer/locales/id/right.json
+++ b/src/renderer/locales/id/right.json
@@ -236,7 +236,7 @@
   "simulatorCliMissingHint": "Alat bantu kecil diperlukan untuk streaming layar simulator ke Braid.",
   "simulatorCliInstall": "Siapkan sekarang",
   "simulatorCliInstalling": "Menyiapkan…",
-  "simulatorCliNeedsBrew": "Penyiapan otomatis memerlukan Homebrew. Instal Homebrew terlebih dahulu, lalu coba lagi.",
+  "simulatorCliNeedsNode": "Penyiapan otomatis memerlukan Node.js (npm). Instal Node.js terlebih dahulu, lalu coba lagi.",
   "simulatorCliManualLinux": "Penyiapan otomatis tidak tersedia di Linux. Instal mobilecli secara manual, lalu muat ulang.",
   "simulatorCliManual": "Panduan setup manual",
   "simulatorStreamError": "Gagal menangkap layar perangkat",

--- a/src/renderer/locales/ja/common.json
+++ b/src/renderer/locales/ja/common.json
@@ -178,6 +178,13 @@
     "checking": "確認中...",
     "upToDate": "最新バージョンです"
   },
+  "adminInstall": {
+    "title": "{{tool}} をインストール",
+    "body": "Braid は {{tool}} を <code>{{path}}</code> にインストールし、すべてのシェルと外部アプリから利用できるようにします。",
+    "note": "このシステム領域への書き込みには、macOS が管理者パスワードの入力を求めます。",
+    "cancel": "キャンセル",
+    "continue": "続行"
+  },
   "tour": {
     "next": "次へ",
     "back": "戻る",

--- a/src/renderer/locales/ja/right.json
+++ b/src/renderer/locales/ja/right.json
@@ -236,7 +236,7 @@
   "simulatorCliMissingHint": "シミュレータ画面をBraidに表示するには、小さなヘルパーツールが必要です。",
   "simulatorCliInstall": "セットアップ",
   "simulatorCliInstalling": "セットアップ中…",
-  "simulatorCliNeedsBrew": "自動セットアップにはHomebrewが必要です。先にHomebrewをインストールしてください。",
+  "simulatorCliNeedsNode": "自動セットアップには Node.js（npm）が必要です。先に Node.js をインストールしてください。",
   "simulatorCliManualLinux": "Linuxでは自動セットアップを利用できません。mobilecliを手動でインストールしてから更新してください。",
   "simulatorCliManual": "手動セットアップガイド",
   "simulatorStreamError": "デバイス画面のキャプチャに失敗しました",

--- a/src/renderer/locales/zh/common.json
+++ b/src/renderer/locales/zh/common.json
@@ -178,6 +178,13 @@
     "checking": "检查中...",
     "upToDate": "Braid 已是最新版本"
   },
+  "adminInstall": {
+    "title": "安装 {{tool}}",
+    "body": "Braid 会将 {{tool}} 安装到 <code>{{path}}</code>，以便所有 shell 和外部应用都能找到它。",
+    "note": "写入此系统位置前，macOS 会要求输入管理员密码。",
+    "cancel": "取消",
+    "continue": "继续"
+  },
   "tour": {
     "next": "下一步",
     "back": "上一步",

--- a/src/renderer/locales/zh/right.json
+++ b/src/renderer/locales/zh/right.json
@@ -236,7 +236,7 @@
   "simulatorCliMissingHint": "需要一个小工具来将模拟器屏幕串流到 Braid。",
   "simulatorCliInstall": "立即设置",
   "simulatorCliInstalling": "设置中…",
-  "simulatorCliNeedsBrew": "自动设置需要 Homebrew。请先安装 Homebrew，然后重试。",
+  "simulatorCliNeedsNode": "自动设置需要 Node.js（npm）。请先安装 Node.js，然后重试。",
   "simulatorCliManualLinux": "Linux 不支持自动设置。请手动安装 mobilecli，然后刷新。",
   "simulatorCliManual": "手动设置指南",
   "simulatorStreamError": "设备屏幕捕获失败",

--- a/src/renderer/styles/dialogs.css
+++ b/src/renderer/styles/dialogs.css
@@ -65,6 +65,28 @@
   margin-top: var(--space-16);
 }
 
+.admin-install-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-10);
+  color: var(--text-secondary);
+  font-size: var(--text-md);
+  line-height: 1.5;
+}
+
+.admin-install-dialog p {
+  margin: 0;
+}
+
+.admin-install-dialog code {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-5);
+  font-size: var(--text-sm);
+}
+
 /* Dialog tab switcher */
 .dialog-tabs {
   display: flex;

--- a/src/shared/tool-install.ts
+++ b/src/shared/tool-install.ts
@@ -1,0 +1,35 @@
+export const TOOL_INSTALL_KEYS = ['git', 'gh', 'claude', 'acli', 'mobilecli'] as const
+
+export type ToolInstallKey = typeof TOOL_INSTALL_KEYS[number]
+
+export type ToolInstallReason =
+  | 'already_installed'
+  | 'installed'
+  | 'unknown_tool'
+  | 'unsupported_platform'
+  | 'missing_prerequisite'
+  | 'admin_required'
+  | 'install_failed'
+  | 'postcheck_failed'
+  | 'manual_completion_required'
+
+export interface ToolInstallResult {
+  key: string
+  success: boolean
+  installed: boolean
+  reason: ToolInstallReason
+  message: string
+  prerequisite?: string
+  targetPath?: string
+  requiresAdmin?: boolean
+}
+
+export interface ToolInstallOptions {
+  allowAdmin?: boolean
+}
+
+const TOOL_INSTALL_KEY_SET = new Set<string>(TOOL_INSTALL_KEYS)
+
+export function isToolInstallKey(value: string): value is ToolInstallKey {
+  return TOOL_INSTALL_KEY_SET.has(value)
+}


### PR DESCRIPTION
## Summary

- Extracts scattered tool install/check logic from `ipc.ts` into a new `ToolInstallerService` (`src/main/services/toolInstaller.ts`) with declarative tool definitions, typed `ToolInstallResult` responses, and prerequisite validation
- Adds an admin-approval flow: when a download-based installer targets a write-protected system directory (e.g. `/usr/local/bin`), the renderer shows an `AdminInstallDialog` before retrying with `osascript ... with administrator privileges`
- Replaces ad-hoc install-then-recheck patterns across four UI surfaces (Onboarding, SettingsGitHub, SettingsJira, SimulatorView) with a shared `installToolAndVerify()` helper

## Layers touched

- [x] **Main process** (`src/main/`) - services, IPC handlers
- [x] **Preload** (`src/preload/`) - context bridge API
- [x] **Renderer** (`src/renderer/`) - components, stores, lib
- [x] **Styles** (`App.css`)

## Changes

**Services** (`toolInstaller.ts`):
- New `ToolInstallerService` class with `checkCommand()` and `install()` methods
- Declarative `TOOL_DEFINITIONS` for git, gh, claude, acli, mobilecli - each with ordered install strategies (exec, shell, download, sequence) and optional prerequisites/platform filters
- `ToolInstallResult` carries a typed `reason` discriminant (`already_installed`, `missing_prerequisite`, `admin_required`, `install_failed`, `postcheck_failed`, `manual_completion_required`, etc.) so the UI can branch on failure cause
- Download strategy supports macOS admin elevation via `osascript`
- ACLI now uses Homebrew tap+install as primary strategy, with direct binary download as fallback

**Shared types** (`src/shared/tool-install.ts`):
- `ToolInstallKey`, `ToolInstallResult`, `ToolInstallOptions` shared across main/preload/renderer

**IPC** (`main/ipc.ts` -> `preload/index.ts` -> `lib/ipc.ts`):
- `shell:checkTool` delegates to `toolInstaller.checkCommand()` (awaits PATH hydration)
- `shell:installTool` returns `ToolInstallResult` instead of `{ success: boolean }`
- `shell:checkGhAuth` now pre-checks gh availability before running `gh auth status`

**Renderer** (`lib/toolInstall.ts`, `lib/adminInstallPrompt.ts`, `AdminInstallDialog.tsx`):
- `installToolAndVerify()` - shared helper that calls install, handles admin_required flow, verifies, and optionally flashes errors
- `AdminInstallDialog` - useSyncExternalStore-based dialog for admin approval
- OnboardingOverlay, SettingsGitHub, SettingsJira, SimulatorView all simplified to use `installToolAndVerify()`

**Lib** (`enrichedEnv.ts`):
- New `refreshEnrichedEnv()` re-probes the login shell PATH after an installer mutates shell config
- LSP download also calls `refreshEnrichedEnv()` post-install

## How to test

1. `yarn dev`
2. Open Settings > Jira - click "Install" for acli (with and without Homebrew available)
3. Open Settings > GitHub - click "Install" for gh
4. Open a project without Claude installed - verify onboarding install flow
5. On a system where `/usr/local/bin` is not writable, verify the admin approval dialog appears for acli direct download
6. `yarn test toolInstaller` - 8 unit tests covering typed results, prerequisite checks, admin flow, fallback strategies

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally with `yarn dev`
- [x] Types pass - `yarn typecheck`
- [x] No console errors or warnings in DevTools
- [x] IPC changes are threaded through all 3 layers (main -> preload -> renderer)
- [x] New state is added to the correct Zustand store