### PR TITLE
feat(mobile): background push, bare terminal tab, notification & usage fixes

### DIFF
--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -15,6 +15,8 @@
         "NSLocalNetworkUsageDescription": "Braid connects to your desktop app on your local network.",
         "NSBonjourServices": [
           "_braid._tcp",
+          "_braid._tcp.",
+          "_braid._tcp",
           "_braid._tcp."
         ],
         "NSAppTransportSecurity": {
@@ -22,6 +24,10 @@
         },
         "ITSAppUsesNonExemptEncryption": false,
         "UISupportedInterfaceOrientations~ipad": [
+          "UIInterfaceOrientationPortrait",
+          "UIInterfaceOrientationPortraitUpsideDown",
+          "UIInterfaceOrientationLandscapeLeft",
+          "UIInterfaceOrientationLandscapeRight",
           "UIInterfaceOrientationPortrait",
           "UIInterfaceOrientationPortraitUpsideDown",
           "UIInterfaceOrientationLandscapeLeft",
@@ -41,6 +47,11 @@
       "usesCleartextTraffic": true,
       "package": "com.agas.braid.mobile",
       "permissions": [
+        "android.permission.ACCESS_NETWORK_STATE",
+        "android.permission.ACCESS_WIFI_STATE",
+        "android.permission.CHANGE_WIFI_MULTICAST_STATE",
+        "android.permission.INTERNET",
+        "android.permission.CAMERA",
         "android.permission.ACCESS_NETWORK_STATE",
         "android.permission.ACCESS_WIFI_STATE",
         "android.permission.CHANGE_WIFI_MULTICAST_STATE",
@@ -92,6 +103,12 @@
       "eas": {
         "projectId": "30316c58-3d94-442c-8728-909ceba9e8c4"
       }
+    },
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/30316c58-3d94-442c-8728-909ceba9e8c4"
     }
   }
 }

--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -15,8 +15,6 @@
         "NSLocalNetworkUsageDescription": "Braid connects to your desktop app on your local network.",
         "NSBonjourServices": [
           "_braid._tcp",
-          "_braid._tcp.",
-          "_braid._tcp",
           "_braid._tcp."
         ],
         "NSAppTransportSecurity": {
@@ -24,10 +22,6 @@
         },
         "ITSAppUsesNonExemptEncryption": false,
         "UISupportedInterfaceOrientations~ipad": [
-          "UIInterfaceOrientationPortrait",
-          "UIInterfaceOrientationPortraitUpsideDown",
-          "UIInterfaceOrientationLandscapeLeft",
-          "UIInterfaceOrientationLandscapeRight",
           "UIInterfaceOrientationPortrait",
           "UIInterfaceOrientationPortraitUpsideDown",
           "UIInterfaceOrientationLandscapeLeft",
@@ -47,11 +41,6 @@
       "usesCleartextTraffic": true,
       "package": "com.agas.braid.mobile",
       "permissions": [
-        "android.permission.ACCESS_NETWORK_STATE",
-        "android.permission.ACCESS_WIFI_STATE",
-        "android.permission.CHANGE_WIFI_MULTICAST_STATE",
-        "android.permission.INTERNET",
-        "android.permission.CAMERA",
         "android.permission.ACCESS_NETWORK_STATE",
         "android.permission.ACCESS_WIFI_STATE",
         "android.permission.CHANGE_WIFI_MULTICAST_STATE",

--- a/mobile-app/eas.json
+++ b/mobile-app/eas.json
@@ -6,20 +6,24 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "development"
     },
     "development-simulator": {
       "developmentClient": true,
       "distribution": "internal",
       "ios": {
         "simulator": true
-      }
+      },
+      "channel": "development-simulator"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "preview"
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "channel": "production"
     }
   },
   "submit": {

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -25,6 +25,7 @@
     "expo-status-bar": "~56.0.4",
     "expo-symbols": "~56.0.5",
     "expo-system-ui": "~56.0.5",
+    "expo-updates": "~56.0.17",
     "expo-web-browser": "~56.0.5",
     "i18next": "^26.3.0",
     "lucide-react-native": "^1.17.0",

--- a/mobile-app/src/app/_layout.tsx
+++ b/mobile-app/src/app/_layout.tsx
@@ -42,6 +42,8 @@ function useNotificationTapRouting(): void {
       const hosts = await loadHosts().catch(() => null);
       const path = getNotificationNavigationPath(response.notification.request.content.data, {
         knownHostIds: hosts ? new Set(hosts.map((host) => host.id)) : undefined,
+        // Remote push carries the desktop instance id; map it back to a host id.
+        hostIdByDesktopId: hosts ? new Map(hosts.map((host) => [host.serverPublicKey, host.id])) : undefined,
       });
       // navigate (not push): a warm tap reuses the already-mounted terminal
       // screen and just updates its params (worktreePath/terminalId), so the

--- a/mobile-app/src/app/host/[hostId].tsx
+++ b/mobile-app/src/app/host/[hostId].tsx
@@ -426,15 +426,18 @@ export default function HostScreen() {
         text: t('common.remove'),
         style: 'destructive',
         onPress: async () => {
-          // Stop desktop background push for this device (best-effort, while
-          // connected) before tearing down the connection and forgetting the host.
-          await manager.unregisterPush(host.id);
-          manager.dropHost(host.id);
+          // Tear down push + connection in the background so the UI transitions
+          // instantly: unregisterPush can wait up to 4s for a socket when the
+          // desktop is offline, and we don't want "Remove" to feel frozen.
+          void (async () => {
+            await manager.unregisterPush(host.id);
+            manager.dropHost(host.id);
+          })();
           const remaining = await removeHost(host.id);
           // No desktops left: kill push registration entirely so a desktop that
           // was offline at removal self-cleans via DeviceNotRegistered on its next
           // push, rather than waiting out the token TTL.
-          if (remaining.length === 0) await unregisterFromPushAsync();
+          if (remaining.length === 0) void unregisterFromPushAsync();
           router.replace('/');
         },
       },

--- a/mobile-app/src/app/host/[hostId].tsx
+++ b/mobile-app/src/app/host/[hostId].tsx
@@ -13,6 +13,7 @@ import { useClientManager } from '@/transport/client-manager';
 import { isErrorVerdict } from '@/transport/connection-health';
 import { desktopSupports, evaluateCompatFromStatus } from '@/transport/protocol-compat';
 import { MOBILE_CAPABILITY } from '@/transport/protocol-version';
+import { unregisterFromPushAsync } from '@/notifications/mobile-notifications';
 import { removeHost } from '@/transport/host-store';
 import type { BraidProject, BraidStatus, BraidTerminal, BraidWorktree, PrStatus } from '@/transport/types';
 import { ConnectionLog } from '@/ui/ConnectionLog';
@@ -425,8 +426,15 @@ export default function HostScreen() {
         text: t('common.remove'),
         style: 'destructive',
         onPress: async () => {
+          // Stop desktop background push for this device (best-effort, while
+          // connected) before tearing down the connection and forgetting the host.
+          await manager.unregisterPush(host.id);
           manager.dropHost(host.id);
-          await removeHost(host.id);
+          const remaining = await removeHost(host.id);
+          // No desktops left: kill push registration entirely so a desktop that
+          // was offline at removal self-cleans via DeviceNotRegistered on its next
+          // push, rather than waiting out the token TTL.
+          if (remaining.length === 0) await unregisterFromPushAsync();
           router.replace('/');
         },
       },

--- a/mobile-app/src/app/index.tsx
+++ b/mobile-app/src/app/index.tsx
@@ -368,19 +368,21 @@ function FreshHomeScreen() {
         text: i18n.t('common.remove'),
         style: 'destructive',
         onPress: async () => {
-          // Tell the desktop to forget our push token (while still connected) so
-          // it stops sending background notifications, then drop the live
-          // connection: removing only from storage leaves the client-manager entry
-          // alive, so it keeps the socket open (and keeps reconnecting + presenting
-          // notifications) for a desktop the user just removed. dropHost closes the
+          // Tear down push + connection in the background so the row disappears
+          // instantly: removing only from storage would leave the client-manager
+          // entry alive (socket open, still reconnecting + notifying), but
+          // unregisterPush can wait up to 4s for a socket when the desktop is
+          // offline, so we don't await it on the UI path. dropHost then closes the
           // socket and tears down the listener.
-          await manager.unregisterPush(host.id);
-          manager.dropHost(host.id);
+          void (async () => {
+            await manager.unregisterPush(host.id);
+            manager.dropHost(host.id);
+          })();
           const next = await removeHost(host.id);
           // No desktops left: tear down push registration entirely so any desktop
           // that was offline at removal self-cleans via DeviceNotRegistered on its
           // next push, instead of waiting out the token TTL.
-          if (next.length === 0) await unregisterFromPushAsync();
+          if (next.length === 0) void unregisterFromPushAsync();
           setHosts(next);
           setSnapshots((current) => {
             const copy = { ...current };
@@ -1007,19 +1009,21 @@ function LegacyHomeScreen() {
         text: i18n.t('common.remove'),
         style: 'destructive',
         onPress: async () => {
-          // Tell the desktop to forget our push token (while still connected) so
-          // it stops sending background notifications, then drop the live
-          // connection: removing only from storage leaves the client-manager entry
-          // alive, so it keeps the socket open (and keeps reconnecting + presenting
-          // notifications) for a desktop the user just removed. dropHost closes the
+          // Tear down push + connection in the background so the row disappears
+          // instantly: removing only from storage would leave the client-manager
+          // entry alive (socket open, still reconnecting + notifying), but
+          // unregisterPush can wait up to 4s for a socket when the desktop is
+          // offline, so we don't await it on the UI path. dropHost then closes the
           // socket and tears down the listener.
-          await manager.unregisterPush(host.id);
-          manager.dropHost(host.id);
+          void (async () => {
+            await manager.unregisterPush(host.id);
+            manager.dropHost(host.id);
+          })();
           const next = await removeHost(host.id);
           // No desktops left: tear down push registration entirely so any desktop
           // that was offline at removal self-cleans via DeviceNotRegistered on its
           // next push, instead of waiting out the token TTL.
-          if (next.length === 0) await unregisterFromPushAsync();
+          if (next.length === 0) void unregisterFromPushAsync();
           setHosts(next);
           setSnapshots((current) => {
             const copy = { ...current };

--- a/mobile-app/src/app/index.tsx
+++ b/mobile-app/src/app/index.tsx
@@ -28,12 +28,13 @@ import Animated, {
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
 import i18n from '@/i18n';
+import { unregisterFromPushAsync } from '@/notifications/mobile-notifications';
 import { getNotificationNavigationPath } from '@/notifications/notification-routing';
 import { useClientManager } from '@/transport/client-manager';
 import { classifyConnection, isErrorVerdict, type ConnectionVerdict } from '@/transport/connection-health';
 import { loadHosts, removeHost, saveHosts, upsertHost } from '@/transport/host-store';
 import { type BonjourHost, matchesDiscoveredHost, mergeDiscoveredEndpoint, startBonjourBrowser } from '@/transport/bonjour';
-import { createHostFromOffer, parsePairingPayload } from '@/transport/rpc-client';
+import { createHostFromOffer, parsePairingPayload, type BraidRpcClient } from '@/transport/rpc-client';
 import type { BraidStatus, BraidTerminal, PairedHost, ProviderRateLimits, RateLimitState } from '@/transport/types';
 import { AgentIcon } from '@/terminal/AgentIcon';
 import { RateLimitSection } from '@/usage/RateLimitSection';
@@ -52,6 +53,23 @@ interface HostSnapshot {
   terminals: BraidTerminal[];
   agentTimeMs: number;
   rateLimits?: RateLimitState | null;
+}
+
+// Fetch a host's Claude/Codex usage. `fresh` (user-initiated pull-to-refresh or
+// the refresh button) asks the desktop to re-poll the providers via
+// `rateLimits.refresh` so the numbers actually move; otherwise we take the cheap
+// cached `rateLimits.get` (used by initial load and activity-driven refreshes, so
+// a terminal event doesn't re-poll the CLIs every time). Both paths are
+// best-effort: a desktop too old to expose either RPC (or a transient failure)
+// returns undefined, and the caller keeps the last known value. On a forced
+// refresh we fall back to `.get` so an old desktop without `.refresh` still shows
+// cached usage instead of nothing - so this needs no protocol bump or capability.
+async function fetchUsage(client: BraidRpcClient, fresh: boolean): Promise<RateLimitState | undefined> {
+  if (fresh) {
+    const refreshed = await client.request<RateLimitState>('rateLimits.refresh').catch(() => undefined);
+    if (refreshed) return refreshed;
+  }
+  return client.request<RateLimitState>('rateLimits.get').catch(() => undefined);
 }
 
 /** An agent that needs the user: waiting for input, or just finished. */
@@ -104,7 +122,7 @@ function FreshHomeScreen() {
 
   useEffect(() => manager.subscribe(bump), [manager]);
 
-  const refreshHost = useCallback(async (host: PairedHost) => {
+  const refreshHost = useCallback(async (host: PairedHost, opts?: { freshUsage?: boolean }) => {
     setSnapshots((current) => ({
       ...current,
       [host.id]: {
@@ -121,7 +139,7 @@ function FreshHomeScreen() {
       const status = await client.request<BraidStatus>('status.get');
       const terminals = await client.request<BraidTerminal[]>('terminal.list');
       const agentTimeMs = terminals.reduce((sum, terminal) => sum + (terminal.totalRunDurationMs ?? 0), 0);
-      const rateLimits = await client.request<RateLimitState>('rateLimits.get').catch(() => undefined);
+      const rateLimits = await fetchUsage(client, opts?.freshUsage === true);
       const saved = await upsertHost(host);
       setHosts(saved);
       setSnapshots((current) => ({
@@ -150,8 +168,8 @@ function FreshHomeScreen() {
     }
   }, [manager]);
 
-  const refreshAll = useCallback((items: PairedHost[]) => {
-    for (const host of items) void refreshHost(host);
+  const refreshAll = useCallback((items: PairedHost[], opts?: { freshUsage?: boolean }) => {
+    for (const host of items) void refreshHost(host, opts);
   }, [refreshHost]);
 
   useEffect(() => {
@@ -176,7 +194,7 @@ function FreshHomeScreen() {
   const onPullRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
-      await Promise.all(hosts.map((host) => refreshHost(host)));
+      await Promise.all(hosts.map((host) => refreshHost(host, { freshUsage: true })));
     } finally {
       setRefreshing(false);
     }
@@ -350,7 +368,19 @@ function FreshHomeScreen() {
         text: i18n.t('common.remove'),
         style: 'destructive',
         onPress: async () => {
+          // Tell the desktop to forget our push token (while still connected) so
+          // it stops sending background notifications, then drop the live
+          // connection: removing only from storage leaves the client-manager entry
+          // alive, so it keeps the socket open (and keeps reconnecting + presenting
+          // notifications) for a desktop the user just removed. dropHost closes the
+          // socket and tears down the listener.
+          await manager.unregisterPush(host.id);
+          manager.dropHost(host.id);
           const next = await removeHost(host.id);
+          // No desktops left: tear down push registration entirely so any desktop
+          // that was offline at removal self-cleans via DeviceNotRegistered on its
+          // next push, instead of waiting out the token TTL.
+          if (next.length === 0) await unregisterFromPushAsync();
           setHosts(next);
           setSnapshots((current) => {
             const copy = { ...current };
@@ -360,7 +390,7 @@ function FreshHomeScreen() {
         },
       },
     ]);
-  }, []);
+  }, [manager]);
 
   const statusLine = counts.needInput > 0
     ? t('home.statusNeedInput', { count: counts.needInput })
@@ -394,7 +424,7 @@ function FreshHomeScreen() {
           </View>
           <View style={styles.topActions}>
             <IconButton icon={<QrCode color={COLORS.text} size={19} />} onPress={() => void openScanner()} accessibilityLabel={t('home.pairDesktop')} variant="panel" size="sm" />
-            <IconButton icon={<RefreshCw color={COLORS.text} size={19} />} onPress={() => refreshAll(hosts)} accessibilityLabel={t('common.refresh')} variant="panel" size="sm" />
+            <IconButton icon={<RefreshCw color={COLORS.text} size={19} />} onPress={() => refreshAll(hosts, { freshUsage: true })} accessibilityLabel={t('common.refresh')} variant="panel" size="sm" />
             <IconButton icon={<Settings color={COLORS.text} size={19} />} onPress={() => router.push('/settings' as Parameters<typeof router.push>[0])} accessibilityLabel={t('home.settings')} variant="panel" size="sm" />
           </View>
         </View>
@@ -796,7 +826,7 @@ function LegacyHomeScreen() {
   // pull-to-refresh.
   useEffect(() => manager.subscribe(bump), [manager]);
 
-  const refreshHost = useCallback(async (host: PairedHost) => {
+  const refreshHost = useCallback(async (host: PairedHost, opts?: { freshUsage?: boolean }) => {
     setSnapshots((current) => ({
       ...current,
       [host.id]: {
@@ -818,7 +848,7 @@ function LegacyHomeScreen() {
       const agentTimeMs = terminals.reduce((sum, terminal) => sum + (terminal.totalRunDurationMs ?? 0), 0);
       // Best-effort: older desktops won't expose rateLimits.get, so a failure
       // here must not knock the host offline - fall back to the last value.
-      const rateLimits = await client.request<RateLimitState>('rateLimits.get').catch(() => undefined);
+      const rateLimits = await fetchUsage(client, opts?.freshUsage === true);
       const saved = await upsertHost(host);
       setHosts(saved);
       setSnapshots((current) => ({
@@ -847,8 +877,8 @@ function LegacyHomeScreen() {
     }
   }, [manager]);
 
-  const refreshAll = useCallback((items: PairedHost[]) => {
-    for (const host of items) void refreshHost(host);
+  const refreshAll = useCallback((items: PairedHost[], opts?: { freshUsage?: boolean }) => {
+    for (const host of items) void refreshHost(host, opts);
   }, [refreshHost]);
 
   // Pull-to-refresh: awaits every host so the spinner stays until the slowest
@@ -856,7 +886,7 @@ function LegacyHomeScreen() {
   const onPullRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
-      await Promise.all(hosts.map((host) => refreshHost(host)));
+      await Promise.all(hosts.map((host) => refreshHost(host, { freshUsage: true })));
     } finally {
       setRefreshing(false);
     }
@@ -977,7 +1007,19 @@ function LegacyHomeScreen() {
         text: i18n.t('common.remove'),
         style: 'destructive',
         onPress: async () => {
+          // Tell the desktop to forget our push token (while still connected) so
+          // it stops sending background notifications, then drop the live
+          // connection: removing only from storage leaves the client-manager entry
+          // alive, so it keeps the socket open (and keeps reconnecting + presenting
+          // notifications) for a desktop the user just removed. dropHost closes the
+          // socket and tears down the listener.
+          await manager.unregisterPush(host.id);
+          manager.dropHost(host.id);
           const next = await removeHost(host.id);
+          // No desktops left: tear down push registration entirely so any desktop
+          // that was offline at removal self-cleans via DeviceNotRegistered on its
+          // next push, instead of waiting out the token TTL.
+          if (next.length === 0) await unregisterFromPushAsync();
           setHosts(next);
           setSnapshots((current) => {
             const copy = { ...current };
@@ -987,7 +1029,7 @@ function LegacyHomeScreen() {
         },
       },
     ]);
-  }, []);
+  }, [manager]);
 
   const sortedSnapshots = useMemo(
     () => hosts.map((host) => snapshots[host.id] ?? { host, state: 'idle' as const, terminals: [], agentTimeMs: 0 }),
@@ -1146,7 +1188,7 @@ function LegacyHomeScreen() {
             <Pressable style={styles.iconButton} onPress={() => router.push('/settings' as Parameters<typeof router.push>[0])} accessibilityLabel={t('home.settings')}>
               <Settings color={COLORS.muted} size={18} />
             </Pressable>
-            <Pressable style={styles.iconButton} onPress={() => refreshAll(hosts)} accessibilityLabel={t('common.refresh')}>
+            <Pressable style={styles.iconButton} onPress={() => refreshAll(hosts, { freshUsage: true })} accessibilityLabel={t('common.refresh')}>
               <RefreshCw color={COLORS.muted} size={18} />
             </Pressable>
           </View>

--- a/mobile-app/src/app/notifications.tsx
+++ b/mobile-app/src/app/notifications.tsx
@@ -7,19 +7,24 @@ import {
   ensureNotificationPermissions,
   getNotificationPermissionState,
   loadPushNotificationsEnabled,
+  loadRemotePushEnabled,
   savePushNotificationsEnabled,
+  saveRemotePushEnabled,
   type NotificationPermissionState,
 } from '@/notifications/mobile-notifications';
+import { useClientManager } from '@/transport/client-manager';
 import { useShared, useTheme, useThemedStyles, type Palette } from '@/ui/theme';
 import { Button, Card, Screen, ScreenHeader } from '@/ui/kit';
 
 interface State {
   pushEnabled: boolean;
+  remotePushEnabled: boolean;
   permission: NotificationPermissionState;
 }
 
 const INITIAL: State = {
   pushEnabled: false,
+  remotePushEnabled: true,
   permission: { granted: false, status: 'undetermined', canAskAgain: true },
 };
 
@@ -28,14 +33,16 @@ export default function NotificationsScreen() {
   const { palette: c } = useTheme();
   const shared = useShared();
   const styles = useThemedStyles(makeStyles);
+  const manager = useClientManager();
   const [state, patch] = useReducer((prev: State, next: Partial<State>) => ({ ...prev, ...next }), INITIAL);
 
   const refresh = useCallback(async () => {
-    const [pushEnabled, permission] = await Promise.all([
+    const [pushEnabled, remotePushEnabled, permission] = await Promise.all([
       loadPushNotificationsEnabled(),
+      loadRemotePushEnabled(),
       getNotificationPermissionState(),
     ]);
-    patch({ pushEnabled, permission });
+    patch({ pushEnabled, remotePushEnabled, permission });
   }, []);
 
   // Re-check on focus and when returning from the system Settings app, so the
@@ -55,6 +62,8 @@ export default function NotificationsScreen() {
       if (!granted) {
         patch({ pushEnabled: false, permission });
         await savePushNotificationsEnabled(false);
+        // Nothing was registered, but stay defensive and clear any token.
+        void manager.syncPushRegistration(false);
         return;
       }
       patch({ pushEnabled: true, permission });
@@ -62,6 +71,18 @@ export default function NotificationsScreen() {
       patch({ pushEnabled: false });
     }
     await savePushNotificationsEnabled(value);
+    // Push the change to connected desktops: register the token only when the
+    // master AND the background sub-toggle are on; otherwise have every desktop
+    // forget it (remote pushes show via the OS regardless of in-app state, so
+    // disabling must reach the desktop).
+    void manager.syncPushRegistration(value && state.remotePushEnabled);
+  };
+
+  const toggleRemotePush = async (value: boolean) => {
+    patch({ remotePushEnabled: value });
+    await saveRemotePushEnabled(value);
+    // Only register when the master is also on and permission is granted.
+    void manager.syncPushRegistration(value && state.pushEnabled && state.permission.granted);
   };
 
   const blocked = state.permission.status === 'denied';
@@ -90,6 +111,20 @@ export default function NotificationsScreen() {
           {blocked && (
             <Button label={t('notifications.openSettings')} variant="secondary" onPress={() => void Linking.openSettings()} />
           )}
+        </Card>
+
+        <Card style={styles.card}>
+          <View style={styles.row}>
+            <Text style={styles.rowLabel}>{t('notifications.backgroundLabel')}</Text>
+            <Switch
+              value={switchOn && state.remotePushEnabled}
+              disabled={!switchOn}
+              onValueChange={(v) => void toggleRemotePush(v)}
+              trackColor={{ false: c.panelStrong, true: c.accent }}
+              thumbColor={c.text}
+            />
+          </View>
+          <Text style={shared.muted}>{t('notifications.backgroundHint')}</Text>
         </Card>
       </View>
     </Screen>

--- a/mobile-app/src/app/terminal/[hostId].tsx
+++ b/mobile-app/src/app/terminal/[hostId].tsx
@@ -1,5 +1,5 @@
 import { router, useLocalSearchParams } from 'expo-router';
-import { Check, ChevronsRight, Command, GitBranch, Keyboard as KeyboardIcon, Monitor, Pencil, Plus, RefreshCw, Send, Smartphone, TerminalSquare, Trash2, X } from 'lucide-react-native';
+import { Check, ChevronsRight, Command, GitBranch, Keyboard as KeyboardIcon, Monitor, MoreHorizontal, Pencil, Plus, RefreshCw, Send, Smartphone, TerminalSquare, Trash2, X } from 'lucide-react-native';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Alert, KeyboardAvoidingView, Modal, Platform, Pressable, ScrollView, Text, TextInput, View } from 'react-native';
@@ -14,9 +14,12 @@ import {
   isTerminalLiveInputWithinByteLimit,
   scheduleTerminalLiveInputFocus,
 } from '@/terminal/terminal-live-input';
-import { AGENT_CATALOG, getAgentEntry } from '@/terminal/agentCatalog';
+import { AGENT_CATALOG, SHELL_AGENT_ID, getAgentEntry } from '@/terminal/agentCatalog';
 import { AgentIcon } from '@/terminal/AgentIcon';
 import { useDetectedAgents } from '@/terminal/useDetectedAgents';
+import { useHostStatus } from '@/terminal/useHostStatus';
+import { desktopSupports } from '@/transport/protocol-compat';
+import { MOBILE_CAPABILITY } from '@/transport/protocol-version';
 import type { BraidProject, BraidTerminal, BraidWorktree } from '@/transport/types';
 import { HeaderBackButton } from '@/ui/kit';
 import { useShared, useTheme } from '@/ui/theme';
@@ -70,6 +73,11 @@ export default function TerminalScreen() {
   const shared = useShared();
   const terminalRef = useRef<TerminalWebViewHandle>(null);
   const detectedAgents = useDetectedAgents(client);
+  const hostStatus = useHostStatus(client);
+  // Bare shell tabs are only offered when the paired desktop advertises the
+  // capability. Older desktops would silently launch Claude for an unknown
+  // agentId, so we hide the option instead of degrading to that surprise.
+  const bareTerminalSupported = desktopSupports(hostStatus, MOBILE_CAPABILITY.bareTerminal);
   const [projects, setProjects] = useState<BraidProject[]>([]);
   const [projectId, setProjectId] = useState<string | null>(null);
   const [worktree, setWorktree] = useState<BraidWorktree | null>(null);
@@ -81,6 +89,7 @@ export default function TerminalScreen() {
   const [selectorsExpanded, setSelectorsExpanded] = useState(true);
   const [creatingTerminal, setCreatingTerminal] = useState(false);
   const [agentPickerOpen, setAgentPickerOpen] = useState(false);
+  const [terminalMoreOpen, setTerminalMoreOpen] = useState(false);
   const [selectedAgentId, setSelectedAgentId] = useState<string>(AGENT_CATALOG[0]?.id ?? 'claude');
   // Terminal being renamed (null when the rename modal is closed) + its draft.
   const [renameTarget, setRenameTarget] = useState<{ terminal: BraidTerminal; draft: string } | null>(null);
@@ -379,19 +388,26 @@ export default function TerminalScreen() {
     // state to catch up.
     const wt = targetWorktree ?? worktree;
     if (!client || !wt || creatingTerminal) return;
-    const agent = getAgentEntry(agentId ?? selectedAgentId) ?? selectedAgent ?? AGENT_CATALOG[0];
+    // A bare shell tab: no agent, no launch command. The desktop (when it
+    // advertises terminal.bare.v1) spawns the PTY and writes nothing.
+    const isBare = (agentId ?? selectedAgentId) === SHELL_AGENT_ID;
+    const agent = isBare ? undefined : getAgentEntry(agentId ?? selectedAgentId) ?? selectedAgent ?? AGENT_CATALOG[0];
     setCreatingTerminal(true);
     setError(null);
     try {
       const created = await client.request<BraidTerminal & { ptyId?: string }>('terminal.create', {
         worktreePath: wt.path,
         worktreeId: wt.id,
-        label: agent?.label ?? t('terminal.defaultLabel'),
-        command: agent?.launchCmd ?? agent?.detectCmd ?? 'claude',
-        agentId: agent?.id ?? 'claude',
+        label: isBare ? t('terminal.shellLabel') : agent?.label ?? t('terminal.defaultLabel'),
+        // Bare terminals omit the command so the desktop leaves a plain prompt.
+        command: isBare ? '' : agent?.launchCmd ?? agent?.detectCmd ?? 'claude',
+        agentId: isBare ? SHELL_AGENT_ID : agent?.id ?? 'claude',
       });
-      setSelectedAgentId(agent?.id ?? 'claude');
-      void SecureStore.setItemAsync(DEFAULT_AGENT_STORAGE_KEY, agent?.id ?? 'claude').catch(() => undefined);
+      // Don't persist 'shell' as the default agent - keep the last real agent.
+      if (!isBare) {
+        setSelectedAgentId(agent?.id ?? 'claude');
+        void SecureStore.setItemAsync(DEFAULT_AGENT_STORAGE_KEY, agent?.id ?? 'claude').catch(() => undefined);
+      }
       const terminal = {
         ...created,
         id: created.id ?? created.ptyId ?? '',
@@ -693,6 +709,10 @@ export default function TerminalScreen() {
     await client.request('terminal.write', { ptyId: active.id, data });
   };
 
+  const writeKey = (data: string) => {
+    void writeBytes(data);
+  };
+
   // The terminal WebView emits the selected text when the user taps "Copy" in
   // the selection menu; push it to the system clipboard so it can be pasted
   // into other apps. Without this handler the extracted text goes nowhere.
@@ -734,6 +754,17 @@ export default function TerminalScreen() {
       return;
     }
     client.request('terminal.write', { ptyId: active.id, data: bytes }).catch(() => undefined);
+  };
+
+  const pasteClipboardToTerminal = async () => {
+    if (!canSend) return;
+    const text = await Clipboard.getStringAsync().catch(() => '');
+    if (!text) return;
+    if (!isTerminalLiveInputWithinByteLimit(text)) {
+      setError(t('terminal.errorInputTooLarge'));
+      return;
+    }
+    await writeBytes(text);
   };
 
   const focusLiveInput = () => {
@@ -786,6 +817,8 @@ export default function TerminalScreen() {
   };
 
   const desktopMode = !!active && desktopModeHandles.has(active.id);
+  const modeLabel = liveInputEnabled ? t('terminal.modeLive') : t('terminal.modeCommand');
+  const displayModeLabel = desktopMode ? t('terminal.displayDesktop') : t('terminal.displayPhone');
 
   // Toggle between phone-fit (the desktop yields, PTY sized to this phone) and
   // desktop size (the desktop drives its native dims, we scale to fit).
@@ -855,9 +888,9 @@ export default function TerminalScreen() {
   };
 
   const liveToggleButton = {
-    width: 36,
-    height: 30,
-    marginHorizontal: 6,
+    width: 40,
+    height: 38,
+    marginRight: 8,
     borderRadius: 8,
     alignItems: 'center' as const,
     justifyContent: 'center' as const,
@@ -1268,6 +1301,30 @@ export default function TerminalScreen() {
                 </Pressable>
               </View>
               <ScrollView style={pickerList} contentContainerStyle={pickerListContent}>
+                {bareTerminalSupported && (
+                  <View style={{ gap: 8 }}>
+                    <Text style={pickerSectionLabel}>{t('terminal.plainShell')}</Text>
+                    <Pressable
+                      style={({ pressed }) => [pickerRow, pressed && pickerRowPressed]}
+                      onPress={() => {
+                        setAgentPickerOpen(false);
+                        void createTerminal(SHELL_AGENT_ID);
+                      }}
+                    >
+                      <View style={pickerRowIcon}>
+                        <TerminalSquare color={colors.text} size={20} />
+                      </View>
+                      <View style={{ flex: 1, minWidth: 0 }}>
+                        <Text style={pickerRowTitle} numberOfLines={1}>
+                          {t('terminal.shellLabel')}
+                        </Text>
+                        <Text style={pickerRowSubtitle} numberOfLines={1}>
+                          {t('terminal.shellSubtitle')}
+                        </Text>
+                      </View>
+                    </Pressable>
+                  </View>
+                )}
                 {detectedSorted.length > 0 && (
                   <View style={{ gap: 8 }}>
                     <Text style={pickerSectionLabel}>{t('terminal.detectedOnHost')}</Text>
@@ -1342,6 +1399,54 @@ export default function TerminalScreen() {
           </Pressable>
         </Modal>
 
+        <Modal visible={terminalMoreOpen} transparent animationType="fade" onRequestClose={() => setTerminalMoreOpen(false)}>
+          <Pressable style={pickerBackdrop} onPress={() => setTerminalMoreOpen(false)}>
+            <Pressable style={pickerPanel} onPress={() => undefined}>
+              <View style={pickerHeader}>
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Text style={pickerTitle}>{t('terminal.moreKeys')}</Text>
+                  <Text style={pickerSubtitle} numberOfLines={1}>{active ? terminalLabel(active) : t('terminal.selectWorktree')}</Text>
+                </View>
+                <Pressable style={pickerCloseButton} onPress={() => setTerminalMoreOpen(false)} accessibilityLabel={t('common.close')}>
+                  <X color={colors.text} size={18} />
+                </Pressable>
+              </View>
+              <View style={{ padding: 12, gap: 10 }}>
+                <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+                  <Key label="Ctrl+D" disabled={!canSend} onPress={() => { setTerminalMoreOpen(false); writeKey('\x04'); }} />
+                  <Key label="Ctrl+Z" disabled={!canSend} onPress={() => { setTerminalMoreOpen(false); writeKey('\x1a'); }} />
+                  <Key label="Ctrl+R" disabled={!canSend} onPress={() => { setTerminalMoreOpen(false); writeKey('\x12'); }} />
+                  <Key label="←" disabled={!canSend} onPress={() => { setTerminalMoreOpen(false); writeKey('\x1b[D'); }} />
+                  <Key label="→" disabled={!canSend} onPress={() => { setTerminalMoreOpen(false); writeKey('\x1b[C'); }} />
+                </View>
+                <Pressable
+                  style={({ pressed }) => [actionRow, pressed && { backgroundColor: colors.panelStrong }, !canSend && { opacity: 0.35 }]}
+                  disabled={!canSend}
+                  onPress={() => {
+                    setTerminalMoreOpen(false);
+                    void toggleDisplayMode();
+                  }}
+                >
+                  {desktopMode ? <Smartphone color={colors.text} size={18} /> : <Monitor color={colors.text} size={18} />}
+                  <Text style={{ color: colors.text, fontSize: 15, fontWeight: '600' }}>
+                    {desktopMode ? t('terminal.switchToPhoneSize') : t('terminal.switchToDesktopSize')}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  style={({ pressed }) => [actionRow, pressed && { backgroundColor: colors.panelStrong }, !canSend && { opacity: 0.35 }]}
+                  disabled={!canSend}
+                  onPress={() => {
+                    setTerminalMoreOpen(false);
+                    void pasteClipboardToTerminal();
+                  }}
+                >
+                  <Text style={{ color: colors.text, fontSize: 15, fontWeight: '600' }}>{t('terminal.paste')}</Text>
+                </Pressable>
+              </View>
+            </Pressable>
+          </Pressable>
+        </Modal>
+
         <View
           style={{ flex: 1, minHeight: 0, position: 'relative', overflow: 'hidden' }}
           onLayout={(event) => {
@@ -1369,23 +1474,21 @@ export default function TerminalScreen() {
           />
         </View>
 
-        <View style={{ flexDirection: 'row', alignItems: 'center', height: 43, borderTopWidth: 1, borderTopColor: colors.border, backgroundColor: colors.panel }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', minHeight: 52, borderTopWidth: 1, borderTopColor: colors.border, backgroundColor: colors.panel }}>
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
-            style={{ flex: 1, height: 43, maxHeight: 43 }}
-            contentContainerStyle={{ height: 42, alignItems: 'center', gap: 6, paddingHorizontal: 10 }}
+            style={{ flex: 1, minHeight: 52, maxHeight: 52 }}
+            contentContainerStyle={{ minHeight: 52, alignItems: 'center', gap: 5, paddingLeft: 8, paddingRight: 6 }}
           >
-            <Key label="Esc" disabled={!canSend} onPress={() => void writeBytes('\x1b')} />
-            <Key label="Tab" disabled={!canSend} onPress={() => void writeBytes('\t')} />
-            <Key label="Ctrl+C" disabled={!canSend} onPress={() => void writeBytes('\x03')} />
-            <Key label="Ctrl+D" disabled={!canSend} onPress={() => void writeBytes('\x04')} />
-            <Key label="↑" disabled={!canSend} onPress={() => void writeBytes('\x1b[A')} />
-            <Key label="↓" disabled={!canSend} onPress={() => void writeBytes('\x1b[B')} />
-            <Key label="←" disabled={!canSend} onPress={() => void writeBytes('\x1b[D')} />
-            <Key label="→" disabled={!canSend} onPress={() => void writeBytes('\x1b[C')} />
+            <Key label="Esc" disabled={!canSend} onPress={() => writeKey('\x1b')} />
+            <Key label="Tab" disabled={!canSend} onPress={() => writeKey('\t')} />
+            <Key label="Ctrl+C" emphasized disabled={!canSend} onPress={() => writeKey('\x03')} />
+            <Key label="↑" disabled={!canSend} onPress={() => writeKey('\x1b[A')} />
+            <Key label="↓" disabled={!canSend} onPress={() => writeKey('\x1b[B')} />
           </ScrollView>
           <Pressable
+            hitSlop={{ top: 4, bottom: 4, left: 2, right: 2 }}
             style={[liveToggleButton, desktopMode && liveToggleButtonActive, !canSend && { opacity: 0.35 }]}
             disabled={!canSend}
             onPress={() => void toggleDisplayMode()}
@@ -1398,6 +1501,16 @@ export default function TerminalScreen() {
             )}
           </Pressable>
           <Pressable
+            hitSlop={{ top: 4, bottom: 4, left: 2, right: 2 }}
+            disabled={!canSend}
+            style={{ width: 40, height: 38, marginRight: 6, borderRadius: 8, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.panelStrong, opacity: canSend ? 1 : 0.35 }}
+            onPress={() => setTerminalMoreOpen(true)}
+            accessibilityLabel={t('terminal.moreKeys')}
+          >
+            <MoreHorizontal color={colors.muted} size={18} />
+          </Pressable>
+          <Pressable
+            hitSlop={{ top: 4, bottom: 4, left: 2, right: 8 }}
             style={[liveToggleButton, liveInputEnabled && liveToggleButtonActive, !canSend && { opacity: 0.35 }]}
             disabled={!canSend}
             onPress={toggleLiveInput}
@@ -1409,14 +1522,19 @@ export default function TerminalScreen() {
 
         {liveInputEnabled ? (
           <Pressable
-            style={{ flexDirection: 'row', alignItems: 'center', minHeight: 46, gap: 8, paddingHorizontal: 12, paddingVertical: 6, borderTopWidth: 1, borderTopColor: colors.border, backgroundColor: colors.panel }}
+            style={{ flexDirection: 'row', alignItems: 'center', minHeight: 48, gap: 8, paddingHorizontal: 12, paddingVertical: 6, borderTopWidth: 1, borderTopColor: colors.border, backgroundColor: colors.panel }}
             onPress={focusLiveInput}
             disabled={!canSend}
             accessibilityLabel={t('terminal.focusLiveInput')}
           >
-            <KeyboardIcon color={colors.muted} size={16} />
+            <View style={{ minHeight: 36, borderRadius: 8, flexDirection: 'row', alignItems: 'center', gap: 7, paddingHorizontal: 10, backgroundColor: colors.panelStrong }}>
+              <KeyboardIcon color={colors.accent} size={15} />
+              <Text style={{ color: colors.text, fontSize: 12, fontWeight: '800' }}>
+                {modeLabel}
+              </Text>
+            </View>
             <Text style={{ flex: 1, color: colors.muted, fontSize: 12, fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace', default: 'monospace' }) }} numberOfLines={1}>
-              {t('terminal.liveInputHint')}
+              {displayModeLabel}
             </Text>
             <TextInput
               ref={liveInputRef}
@@ -1438,9 +1556,9 @@ export default function TerminalScreen() {
             />
           </Pressable>
         ) : (
-          <View style={{ flexDirection: 'row', alignItems: 'center', minHeight: 46, gap: 8, paddingHorizontal: 12, paddingVertical: 6, borderTopWidth: 1, borderTopColor: colors.border, backgroundColor: colors.panel }}>
-            <TextInput value={input} onChangeText={setInput} placeholder={inputPlaceholder} placeholderTextColor={colors.subtle} autoCapitalize="none" autoCorrect={false} style={[shared.input, { flex: 1, minHeight: 34, height: 34, paddingVertical: 0, borderRadius: 8, backgroundColor: colors.panelStrong, fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace', default: 'monospace' }) }]} onSubmitEditing={submit} editable={canSend} />
-            <Pressable style={{ width: 34, height: 34, borderRadius: 17, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.panelStrong, opacity: canSend ? 1 : 0.35 }} onPress={submit} disabled={!canSend}><Send color={colors.text} size={17} /></Pressable>
+          <View style={{ flexDirection: 'row', alignItems: 'center', minHeight: 48, gap: 8, paddingHorizontal: 12, paddingVertical: 6, borderTopWidth: 1, borderTopColor: colors.border, backgroundColor: colors.panel }}>
+            <TextInput value={input} onChangeText={setInput} placeholder={inputPlaceholder} placeholderTextColor={colors.subtle} autoCapitalize="none" autoCorrect={false} style={[shared.input, { flex: 1, minHeight: 38, height: 38, paddingVertical: 0, borderRadius: 8, backgroundColor: colors.panelStrong, fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace', default: 'monospace' }) }]} onSubmitEditing={submit} editable={canSend} />
+            <Pressable hitSlop={{ top: 4, bottom: 4, left: 2, right: 2 }} style={{ width: 42, height: 38, borderRadius: 8, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.panelStrong, opacity: canSend ? 1 : 0.35 }} onPress={submit} disabled={!canSend}><Send color={colors.text} size={17} /></Pressable>
           </View>
         )}
       </KeyboardAvoidingView>
@@ -1448,12 +1566,30 @@ export default function TerminalScreen() {
   );
 }
 
-function Key({ label, onPress, disabled = false }: { label: string; onPress: () => void; disabled?: boolean }) {
+function Key({ label, onPress, disabled = false, emphasized = false }: { label: string; onPress: () => void; disabled?: boolean; emphasized?: boolean }) {
   const colors = useTheme().palette;
   return (
-    <Pressable disabled={disabled} style={{ minWidth: 36, height: 30, borderRadius: 8, alignItems: 'center', justifyContent: 'center', flexDirection: 'row', gap: 5, paddingHorizontal: 10, backgroundColor: colors.panelStrong, opacity: disabled ? 0.35 : 1 }} onPress={onPress}>
-      {label === 'Ctrl+C' ? <Command color={colors.muted} size={12} /> : null}
-      <Text style={{ color: colors.muted, fontSize: 12, fontWeight: '700', fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace', default: 'monospace' }) }}>{label}</Text>
+    <Pressable
+      hitSlop={{ top: 4, bottom: 4, left: 2, right: 2 }}
+      disabled={disabled}
+      style={({ pressed }) => ({
+        minWidth: emphasized ? 68 : 40,
+        height: 38,
+        borderRadius: 8,
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'row',
+        gap: 4,
+        paddingHorizontal: 8,
+        backgroundColor: emphasized ? colors.danger : pressed ? colors.panelStrong : colors.bg,
+        borderWidth: emphasized ? 0 : 1,
+        borderColor: colors.border,
+        opacity: disabled ? 0.35 : 1,
+      })}
+      onPress={onPress}
+    >
+      {label === 'Ctrl+C' ? <Command color={emphasized ? colors.bg : colors.subtle} size={12} /> : null}
+      <Text style={{ color: emphasized ? colors.bg : colors.subtle, fontSize: 12, fontWeight: '800', fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace', default: 'monospace' }) }}>{label}</Text>
     </Pressable>
   );
 }

--- a/mobile-app/src/i18n/locales/en.json
+++ b/mobile-app/src/i18n/locales/en.json
@@ -113,7 +113,9 @@
     "pushLabel": "Push notifications",
     "hint": "Get a notification when an agent task finishes, needs input, or errors on your desktop.",
     "hintBlocked": "Notifications are turned off in system settings. Open Settings to allow them.",
-    "openSettings": "Open Settings"
+    "openSettings": "Open Settings",
+    "backgroundLabel": "Background notifications",
+    "backgroundHint": "Also receive alerts when the app is closed. These are delivered via Apple/Google push services and aren't end-to-end encrypted, unlike alerts shown while the app is open."
   },
   "troubleshoot": {
     "title": "Troubleshooting",
@@ -276,12 +278,21 @@
     "detectedOnHost": "Detected on this host",
     "otherAgents": "Other agents",
     "allAgents": "All agents",
+    "plainShell": "Plain shell",
+    "shellLabel": "Terminal",
+    "shellSubtitle": "Bare shell, no agent",
     "switchToPhoneSize": "Switch to phone size",
     "switchToDesktopSize": "Switch to desktop size",
     "switchToBufferedInput": "Switch to buffered command input",
     "switchToLiveInput": "Switch to live terminal input",
     "focusLiveInput": "Focus live terminal input",
-    "liveInputHint": "Keyboard input goes directly to terminal"
+    "liveInputHint": "Keyboard input goes directly to terminal",
+    "moreKeys": "More keys",
+    "paste": "Paste",
+    "modeCommand": "Command",
+    "modeLive": "Live",
+    "displayPhone": "Phone fit",
+    "displayDesktop": "Desktop size"
   },
   "sourceControl": {
     "title": "Source Control",

--- a/mobile-app/src/i18n/locales/id.json
+++ b/mobile-app/src/i18n/locales/id.json
@@ -113,7 +113,9 @@
     "pushLabel": "Notifikasi push",
     "hint": "Dapatkan notifikasi saat tugas agen selesai, memerlukan masukan, atau mengalami error di desktop Anda.",
     "hintBlocked": "Notifikasi dimatikan di pengaturan sistem. Buka Pengaturan untuk mengizinkannya.",
-    "openSettings": "Buka Pengaturan"
+    "openSettings": "Buka Pengaturan",
+    "backgroundLabel": "Notifikasi latar belakang",
+    "backgroundHint": "Terima juga peringatan saat aplikasi tertutup. Ini dikirim melalui layanan push Apple/Google dan tidak dienkripsi end-to-end, berbeda dengan peringatan yang muncul saat aplikasi terbuka."
   },
   "troubleshoot": {
     "title": "Pemecahan Masalah",
@@ -276,12 +278,21 @@
     "detectedOnHost": "Terdeteksi di host ini",
     "otherAgents": "Agen lainnya",
     "allAgents": "Semua agen",
+    "plainShell": "Shell biasa",
+    "shellLabel": "Terminal",
+    "shellSubtitle": "Shell polos, tanpa agen",
     "switchToPhoneSize": "Beralih ke ukuran ponsel",
     "switchToDesktopSize": "Beralih ke ukuran desktop",
     "switchToBufferedInput": "Beralih ke input perintah buffer",
     "switchToLiveInput": "Beralih ke input terminal langsung",
     "focusLiveInput": "Fokuskan input terminal langsung",
-    "liveInputHint": "Input keyboard langsung ke terminal"
+    "liveInputHint": "Input keyboard langsung ke terminal",
+    "moreKeys": "Tombol lainnya",
+    "paste": "Tempel",
+    "modeCommand": "Perintah",
+    "modeLive": "Langsung",
+    "displayPhone": "Sesuaikan ponsel",
+    "displayDesktop": "Ukuran desktop"
   },
   "sourceControl": {
     "title": "Kontrol Sumber",

--- a/mobile-app/src/i18n/locales/ja.json
+++ b/mobile-app/src/i18n/locales/ja.json
@@ -106,7 +106,9 @@
     "pushLabel": "プッシュ通知",
     "hint": "デスクトップでエージェントのタスクが完了したとき、入力が必要なとき、またはエラーが発生したときに通知を受け取ります。",
     "hintBlocked": "システム設定で通知がオフになっています。許可するには設定を開いてください。",
-    "openSettings": "設定を開く"
+    "openSettings": "設定を開く",
+    "backgroundLabel": "バックグラウンド通知",
+    "backgroundHint": "アプリを閉じているときも通知を受け取ります。これらはApple/Googleのプッシュサービス経由で配信され、アプリを開いているときの通知とは異なり、エンドツーエンドで暗号化されません。"
   },
   "troubleshoot": {
     "title": "トラブルシューティング",
@@ -263,12 +265,21 @@
     "detectedOnHost": "このホストで検出",
     "otherAgents": "その他のエージェント",
     "allAgents": "すべてのエージェント",
+    "plainShell": "プレーンシェル",
+    "shellLabel": "ターミナル",
+    "shellSubtitle": "エージェントなしの素のシェル",
     "switchToPhoneSize": "スマートフォンサイズに切り替え",
     "switchToDesktopSize": "デスクトップサイズに切り替え",
     "switchToBufferedInput": "バッファ入力に切り替え",
     "switchToLiveInput": "ライブターミナル入力に切り替え",
     "focusLiveInput": "ライブターミナル入力にフォーカス",
-    "liveInputHint": "キーボード入力はターミナルに直接送られます"
+    "liveInputHint": "キーボード入力はターミナルに直接送られます",
+    "moreKeys": "その他のキー",
+    "paste": "ペースト",
+    "modeCommand": "コマンド",
+    "modeLive": "ライブ",
+    "displayPhone": "スマホに合わせる",
+    "displayDesktop": "デスクトップサイズ"
   },
   "sourceControl": {
     "title": "ソース管理",

--- a/mobile-app/src/i18n/locales/zh.json
+++ b/mobile-app/src/i18n/locales/zh.json
@@ -113,7 +113,9 @@
     "pushLabel": "推送通知",
     "hint": "当代理任务在桌面端完成、需要输入或出错时接收通知。",
     "hintBlocked": "系统设置中已关闭通知。请打开设置以允许通知。",
-    "openSettings": "打开设置"
+    "openSettings": "打开设置",
+    "backgroundLabel": "后台通知",
+    "backgroundHint": "在应用关闭时也接收提醒。这些提醒通过 Apple/Google 推送服务发送，不像应用打开时显示的提醒那样进行端到端加密。"
   },
   "troubleshoot": {
     "title": "故障排除",
@@ -276,12 +278,21 @@
     "detectedOnHost": "在此主机上检测到",
     "otherAgents": "其他智能体",
     "allAgents": "所有智能体",
+    "plainShell": "纯 Shell",
+    "shellLabel": "终端",
+    "shellSubtitle": "纯 Shell，无智能体",
     "switchToPhoneSize": "切换到手机尺寸",
     "switchToDesktopSize": "切换到桌面尺寸",
     "switchToBufferedInput": "切换到缓冲命令输入",
     "switchToLiveInput": "切换到实时终端输入",
     "focusLiveInput": "聚焦实时终端输入",
-    "liveInputHint": "键盘输入直接发送到终端"
+    "liveInputHint": "键盘输入直接发送到终端",
+    "moreKeys": "更多按键",
+    "paste": "粘贴",
+    "modeCommand": "命令",
+    "modeLive": "实时",
+    "displayPhone": "适配手机",
+    "displayDesktop": "桌面尺寸"
   },
   "sourceControl": {
     "title": "源代码管理",

--- a/mobile-app/src/notifications/mobile-notifications.ts
+++ b/mobile-app/src/notifications/mobile-notifications.ts
@@ -1,3 +1,5 @@
+import Constants from 'expo-constants';
+import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import * as SecureStore from 'expo-secure-store';
 import { Platform } from 'react-native';
@@ -6,6 +8,7 @@ import { buildLocalNotificationData, type DesktopNotificationParams } from './no
 
 const ANDROID_CHANNEL_ID = 'braid-desktop';
 const PUSH_ENABLED_KEY = 'braid.mobile.pushNotificationsEnabled';
+const REMOTE_PUSH_ENABLED_KEY = 'braid.mobile.remotePushEnabled';
 
 let channelConfigured = false;
 
@@ -34,6 +37,23 @@ export async function loadPushNotificationsEnabled(): Promise<boolean> {
 
 export async function savePushNotificationsEnabled(enabled: boolean): Promise<void> {
   await SecureStore.setItemAsync(PUSH_ENABLED_KEY, enabled ? 'true' : 'false').catch(() => undefined);
+}
+
+/**
+ * Independent sub-toggle for BACKGROUND (remote) notifications - the ones
+ * relayed via Expo/APNs/FCM that arrive when the app is closed. Distinct from the
+ * master toggle because these are NOT end-to-end encrypted (content rides
+ * third-party push infra), so a user may want in-app/foreground alerts only.
+ * When off we never register a push token, so the desktop can't reach this device
+ * while it's backgrounded. Defaults to enabled.
+ */
+export async function loadRemotePushEnabled(): Promise<boolean> {
+  const raw = await SecureStore.getItemAsync(REMOTE_PUSH_ENABLED_KEY).catch(() => null);
+  return raw === null ? true : raw === 'true';
+}
+
+export async function saveRemotePushEnabled(enabled: boolean): Promise<void> {
+  await SecureStore.setItemAsync(REMOTE_PUSH_ENABLED_KEY, enabled ? 'true' : 'false').catch(() => undefined);
 }
 
 /**
@@ -93,4 +113,54 @@ export async function scheduleDesktopNotification(
     },
     trigger: null,
   });
+}
+
+export interface PushTokenRegistration {
+  token: string;
+  platform: 'ios' | 'android';
+}
+
+/**
+ * Tear down this device's APNs/FCM registration entirely, killing the Expo push
+ * token app-wide. Call ONLY when no paired desktops remain: any desktop still
+ * holding the (now-dead) token gets a `DeviceNotRegistered` receipt on its next
+ * push and drops it immediately - which cleans up a desktop that was offline at
+ * removal time (so the per-pairing unregister couldn't reach it) without waiting
+ * for the token TTL. A later re-pair re-registers a fresh token. Best-effort.
+ */
+export async function unregisterFromPushAsync(): Promise<void> {
+  try {
+    await Notifications.unregisterForNotificationsAsync();
+  } catch {
+    // Not provisioned / never registered: nothing to tear down.
+  }
+}
+
+/**
+ * Acquire this device's Expo push token so the desktop can alert it while the
+ * app is backgrounded (the WS is closed then, so the in-app notification path
+ * can't reach it). Returns null - and the app simply stays foreground-only -
+ * when notifications are disabled/denied, on web/simulator, or when remote push
+ * isn't provisioned (Expo Go, missing APNs/FCM credentials), so the caller can
+ * treat it as best-effort. Requires a development build with push configured.
+ */
+export async function registerForPushTokenAsync(): Promise<PushTokenRegistration | null> {
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') return null;
+  if (!Device.isDevice) return null; // Push tokens aren't issued on simulators.
+  if (!(await loadPushNotificationsEnabled())) return null;
+  if (!(await loadRemotePushEnabled())) return null; // background push opted out
+  if (!(await ensureNotificationPermissions())) return null;
+  configureChannel();
+  try {
+    const projectId =
+      Constants.expoConfig?.extra?.eas?.projectId ?? Constants.easConfig?.projectId;
+    const { data } = await Notifications.getExpoPushTokenAsync(
+      projectId ? { projectId } : undefined,
+    );
+    return { token: data, platform: Platform.OS };
+  } catch {
+    // No APNs/FCM entitlement, Expo Go, or offline: background push just won't
+    // work yet. Foreground (WS) notifications are unaffected.
+    return null;
+  }
 }

--- a/mobile-app/src/notifications/notification-routing.ts
+++ b/mobile-app/src/notifications/notification-routing.ts
@@ -26,6 +26,13 @@ export interface LocalNotificationData {
 
 export interface NotificationNavigationOptions {
   knownHostIds?: ReadonlySet<string>;
+  /**
+   * Maps a desktop instance id (`serverPublicKey`) to the local paired-host id.
+   * Remote push payloads carry `desktopId` instead of `hostId` (the desktop
+   * doesn't know our local host id), so this resolves them back to a routable
+   * host. Local (WS) notifications already embed `hostId` and skip this.
+   */
+  hostIdByDesktopId?: ReadonlyMap<string, string>;
 }
 
 function readNonEmptyString(value: unknown): string | null {
@@ -54,7 +61,12 @@ export function getNotificationNavigationPath(
   if (!data || typeof data !== 'object') return null;
 
   const record = data as Record<string, unknown>;
-  const hostId = readNonEmptyString(record.hostId);
+  // Local notifications embed `hostId`; remote push embeds `desktopId` (the
+  // desktop's instance id), which we resolve to a local host id.
+  const desktopId = readNonEmptyString(record.desktopId);
+  const hostId =
+    readNonEmptyString(record.hostId) ??
+    (desktopId ? options.hostIdByDesktopId?.get(desktopId) ?? null : null);
   if (!hostId) return null;
   if (options.knownHostIds && !options.knownHostIds.has(hostId)) return null;
 

--- a/mobile-app/src/terminal/agentCatalog.ts
+++ b/mobile-app/src/terminal/agentCatalog.ts
@@ -38,6 +38,12 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
   { id: 'openclaw', label: 'OpenClaw', detectCmd: 'openclaw', launchCmd: 'openclaw', faviconDomain: 'openclaw.ai' },
 ];
 
+// Sentinel id for a bare terminal: spawn the PTY with no agent launch command,
+// leaving a plain shell prompt. Not part of AGENT_CATALOG (it isn't a detected
+// CLI); the terminal screen renders it as its own picker row and gates it on the
+// desktop's `terminal.bare.v1` capability. Mirrors SHELL_AGENT_ID on the desktop.
+export const SHELL_AGENT_ID = 'shell';
+
 export function getAgentEntry(agentId: string): AgentCatalogEntry | undefined {
   return AGENT_CATALOG.find((agent) => agent.id === agentId);
 }

--- a/mobile-app/src/terminal/useHostStatus.ts
+++ b/mobile-app/src/terminal/useHostStatus.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+import type { BraidRpcClient } from '@/transport/rpc-client';
+import type { BraidStatus } from '@/transport/types';
+
+/**
+ * Fetches the paired desktop's `status.get` once per client so a screen can gate
+ * capability-negotiated features (via `desktopSupports`). Returns null until the
+ * first response lands, or if the host is disconnected. Kept intentionally small
+ * - it does not poll; capabilities don't change within a connection.
+ */
+export function useHostStatus(client: BraidRpcClient | null): BraidStatus | null {
+  const [status, setStatus] = useState<BraidStatus | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    async function run() {
+      if (!client) {
+        if (active) setStatus(null);
+        return;
+      }
+      try {
+        const next = await client.request<BraidStatus>('status.get');
+        if (active) setStatus(next);
+      } catch {
+        if (active) setStatus(null);
+      }
+    }
+    void run();
+    return () => {
+      active = false;
+    };
+  }, [client]);
+
+  return status;
+}

--- a/mobile-app/src/transport/client-manager.tsx
+++ b/mobile-app/src/transport/client-manager.tsx
@@ -10,6 +10,7 @@ import { AppState, type AppStateStatus } from 'react-native';
 import { loadHosts } from '@/transport/host-store';
 import { BraidAuthError, BraidRpcClient } from '@/transport/rpc-client';
 import type { ConnectionLogEntry, ConnectionLogLevel, ConnectionState } from '@/transport/connection-health';
+import { MOBILE_CAPABILITY } from '@/transport/protocol-version';
 import type { PairedHost, RpcNotification } from '@/transport/types';
 import { registerForPushTokenAsync, scheduleDesktopNotification } from '@/notifications/mobile-notifications';
 import type { DesktopNotificationParams } from '@/notifications/notification-routing';
@@ -47,6 +48,10 @@ interface Entry {
   connectStartedAt: number | null;
   /** Bounded ring buffer of recent connection events (newest last). */
   log: ConnectionLogEntry[];
+  /** Desktop capabilities from status.get, fetched once per connection (null
+   *  until fetched, reset on each reconnect). Gates capability-negotiated calls
+   *  like push registration so we don't fire RPCs an older desktop lacks. */
+  capabilities: string[] | null;
 }
 
 export interface ClientManager {
@@ -148,13 +153,31 @@ function createManager(): ClientManager & {
     });
   }
 
+  // Fetch (and cache for this connection) the desktop's advertised capabilities,
+  // so we can gate capability-negotiated calls instead of firing RPCs an older
+  // desktop lacks (which the desktop answers with method-not-found - logged as an
+  // error even when the caller catches it). status.get is a core method present
+  // on every desktop; one that predates the capabilities field returns none, so
+  // the feature reads as unsupported.
+  async function desktopSupports(entry: Entry, capability: string): Promise<boolean> {
+    if (entry.capabilities == null) {
+      const status = await entry.client.request<{ capabilities?: string[] }>('status.get').catch(() => null);
+      if (entry.disposed) return false;
+      entry.capabilities = status?.capabilities ?? [];
+    }
+    return entry.capabilities.includes(capability);
+  }
+
   // Hand the desktop this device's Expo push token so it can alert us while
   // backgrounded (the socket is closed then). Fire-and-forget and best-effort:
-  // a desktop too old to support push answers method-not-found (ignored), and a
-  // device without push provisioned gets a null token (skipped). The desktop
-  // persists the token, so we only register on first connect, not every reconnect.
+  // gated on the desktop advertising push support (so we never call a method an
+  // older desktop lacks), and skipped when the device has no token (push disabled
+  // or not provisioned). Called on every connect so the desktop's freshness
+  // heartbeat stays current.
   function registerPush(entry: Entry): void {
     void (async () => {
+      if (entry.disposed) return;
+      if (!(await desktopSupports(entry, MOBILE_CAPABILITY.pushNotifications))) return;
       const reg = await registerForPushTokenAsync();
       if (!reg || entry.disposed) return;
       await entry.client.request('notifications.registerPush', { token: reg.token, platform: reg.platform }).catch(() => undefined);
@@ -222,6 +245,9 @@ function createManager(): ClientManager & {
   function connectEntry(entry: Entry): void {
     // Reset transport state (nonce counter, listeners) before each (re)connect.
     entry.client.close();
+    // Capabilities are per-connection; refetch after this (re)connect in case the
+    // desktop was upgraded since we last saw it.
+    entry.capabilities = null;
     // First attempt reads as 'connecting'; subsequent attempts as 'reconnecting'
     // so classifyConnection() can escalate the verdict as the streak grows.
     entry.state = entry.attempt > 0 ? 'reconnecting' : 'connecting';
@@ -269,6 +295,7 @@ function createManager(): ClientManager & {
       lastConnectedAt: null,
       connectStartedAt: null,
       log: [],
+      capabilities: null,
     };
     // Register notification routing once; it survives reconnects (the client
     // keeps notificationListeners across close()), so we never tear it down
@@ -392,12 +419,14 @@ function createManager(): ClientManager & {
         }
       });
     }
+    if (!(await desktopSupports(entry, MOBILE_CAPABILITY.pushNotifications))) return;
     await entry.client.request('notifications.unregisterPush').catch(() => undefined);
   };
 
   const syncPushRegistration = async (enabled: boolean): Promise<void> => {
     for (const entry of entries.values()) {
       if (entry.state !== 'connected') continue;
+      if (!(await desktopSupports(entry, MOBILE_CAPABILITY.pushNotifications))) continue;
       if (enabled) {
         registerPush(entry);
       } else {

--- a/mobile-app/src/transport/client-manager.tsx
+++ b/mobile-app/src/transport/client-manager.tsx
@@ -403,15 +403,18 @@ function createManager(): ClientManager & {
         entry.reconnectTimer = null;
       }
       await new Promise<void>((resolve) => {
-        const off = entry.client.onOpen(() => {
-          off();
-          clearTimeout(timer);
-          resolve();
-        });
+        // `off` is declared first and guarded so a (hypothetical) synchronous
+        // onOpen can't reference it before assignment.
+        let off: (() => void) | undefined;
         const timer = setTimeout(() => {
-          off();
+          off?.();
           resolve();
         }, 4000);
+        off = entry.client.onOpen(() => {
+          clearTimeout(timer);
+          off?.();
+          resolve();
+        });
         // Kick a connect unless one is already in flight (don't reset it).
         if (entry.state !== 'connecting') {
           entry.attempt = 0;

--- a/mobile-app/src/transport/client-manager.tsx
+++ b/mobile-app/src/transport/client-manager.tsx
@@ -11,7 +11,7 @@ import { loadHosts } from '@/transport/host-store';
 import { BraidAuthError, BraidRpcClient } from '@/transport/rpc-client';
 import type { ConnectionLogEntry, ConnectionLogLevel, ConnectionState } from '@/transport/connection-health';
 import type { PairedHost, RpcNotification } from '@/transport/types';
-import { scheduleDesktopNotification } from '@/notifications/mobile-notifications';
+import { registerForPushTokenAsync, scheduleDesktopNotification } from '@/notifications/mobile-notifications';
 import type { DesktopNotificationParams } from '@/notifications/notification-routing';
 
 const RECONNECT_BASE_MS = 1_000;
@@ -34,7 +34,6 @@ interface Entry {
   state: HostConnectionState;
   /** Consecutive failed/dropped connect attempts; drives reconnect backoff. */
   attempt: number;
-  notifSubId: string | null;
   offNotification: (() => void) | null;
   offClose: (() => void) | null;
   offOpen: (() => void) | null;
@@ -55,6 +54,20 @@ export interface ClientManager {
   acquireHost: (host: PairedHost) => BraidRpcClient;
   getClient: (hostId: string) => BraidRpcClient | null;
   dropHost: (hostId: string) => void;
+  /**
+   * Tell the desktop to forget this device's push token so it stops sending
+   * background notifications. Best-effort and only effective while connected;
+   * call it before dropHost on host removal so a removed desktop goes quiet
+   * (otherwise the desktop keeps the token and keeps pushing to the phone).
+   */
+  unregisterPush: (hostId: string) => Promise<void>;
+  /**
+   * Apply the device-wide "desktop notifications" toggle to every connected
+   * desktop: register this device's push token everywhere when enabled, or tell
+   * every desktop to forget it when disabled. Disabling must reach the desktop
+   * because remote pushes are shown by the OS regardless of in-app state.
+   */
+  syncPushRegistration: (enabled: boolean) => Promise<void>;
   /** Current connection state for a host (for UI status). */
   getState: (hostId: string) => HostConnectionState;
   /** Consecutive failed reconnect attempts (0 when connected/idle). */
@@ -123,15 +136,29 @@ function createManager(): ClientManager & {
 
   // Subscribe to desktop notifications once. On later reconnects the client's
   // resendSubscriptions() replays this automatically, so we never re-subscribe.
+  //
+  // Fire-and-forget: the notification subscription lives for the whole
+  // connection, so we never unsubscribe it explicitly (and thus don't track the
+  // returned id). dropHost()'s clearSubscriptions() + close() tears it down, and
+  // the desktop drops every subscription when the socket closes - so an explicit
+  // notifications.unsubscribe RPC would only race that close, never beat it.
   function subscribeNotifications(entry: Entry): void {
-    entry.client
-      .subscribe('notifications.subscribe')
-      .then((id) => {
-        entry.notifSubId = id;
-      })
-      .catch(() => {
-        // Retried on the next reconnect via resendSubscriptions().
-      });
+    entry.client.subscribe('notifications.subscribe').catch(() => {
+      // Retried on the next reconnect via resendSubscriptions().
+    });
+  }
+
+  // Hand the desktop this device's Expo push token so it can alert us while
+  // backgrounded (the socket is closed then). Fire-and-forget and best-effort:
+  // a desktop too old to support push answers method-not-found (ignored), and a
+  // device without push provisioned gets a null token (skipped). The desktop
+  // persists the token, so we only register on first connect, not every reconnect.
+  function registerPush(entry: Entry): void {
+    void (async () => {
+      const reg = await registerForPushTokenAsync();
+      if (!reg || entry.disposed) return;
+      await entry.client.request('notifications.registerPush', { token: reg.token, platform: reg.platform }).catch(() => undefined);
+    })();
   }
 
   function scheduleReconnect(entry: Entry): void {
@@ -183,6 +210,12 @@ function createManager(): ClientManager & {
       entry.everConnected = true;
       subscribeNotifications(entry);
     }
+    // Re-register the push token on every connect (not just the first) so the
+    // desktop refreshes its freshness timestamp. The desktop expires tokens that
+    // haven't been seen within its TTL, so a device that's gone (removed while
+    // offline, uninstalled) stops getting pushes; an active one keeps them alive
+    // by reconnecting whenever the app is opened.
+    registerPush(entry);
     emit();
   }
 
@@ -227,7 +260,6 @@ function createManager(): ClientManager & {
       client,
       state: 'disconnected',
       attempt: 0,
-      notifSubId: null,
       offNotification: null,
       offClose: null,
       offOpen: null,
@@ -329,6 +361,51 @@ function createManager(): ClientManager & {
     connectEntry(entry);
   };
 
+  const unregisterPush = async (hostId: string): Promise<void> => {
+    const entry = entries.get(hostId);
+    if (!entry) return;
+    // The desktop only learns to drop our token over a live socket. On the
+    // homepage the app is foregrounded and usually already (re)connecting, so
+    // give it a brief window to finish before giving up - a "remove" right after
+    // opening the app still lands. If the desktop is genuinely unreachable we
+    // proceed anyway: it isn't pushing while offline, and its token TTL expires
+    // us if it never sees this device again.
+    if (entry.state !== 'connected') {
+      if (entry.reconnectTimer) {
+        clearTimeout(entry.reconnectTimer);
+        entry.reconnectTimer = null;
+      }
+      await new Promise<void>((resolve) => {
+        const off = entry.client.onOpen(() => {
+          off();
+          clearTimeout(timer);
+          resolve();
+        });
+        const timer = setTimeout(() => {
+          off();
+          resolve();
+        }, 4000);
+        // Kick a connect unless one is already in flight (don't reset it).
+        if (entry.state !== 'connecting') {
+          entry.attempt = 0;
+          connectEntry(entry);
+        }
+      });
+    }
+    await entry.client.request('notifications.unregisterPush').catch(() => undefined);
+  };
+
+  const syncPushRegistration = async (enabled: boolean): Promise<void> => {
+    for (const entry of entries.values()) {
+      if (entry.state !== 'connected') continue;
+      if (enabled) {
+        registerPush(entry);
+      } else {
+        await entry.client.request('notifications.unregisterPush').catch(() => undefined);
+      }
+    }
+  };
+
   const dropHost = (hostId: string): void => {
     const entry = entries.get(hostId);
     if (!entry) return;
@@ -405,7 +482,7 @@ function createManager(): ClientManager & {
     for (const id of [...entries.keys()]) dropHost(id);
   };
 
-  return { acquireHost, getClient, getState, getReconnectAttempt, getLastConnectedAt, getConnectionLog, forceReconnect, dropHost, subscribe, subscribeActivity, init, onAppState, disposeAll };
+  return { acquireHost, getClient, getState, getReconnectAttempt, getLastConnectedAt, getConnectionLog, forceReconnect, dropHost, unregisterPush, syncPushRegistration, subscribe, subscribeActivity, init, onAppState, disposeAll };
 }
 
 const Ctx = createContext<ClientManager | null>(null);
@@ -434,6 +511,8 @@ export function ClientManagerProvider({ children }: { children: ReactNode }) {
       getConnectionLog: manager.getConnectionLog,
       forceReconnect: manager.forceReconnect,
       dropHost: manager.dropHost,
+      unregisterPush: manager.unregisterPush,
+      syncPushRegistration: manager.syncPushRegistration,
       subscribe: manager.subscribe,
       subscribeActivity: manager.subscribeActivity,
     }),

--- a/mobile-app/src/transport/protocol-version.ts
+++ b/mobile-app/src/transport/protocol-version.ts
@@ -29,4 +29,6 @@ export const MOBILE_CAPABILITY = {
   githubPrStatus: 'github.pr-status.v1',
   jira: 'jira.lookup.v1',
   copyFiles: 'worktree.copy-files.v1',
+  bareTerminal: 'terminal.bare.v1',
+  pushNotifications: 'notifications.push.v1',
 } as const;

--- a/mobile-app/yarn.lock
+++ b/mobile-app/yarn.lock
@@ -3584,6 +3584,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arg@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "arg@npm:4.1.3"
+  checksum: 10c0/070ff801a9d236a6caa647507bdcc7034530604844d64408149a26b9e87c2f97650055c0f049abd1efc024b334635c01f29e0b632b371ac3f26130f4cf65997a
+  languageName: node
+  linkType: hard
+
 "arg@npm:^5.0.2":
   version: 5.0.2
   resolution: "arg@npm:5.0.2"
@@ -4127,6 +4134,7 @@ __metadata:
     expo-status-bar: "npm:~56.0.4"
     expo-symbols: "npm:~56.0.5"
     expo-system-ui: "npm:~56.0.5"
+    expo-updates: "npm:~56.0.17"
     expo-web-browser: "npm:~56.0.5"
     i18next: "npm:^26.3.0"
     jest: "npm:~29.7.0"
@@ -5782,6 +5790,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-eas-client@npm:~56.0.0":
+  version: 56.0.1
+  resolution: "expo-eas-client@npm:56.0.1"
+  checksum: 10c0/01627f690371353115da0db561f77d091203c2a28076aecfac69bacc84ca025b2b035dc6079190c2940d4045e5e8ff511f276b0ea09aa5e078b457eae3f7eadd
+  languageName: node
+  linkType: hard
+
 "expo-file-system@npm:~56.0.7":
   version: 56.0.7
   resolution: "expo-file-system@npm:56.0.7"
@@ -6037,6 +6052,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-structured-headers@npm:~56.0.0":
+  version: 56.0.0
+  resolution: "expo-structured-headers@npm:56.0.0"
+  checksum: 10c0/f4f88184abe0532f0aaff52e2963275c3db5e03cc1579faae82f2dbe859f44ed65660444faa2e0290ee7f604ae1a5d4b76ffe9484193147d01a3cc6ea54d4957
+  languageName: node
+  linkType: hard
+
 "expo-symbols@npm:^56.0.5, expo-symbols@npm:~56.0.5":
   version: 56.0.5
   resolution: "expo-symbols@npm:56.0.5"
@@ -6075,6 +6097,39 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: 10c0/9200d11a5affb568b6d39fe500578e9d38a2164d05fef3bc8a6ec1ff7393fe416ec62596d4d46677406e9f20c6b5e660b8fa85015b09d6695c0d3bd87187f360
+  languageName: node
+  linkType: hard
+
+"expo-updates@npm:~56.0.17":
+  version: 56.0.17
+  resolution: "expo-updates@npm:56.0.17"
+  dependencies:
+    "@expo/code-signing-certificates": "npm:^0.0.6"
+    "@expo/plist": "npm:^0.7.0"
+    "@expo/spawn-async": "npm:^1.8.0"
+    arg: "npm:^4.1.0"
+    chalk: "npm:^4.1.2"
+    debug: "npm:^4.3.4"
+    expo-eas-client: "npm:~56.0.0"
+    expo-manifests: "npm:~56.0.4"
+    expo-structured-headers: "npm:~56.0.0"
+    expo-updates-interface: "npm:~56.0.1"
+    getenv: "npm:^2.0.0"
+    glob: "npm:^13.0.0"
+    ignore: "npm:^5.3.1"
+    nullthrows: "npm:^1.1.1"
+    resolve-from: "npm:^5.0.0"
+  peerDependencies:
+    expo: "*"
+    expo-dev-client: "*"
+    react: "*"
+    react-native: "*"
+  peerDependenciesMeta:
+    expo-dev-client:
+      optional: true
+  bin:
+    expo-updates: bin/cli.js
+  checksum: 10c0/ab6956f91172a1d0cda94774d48ba9173effa210d1c54484c62fcce17c1cf8fbcb5c7dbf8a5eb3f7d63faa1938135ce5bd2116bf9e53ea54148a41e9bd39fac1
   languageName: node
   linkType: hard
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,7 @@ import { ensureAllAgentHooks } from './services/agentHooks'
 import { startAgentHookServer, stopAgentHookServer } from './services/agentHookServer'
 import { startAgentAwakeService, stopAgentAwakeService } from './services/agentAwake'
 import { startMobileTerminalNotifier } from './services/mobileServer/terminalNotifier'
+import { startMobilePushNotifier } from './services/mobileServer/pushNotifier'
 import { startTerminalActivityTracking } from './services/mobileServer/terminalActivity'
 import { startTerminalRunTimer } from './services/terminalRunTimer'
 import { ptyService } from './services/pty'
@@ -321,6 +322,11 @@ app.whenReady().then(async () => {
   // Bridge big-terminal agent status to paired mobile devices (main-process,
   // independent of the renderer observing the terminal).
   startMobileTerminalNotifier()
+
+  // Relay the same agent alerts to backgrounded (disconnected) devices via Expo
+  // push, so notifications arrive when the app isn't open. Connected devices are
+  // skipped (they get the alert over the WS), so there is no duplicate.
+  startMobilePushNotifier()
 
   // Track each big terminal's current agent state so terminal.list can report
   // which agents need attention on the mobile homepage.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -737,7 +737,13 @@ export function registerIpcHandlers(): void {
     return mobileNgrokTunnel.getStatus()
   })
   ipcMain.handle('mobile:getDevices', () => deviceStore.load())
-  ipcMain.handle('mobile:removeDevice', (_e, deviceId: string) => deviceStore.removeDevice(deviceId))
+  ipcMain.handle('mobile:removeDevice', (_e, deviceId: string) => {
+    // Drop the live socket first so its notification subscription stops firing,
+    // then forget the device. Order matters: removing from the store alone leaves
+    // an open connection that keeps pushing notifications to the phone.
+    mobileServer.disconnectDevice(deviceId)
+    deviceStore.removeDevice(deviceId)
+  })
 
   // LSP
   ipcMain.handle('lsp:detectServers', (_e, projectPath: string, userConfigs: LspServerConfig[]) =>

--- a/src/main/services/mobileServer/__tests__/rpc.test.ts
+++ b/src/main/services/mobileServer/__tests__/rpc.test.ts
@@ -59,6 +59,16 @@ vi.mock('../../pty', () => ({
       // filtered out: it is a closed/zombie session the desktop no longer shows.
       { ptyId: 'pty-3', cwd: '/test', terminalId: 'bt-100-3' },
     ]),
+    // terminal.list sources the live terminal set from the daemon's full session
+    // list (keyed by the bt- terminalId), then intersects with the renderer's
+    // "known" set to drop orphans. Mirror that here: bt-100-1 is tracked, bt-100-3
+    // is an orphan the renderer no longer reports, and right-panel-1 is a non-bt
+    // session that must be excluded by the bt- prefix filter.
+    listSessions: vi.fn(async () => [
+      { sessionId: 'bt-100-1', cwd: '/test', cols: 80, rows: 24, createdAt: 0, attachedClients: 0 },
+      { sessionId: 'bt-100-3', cwd: '/test', cols: 80, rows: 24, createdAt: 0, attachedClients: 0 },
+      { sessionId: 'right-panel-1', cwd: '/test', cols: 80, rows: 24, createdAt: 0, attachedClients: 0 },
+    ]),
     write: vi.fn(),
     resize: vi.fn(),
     getSize: vi.fn(() => ({ cols: 120, rows: 40 })),
@@ -188,6 +198,42 @@ describe('RPC Dispatch', () => {
     expect(result.worktreeId).toBe('p1-wt-test/wt-1')
   })
 
+  it('terminal.create with agentId "shell" spawns a bare terminal (no agent, no launch command)', async () => {
+    const { ptyService } = await import('../../pty')
+    vi.mocked(ptyService.write).mockClear()
+    vi.mocked(ptyService.setBigTerminalMetadata!).mockClear()
+    const req: JsonRpcRequest = {
+      jsonrpc: '2.0', id: 100, method: 'terminal.create',
+      params: { worktreePath: '/test/wt', agentId: 'shell' },
+    }
+    const res = await dispatch(req, conn)
+    expect(res.error).toBeUndefined()
+    const result = res.result as Record<string, unknown>
+    expect(result.terminalId).toMatch(/^bt-/)
+    // No agent attached - the home screen shows no agent status for a bare shell.
+    expect(result.agentId).toBeUndefined()
+    // Nothing is written to the PTY, so the tab is just a shell prompt.
+    expect(ptyService.write).not.toHaveBeenCalled()
+    // Metadata is persisted without an agentId.
+    expect(ptyService.setBigTerminalMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: undefined }),
+    )
+  })
+
+  it('terminal.create without an agentId still defaults to Claude (legacy mobile builds)', async () => {
+    const { ptyService } = await import('../../pty')
+    vi.mocked(ptyService.write).mockClear()
+    const req: JsonRpcRequest = {
+      jsonrpc: '2.0', id: 101, method: 'terminal.create',
+      params: { worktreePath: '/test/wt' },
+    }
+    const res = await dispatch(req, conn)
+    expect(res.error).toBeUndefined()
+    const result = res.result as Record<string, unknown>
+    expect(result.agentId).toBe('claude')
+    expect(ptyService.write).toHaveBeenCalledWith('pty-new', 'claude\n')
+  })
+
   it('terminal.close kills the big terminal by its id (reaps PTY + metadata)', async () => {
     const { ptyService } = await import('../../pty')
     vi.mocked(ptyService.killBigTerminal!).mockClear()
@@ -272,14 +318,19 @@ describe('RPC Dispatch', () => {
   })
 
   it('dispatches terminal.list and excludes non big terminals and orphans', async () => {
+    // The renderer is authoritative for which big terminals exist. Seed its set
+    // with only bt-100-1 so the daemon's orphan (bt-100-3) is dropped.
+    const { setKnownBigTerminals } = await import('../knownBigTerminals')
+    setKnownBigTerminals([{ terminalId: 'bt-100-1', label: 'Claude', agentId: 'claude' }])
     const req: JsonRpcRequest = { jsonrpc: '2.0', id: 5, method: 'terminal.list', params: { worktreePath: '/test' } }
     const res = await dispatch(req, conn)
     expect(res.error).toBeUndefined()
     const terminals = res.result as Array<Record<string, unknown>>
-    // Only the labelled bt- big terminal is surfaced; the right-panel terminal
-    // (no terminalId) and the orphaned bt- terminal (no label) are filtered out.
+    // Only the tracked bt- big terminal is surfaced; the non-bt right-panel
+    // session and the orphaned bt- terminal (absent from the known set) are
+    // filtered out. In the daemon model the session id is the terminal/pty id.
     expect(terminals).toHaveLength(1)
-    expect(terminals[0].ptyId).toBe('pty-1')
+    expect(terminals[0].ptyId).toBe('bt-100-1')
     expect(terminals[0].terminalId).toBe('bt-100-1')
   })
 

--- a/src/main/services/mobileServer/__tests__/rpc.test.ts
+++ b/src/main/services/mobileServer/__tests__/rpc.test.ts
@@ -19,6 +19,13 @@ vi.mock('../../storage', () => ({
   },
 }))
 
+vi.mock('../deviceStore', () => ({
+  deviceStore: {
+    setPushToken: vi.fn(),
+    clearPushToken: vi.fn(),
+  },
+}))
+
 vi.mock('../../git', () => ({
   gitService: {
     getWorktrees: vi.fn(async () => [{ path: '/test/wt', branch: 'main' }]),
@@ -232,6 +239,43 @@ describe('RPC Dispatch', () => {
     const result = res.result as Record<string, unknown>
     expect(result.agentId).toBe('claude')
     expect(ptyService.write).toHaveBeenCalledWith('pty-new', 'claude\n')
+  })
+
+  it('notifications.registerPush stores the token for the connection device', async () => {
+    const { deviceStore } = await import('../deviceStore')
+    vi.mocked(deviceStore.setPushToken).mockClear()
+    const req: JsonRpcRequest = {
+      jsonrpc: '2.0', id: 110, method: 'notifications.registerPush',
+      params: { token: 'ExponentPushToken[abc]', platform: 'ios' },
+    }
+    const res = await dispatch(req, conn)
+    expect(res.error).toBeUndefined()
+    expect(res.result).toEqual({ ok: true })
+    expect(deviceStore.setPushToken).toHaveBeenCalledWith('d1', 'ExponentPushToken[abc]', 'ios')
+  })
+
+  it('notifications.registerPush rejects a missing token and ignores a bad platform', async () => {
+    const { deviceStore } = await import('../deviceStore')
+    vi.mocked(deviceStore.setPushToken).mockClear()
+    const missing = await dispatch({ jsonrpc: '2.0', id: 111, method: 'notifications.registerPush', params: {} }, conn)
+    expect(missing.error).toBeDefined()
+    expect(deviceStore.setPushToken).not.toHaveBeenCalled()
+    // Unknown platform is dropped to undefined rather than persisted verbatim.
+    const badPlatform = await dispatch(
+      { jsonrpc: '2.0', id: 112, method: 'notifications.registerPush', params: { token: 't', platform: 'web' } },
+      conn,
+    )
+    expect(badPlatform.error).toBeUndefined()
+    expect(deviceStore.setPushToken).toHaveBeenCalledWith('d1', 't', undefined)
+  })
+
+  it('notifications.unregisterPush clears the token for the connection device', async () => {
+    const { deviceStore } = await import('../deviceStore')
+    vi.mocked(deviceStore.clearPushToken).mockClear()
+    const res = await dispatch({ jsonrpc: '2.0', id: 113, method: 'notifications.unregisterPush' }, conn)
+    expect(res.error).toBeUndefined()
+    expect(res.result).toEqual({ ok: true })
+    expect(deviceStore.clearPushToken).toHaveBeenCalledWith('d1')
   })
 
   it('terminal.close kills the big terminal by its id (reaps PTY + metadata)', async () => {

--- a/src/main/services/mobileServer/deviceStore.ts
+++ b/src/main/services/mobileServer/deviceStore.ts
@@ -69,6 +69,29 @@ class DeviceStore {
     }
   }
 
+  /** Store (or refresh) a device's Expo push token so the desktop can alert it
+   *  while it is backgrounded. No-op if the device is unknown. */
+  setPushToken(deviceId: string, token: string, platform?: 'ios' | 'android'): void {
+    const devices = this.load()
+    const device = devices.find((d) => d.id === deviceId)
+    if (!device) return
+    device.pushToken = token
+    device.pushPlatform = platform
+    device.pushTokenUpdatedAt = Date.now()
+    this.save(devices)
+  }
+
+  /** Drop a device's push token (user disabled notifications, or the token went
+   *  stale / DeviceNotRegistered). No-op if unknown or already absent. */
+  clearPushToken(deviceId: string): void {
+    const devices = this.load()
+    const device = devices.find((d) => d.id === deviceId)
+    if (!device || device.pushToken === undefined) return
+    delete device.pushToken
+    delete device.pushPlatform
+    this.save(devices)
+  }
+
   /** Create a one-time pairing token (not yet associated with a device). */
   createPairingToken(transport: MobilePairingTransport = 'lan'): string {
     const token = crypto.randomBytes(32).toString('hex')

--- a/src/main/services/mobileServer/deviceStore.ts
+++ b/src/main/services/mobileServer/deviceStore.ts
@@ -89,6 +89,7 @@ class DeviceStore {
     if (!device || device.pushToken === undefined) return
     delete device.pushToken
     delete device.pushPlatform
+    delete device.pushTokenUpdatedAt
     this.save(devices)
   }
 

--- a/src/main/services/mobileServer/mobileServer.ts
+++ b/src/main/services/mobileServer/mobileServer.ts
@@ -436,6 +436,30 @@ class MobileServer {
     }
   }
 
+  /**
+   * Forcibly drop a device's live connection. Removing/forgetting a device on
+   * the desktop only deletes it from the trusted store, which does NOT tear down
+   * an already-open socket: the notification subscription registered at
+   * `notifications.subscribe` keeps firing `agentService.onNotify` and pushing
+   * over the stale connection, so the phone kept receiving notifications after
+   * being "disconnected". Closing the socket here stops that immediately (and any
+   * reconnect re-auth fails now that the device is untrusted). We unsubscribe and
+   * drop the connection synchronously rather than relying on the async ws 'close'
+   * event so the leak is closed the moment the device is removed.
+   */
+  disconnectDevice(deviceId: string): void {
+    const conn = this.connections.get(deviceId)
+    if (!conn) return
+    for (const unsub of conn.subscriptions.values()) unsub()
+    conn.subscriptions.clear()
+    this.connections.delete(deviceId)
+    if (conn.ws.readyState === WebSocket.OPEN || conn.ws.readyState === WebSocket.CONNECTING) {
+      conn.ws.close(4001, 'Device removed')
+    }
+    logger.info(`[MobileServer] Device "${conn.device.name}" (${deviceId}) disconnected (removed)`)
+    this.notifyDesktopWindows('mobile:deviceDisconnected', { deviceId })
+  }
+
   // ── Pairing ───────────────────────────────────────────────────────────
 
   /** Generate a pairing offer for display as QR code. */
@@ -472,6 +496,21 @@ class MobileServer {
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────
+
+  /** Whether a device has a live authenticated socket right now. The push
+   *  notifier uses this to alert only backgrounded (disconnected) devices, so a
+   *  connected device gets its notification over the WS and never a duplicate
+   *  push. */
+  isDeviceConnected(deviceId: string): boolean {
+    return this.connections.has(deviceId)
+  }
+
+  /** This desktop's stable instance id (== the `serverPublicKey` mobile stores
+   *  per paired host). Embedded in push payloads so a tapped push resolves back
+   *  to the right host on the device. */
+  getInstanceId(): string {
+    return this.instanceId
+  }
 
   private findConnectionByWs(ws: WebSocket): MobileConnection | null {
     for (const conn of this.connections.values()) {

--- a/src/main/services/mobileServer/pushNotifier.ts
+++ b/src/main/services/mobileServer/pushNotifier.ts
@@ -119,7 +119,18 @@ async function handleNotification(n: MobileNotification): Promise<void> {
 
 /** Subscribe agent notifications to the Expo push bridge. Returns an unsubscribe
  *  fn. Mirrors startMobileTerminalNotifier - both ride the same onNotify stream,
- *  so push content matches the WS notifications exactly. */
+ *  so push content matches the WS notifications exactly.
+ *
+ *  KILL SWITCH: outbound push to exp.host is a third-party dependency pending
+ *  the internal External Service Review, so it stays OFF unless explicitly
+ *  enabled via BRAID_ENABLE_MOBILE_PUSH=1. When off we never subscribe, so the
+ *  desktop never POSTs to Expo (it still accepts token registrations harmlessly;
+ *  they just go unused). Flip the env var once the review clears. */
 export function startMobilePushNotifier(): () => void {
+  const enabled = process.env.BRAID_ENABLE_MOBILE_PUSH === '1' || process.env.BRAID_ENABLE_MOBILE_PUSH === 'true'
+  if (!enabled) {
+    logger.info('[MobilePush] disabled (set BRAID_ENABLE_MOBILE_PUSH=1 to enable; pending External Service Review)')
+    return () => {}
+  }
   return agentService.onNotify((n) => { void handleNotification(n) })
 }

--- a/src/main/services/mobileServer/pushNotifier.ts
+++ b/src/main/services/mobileServer/pushNotifier.ts
@@ -1,0 +1,125 @@
+// ── Mobile push notification bridge (Expo) ───────────────────────────────────
+//
+// Delivers agent alerts (done / needs-input / error) to paired devices that are
+// NOT currently connected - i.e. the app is backgrounded or killed, so the live
+// E2EE WebSocket is closed and the in-app `notifications.subscribe` path can't
+// reach them. Connected devices still get their alert over the socket (handled
+// in rpc.ts), and this notifier explicitly skips them, so a device never gets
+// both a WS notification and a push for the same event.
+//
+// PRIVACY: unlike the WS channel, this is NOT end-to-end encrypted. The title /
+// body ride Expo's push service and then APNs / FCM, so the notification content
+// (project, branch, agent) is visible to those third parties. This is a
+// deliberate v1 trade-off for background delivery. A future revision can ship an
+// encrypted payload + on-device Notification Service Extension to close that gap.
+//
+// EXTERNAL SERVICE: this posts to https://exp.host (Expo). That is a third-party
+// dependency the desktop did not previously call; enabling it in a shipping
+// build is subject to the internal External Service Review.
+
+import { agentService, type MobileNotification } from '../agent'
+import { deviceStore } from './deviceStore'
+import { mobileServer } from './mobileServer'
+import { logger } from '../../lib/logger'
+
+const EXPO_PUSH_ENDPOINT = 'https://exp.host/--/api/v2/push/send'
+
+// NOT a token expiry: Expo push tokens don't expire on a timer (they're stable
+// per app install, only rotating on reinstall/restore). This is OUR staleness
+// policy on the registration record: the device re-registers on every connect (a
+// heartbeat that refreshes `pushTokenUpdatedAt`), so a registration we haven't
+// seen refreshed within this window means the device hasn't checked in for a
+// long time - removed while offline, uninstalled, or lost. We stop pushing to it
+// so a desktop can't keep notifying a phone that walked away without an explicit
+// unregister ever reaching us. Generous, since someone relying on background push
+// may open the app only occasionally; each open (foreground -> reconnect)
+// refreshes the heartbeat.
+const MAX_PUSH_REGISTRATION_AGE_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+
+interface ExpoPushMessage {
+  to: string
+  title: string
+  body: string
+  data: Record<string, unknown>
+  sound: 'default'
+  priority: 'high'
+  channelId?: string
+}
+
+/** Map an internal notification to the Expo push message for one device token.
+ *  `data` carries the desktop instance id (so a tapped push resolves back to the
+ *  right paired host) plus the existing deep-link hints. */
+function buildMessage(token: string, platform: 'ios' | 'android' | undefined, n: MobileNotification): ExpoPushMessage {
+  return {
+    to: token,
+    title: n.title || 'Braid',
+    body: n.body || '',
+    data: {
+      desktopId: mobileServer.getInstanceId(),
+      type: n.type,
+      worktreePath: n.worktreePath,
+      terminalId: n.terminalId,
+      worktreeName: n.branch,
+    },
+    sound: 'default',
+    priority: 'high',
+    // The mobile app pre-creates this Android channel; iOS ignores it.
+    ...(platform === 'android' ? { channelId: 'braid-desktop' } : {}),
+  }
+}
+
+/** POST a batch to Expo and reap dead tokens. Expo returns a `data` array of
+ *  tickets aligned to the input order; a `DeviceNotRegistered` error means the
+ *  token is permanently invalid (app uninstalled / push disabled), so we clear
+ *  it to stop sending into the void. Best-effort: any transport error is logged
+ *  and dropped, never thrown into the notify path. */
+async function send(messages: ExpoPushMessage[], deviceIds: string[]): Promise<void> {
+  try {
+    const res = await fetch(EXPO_PUSH_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(messages),
+    })
+    if (!res.ok) {
+      logger.warn(`[MobilePush] Expo push failed: HTTP ${res.status}`)
+      return
+    }
+    const json = (await res.json()) as { data?: Array<{ status?: string; details?: { error?: string } }> }
+    const tickets = json.data ?? []
+    tickets.forEach((ticket, i) => {
+      if (ticket?.status === 'error' && ticket.details?.error === 'DeviceNotRegistered') {
+        deviceStore.clearPushToken(deviceIds[i])
+        logger.info(`[MobilePush] Cleared stale push token for device ${deviceIds[i]}`)
+      }
+    })
+  } catch (err) {
+    logger.warn('[MobilePush] Expo push request error:', err)
+  }
+}
+
+async function handleNotification(n: MobileNotification): Promise<void> {
+  // Only devices with a recently-refreshed registration AND not currently
+  // connected. A connected device is served by the WS path; pushing to it too
+  // would double-notify. A registration we haven't seen refreshed within the max
+  // age means the device hasn't checked in for a long time - removed while
+  // offline, uninstalled, or lost - so we stop pushing to it.
+  const now = Date.now()
+  const targets = deviceStore
+    .load()
+    .filter(
+      (d) =>
+        d.pushToken &&
+        now - (d.pushTokenUpdatedAt ?? 0) < MAX_PUSH_REGISTRATION_AGE_MS &&
+        !mobileServer.isDeviceConnected(d.id),
+    )
+  if (targets.length === 0) return
+  const messages = targets.map((d) => buildMessage(d.pushToken!, d.pushPlatform, n))
+  await send(messages, targets.map((d) => d.id))
+}
+
+/** Subscribe agent notifications to the Expo push bridge. Returns an unsubscribe
+ *  fn. Mirrors startMobileTerminalNotifier - both ride the same onNotify stream,
+ *  so push content matches the WS notifications exactly. */
+export function startMobilePushNotifier(): () => void {
+  return agentService.onNotify((n) => { void handleNotification(n) })
+}

--- a/src/main/services/mobileServer/rpc.ts
+++ b/src/main/services/mobileServer/rpc.ts
@@ -13,6 +13,7 @@ import { rateLimitService } from '../rateLimits/service'
 import { enrichedEnv } from '../../lib/enrichedEnv'
 import { MOBILE_PROTOCOL_VERSION, MIN_COMPATIBLE_MOBILE_VERSION, MOBILE_CAPABILITIES } from './protocol'
 import { getMobileInstanceName } from './instanceName'
+import { deviceStore } from './deviceStore'
 import { markMobileTerminalActive, markMobileTerminalInactive, getTerminalPresence } from './mobileTerminalPresence'
 import { getMobileDisplayMode, resetMobileDisplayMode, setMobileDisplayMode, type MobileDisplayMode } from './mobileTerminalDisplay'
 import { clearMobileTerminalActor, isMobileTerminalActor, setMobileTerminalActor } from './mobileTerminalActor'
@@ -62,6 +63,11 @@ const MOBILE_AGENT_CATALOG = [
   { id: 'codex', label: 'Codex', launchCmd: 'codex' },
   { id: 'gemini', label: 'Gemini CLI', launchCmd: 'gemini' },
 ]
+// Sentinel agentId for a bare terminal: spawn the PTY but write no launch
+// command, so the tab is just a shell prompt with no agent attached. Gated on
+// the desktop side by the `terminal.bare.v1` capability (mobile only offers it
+// when this desktop advertises it). Older mobile builds never send it.
+const SHELL_AGENT_ID = 'shell'
 
 function register(name: string, handler: RpcHandler): void {
   methods.set(name, handler)
@@ -505,11 +511,16 @@ function resolveTerminalContext(terminalId?: string, ptyId?: string): {
 register('terminal.create', async (params) => {
   const worktreePath = params.worktreePath as string
   if (!worktreePath) throw new Error('worktreePath is required')
+  // A bare terminal is requested with agentId 'shell': spawn the PTY but launch
+  // nothing, leaving a plain shell prompt. Distinct from the legacy no-agent
+  // path below, which still defaults to Claude so older mobile builds (that omit
+  // agentId entirely) keep their existing behavior.
+  const isBareTerminal = (params.agentId as string | undefined)?.trim() === SHELL_AGENT_ID
   const requestedAgentId = (params.agentId as string | undefined)?.trim() || MOBILE_AGENT_CATALOG[0]?.id || 'claude'
-  const agent = MOBILE_AGENT_CATALOG.find((item) => item.id === requestedAgentId)
+  const agent = isBareTerminal ? undefined : MOBILE_AGENT_CATALOG.find((item) => item.id === requestedAgentId)
   const label = (params.label as string | undefined)?.trim() || agent?.label || 'Terminal'
-  const command = (params.command as string | undefined)?.trim() || agent?.launchCmd || 'claude'
-  const agentId = agent?.id || requestedAgentId
+  const command = isBareTerminal ? '' : (params.command as string | undefined)?.trim() || agent?.launchCmd || 'claude'
+  const agentId = isBareTerminal ? undefined : agent?.id || requestedAgentId
   const terminalId = `bt-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`
   // Prefer the id the client sent, but fall back to the registry keyed by path.
   // The registry covers worktrees reachable via deep links that the client
@@ -914,6 +925,24 @@ register('notifications.unsubscribe', async (params, connection) => {
     unsub()
     connection.subscriptions.delete(subId)
   }
+})
+
+// Register this device's Expo push token so the desktop can alert it while it is
+// backgrounded (its socket is closed). The token is persisted on the trusted
+// device; the push notifier (pushNotifier.ts) sends only to devices that are NOT
+// currently connected, so a foregrounded device still gets its alert over the
+// E2EE WS and never a duplicate push.
+register('notifications.registerPush', async (params, connection) => {
+  const token = (params.token as string | undefined)?.trim()
+  if (!token) throw new Error('token is required')
+  const platform = params.platform === 'ios' || params.platform === 'android' ? params.platform : undefined
+  deviceStore.setPushToken(connection.device.id, token, platform)
+  return { ok: true }
+})
+
+register('notifications.unregisterPush', async (_params, connection) => {
+  deviceStore.clearPushToken(connection.device.id)
+  return { ok: true }
 })
 
 // ── Dispatch ──────────────────────────────────────────────────────────────────

--- a/src/main/services/mobileServer/types.ts
+++ b/src/main/services/mobileServer/types.ts
@@ -10,6 +10,9 @@ export interface TrustedDevice {
   pairedAt: number              // Date.now()
   lastSeenAt: number            // Updated on each successful connection
   pairingTransport?: MobilePairingTransport // Transport used by the pairing offer that created this device
+  pushToken?: string            // Expo push token, for delivering alerts while the device is backgrounded (disconnected). Absent until the device registers one.
+  pushPlatform?: 'ios' | 'android' // Platform behind the token, for channel/priority shaping when sending
+  pushTokenUpdatedAt?: number   // Date.now() of the last register (a heartbeat the device refreshes on every connect - the Expo token itself doesn't expire). The push notifier ignores registrations not refreshed within MAX_PUSH_REGISTRATION_AGE_MS, so a device that's gone for good (removed while offline, uninstalled) stops getting pushes without an explicit unregister.
 }
 
 // ── E2EE Session ──────────────────────────────────────────────────────────────

--- a/src/renderer/components/Settings/SettingsMobile.tsx
+++ b/src/renderer/components/Settings/SettingsMobile.tsx
@@ -14,6 +14,7 @@ import {
   IconSmartphone,
   IconLock,
   IconSparkle,
+  IconCheckmark,
   IconCopy,
   IconRefresh,
   IconGlobe,
@@ -135,17 +136,24 @@ export function SettingsMobile() {
   const { copied: copiedEndpoint, handleCopy: handleCopyEndpoint } = useCopyToClipboard(state.ngrokTunnel.endpoint ?? '')
 
   const loadData = useCallback(async () => {
-    try {
-      const [status, devices, tunnel] = await Promise.all([
-        ipc.mobile.getStatus(),
-        ipc.mobile.getDevices(),
-        ipc.mobile.getNgrokTunnelStatus(),
-      ])
-      dispatch({ type: 'SET_STATUS', running: status.running, port: status.port, connectedDevices: status.connectedDevices })
-      dispatch({ type: 'SET_DEVICES', devices: devices as MobileDevice[] })
-      dispatch({ type: 'SET_NGROK_TUNNEL', tunnel: tunnel as NgrokTunnelStatus })
-    } catch {
-      // Server may not be running
+    // Settle each call independently. A single failing IPC (e.g. ngrok status
+    // while a tunnel is mid-start) must NOT blank the device list / connected
+    // indicators - which is exactly what an all-or-nothing Promise.all in a
+    // swallowing try/catch did, leaving a freshly paired phone invisible on the
+    // desktop until a full reconnect.
+    const [status, devices, tunnel] = await Promise.allSettled([
+      ipc.mobile.getStatus(),
+      ipc.mobile.getDevices(),
+      ipc.mobile.getNgrokTunnelStatus(),
+    ])
+    if (status.status === 'fulfilled') {
+      dispatch({ type: 'SET_STATUS', running: status.value.running, port: status.value.port, connectedDevices: status.value.connectedDevices })
+    }
+    if (devices.status === 'fulfilled') {
+      dispatch({ type: 'SET_DEVICES', devices: devices.value as MobileDevice[] })
+    }
+    if (tunnel.status === 'fulfilled') {
+      dispatch({ type: 'SET_NGROK_TUNNEL', tunnel: tunnel.value as NgrokTunnelStatus })
     }
   }, [])
 
@@ -168,15 +176,18 @@ export function SettingsMobile() {
     }
   }, [loadData])
 
-  // Fallback to the push event above: while a QR is on screen, poll the device
-  // list. This catches the pairing even if the 'mobile:deviceConnected' event is
-  // missed (e.g. a stale preload after a hot-reload), using only the pre-existing
-  // getStatus/getDevices IPC. Stops as soon as the QR is gone.
+  // Reliable backbone behind the push 'mobile:deviceConnected' event: while the
+  // server is up, poll status/devices so the connected indicators and paired
+  // list self-heal even if that event is missed (a stale preload after a
+  // hot-reload, or a first-pair race). Previously this was gated on the QR being
+  // on screen, so a missed event left a freshly paired - and on the phone,
+  // solidly connected - device invisible on the desktop until a full reconnect.
+  // Only runs while this page is mounted; the cleanup clears it on unmount.
   useEffect(() => {
-    if (!state.qrDataUrl) return
-    const timer = setInterval(() => { void loadData() }, 2500)
+    if (!state.serverRunning) return
+    const timer = setInterval(() => { void loadData() }, 2000)
     return () => clearInterval(timer)
-  }, [state.qrDataUrl, loadData])
+  }, [state.serverRunning, loadData])
 
   // When the device list gains an entry that wasn't paired when this QR was
   // generated, that's the scan we were waiting for - swap the QR for success.
@@ -392,17 +403,31 @@ export function SettingsMobile() {
           {running ? (
             <div className="mobile-pair-body">
               {state.justPaired ? (
-                <div className="mobile-pair-cta">
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-8)' }} aria-hidden="true">
-                    <StatusDot state="success" />
-                    <IconSmartphone size={20} />
+                <div className="mobile-paired">
+                  <div className="mobile-paired-burst" aria-hidden="true">
+                    <span className="mobile-paired-ring mobile-paired-ring--one" />
+                    <span className="mobile-paired-ring mobile-paired-ring--two" />
+                    <span className="mobile-paired-badge">
+                      <IconCheckmark size={32} />
+                    </span>
                   </div>
-                  <h4 className="mobile-pair-title" style={{ margin: 0 }}>{t('mobile.pairedTitle')}</h4>
+                  <h4 className="mobile-paired-title">{t('mobile.pairedTitle')}</h4>
+                  <span className="mobile-paired-device">
+                    <StatusDot state="success" />
+                    <IconSmartphone size={13} />
+                    <span className="mobile-paired-device-name">{state.justPaired.name || t('mobile.unnamed')}</span>
+                    <span className="mobile-paired-e2ee"><IconLock size={10} />E2EE</span>
+                  </span>
                   <p className="mobile-pair-cta-text">{t('mobile.pairedDesc', { name: state.justPaired.name || t('mobile.unnamed') })}</p>
-                  <Button onClick={() => { dispatch({ type: 'SET_JUST_PAIRED', device: null }); void handleGeneratePairing() }} disabled={state.loading}>
-                    <IconSparkle size={14} />
-                    {t('mobile.pairAnother')}
-                  </Button>
+                  <div className="mobile-paired-actions">
+                    <Button variant="primary" onClick={() => { dispatch({ type: 'SET_JUST_PAIRED', device: null }); void handleGeneratePairing() }} disabled={state.loading}>
+                      <IconSparkle size={14} />
+                      {t('mobile.pairAnother')}
+                    </Button>
+                    <Button onClick={() => dispatch({ type: 'SET_JUST_PAIRED', device: null })}>
+                      {t('mobile.pairedDone')}
+                    </Button>
+                  </div>
                 </div>
               ) : state.qrDataUrl ? (
                 <>

--- a/src/renderer/locales/en/settings.json
+++ b/src/renderer/locales/en/settings.json
@@ -497,6 +497,7 @@
     "pairedTitle": "Connected!",
     "pairedDesc": "{{name}} is now paired with this desktop.",
     "pairAnother": "Pair another device",
+    "pairedDone": "Done",
     "copyCode": "Copy Code",
     "copiedCode": "Copied",
     "pairingHint": "Scan this QR code with the Braid mobile app. Each code is single-use.",

--- a/src/renderer/locales/id/settings.json
+++ b/src/renderer/locales/id/settings.json
@@ -497,6 +497,7 @@
     "pairedTitle": "Terhubung!",
     "pairedDesc": "{{name}} kini terpasang dengan desktop ini.",
     "pairAnother": "Pasangkan perangkat lain",
+    "pairedDone": "Selesai",
     "copyCode": "Salin Kode",
     "copiedCode": "Disalin",
     "pairingHint": "Pindai kode QR ini dengan aplikasi Braid mobile. Setiap kode hanya dapat digunakan sekali.",

--- a/src/renderer/locales/ja/settings.json
+++ b/src/renderer/locales/ja/settings.json
@@ -497,6 +497,7 @@
     "pairedTitle": "接続しました！",
     "pairedDesc": "{{name}} がこのデスクトップとペアリングされました。",
     "pairAnother": "別のデバイスをペアリング",
+    "pairedDone": "完了",
     "copyCode": "コードをコピー",
     "copiedCode": "コピーしました",
     "pairingHint": "BraidモバイルアプリでこのQRコードをスキャンしてください。各コードは1回限り有効です。",

--- a/src/renderer/locales/zh/settings.json
+++ b/src/renderer/locales/zh/settings.json
@@ -497,6 +497,7 @@
     "pairedTitle": "已连接！",
     "pairedDesc": "{{name}} 已与此桌面配对。",
     "pairAnother": "配对其他设备",
+    "pairedDone": "完成",
     "copyCode": "复制代码",
     "copiedCode": "已复制",
     "pairingHint": "使用 Braid 移动应用扫描此二维码。每个代码仅限一次使用。",

--- a/src/renderer/styles/mobile-pairing.css
+++ b/src/renderer/styles/mobile-pairing.css
@@ -641,6 +641,136 @@
   line-height: var(--leading-relaxed);
 }
 
+/* Paired success state - the celebratory moment after a phone consumes the QR */
+
+.mobile-paired {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-12);
+  padding: var(--space-12) 0 var(--space-4);
+  text-align: center;
+  animation: mobile-paired-in 460ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.mobile-paired-burst {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 132px;
+  height: 132px;
+}
+
+.mobile-paired-ring {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  border: 1px solid color-mix(in srgb, var(--green) 44%, transparent);
+  border-radius: var(--radius-full);
+  transform: translate(-50%, -50%);
+  animation: mobile-paired-pulse 2.6s ease-out infinite;
+}
+
+.mobile-paired-ring--one {
+  width: 86px;
+  height: 86px;
+}
+
+.mobile-paired-ring--two {
+  width: 122px;
+  height: 122px;
+  animation-delay: -1.3s;
+}
+
+.mobile-paired-badge {
+  position: relative;
+  z-index: var(--z-base);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 66px;
+  height: 66px;
+  border: 1px solid color-mix(in srgb, var(--green) 55%, transparent);
+  border-radius: var(--radius-full);
+  background:
+    linear-gradient(150deg, color-mix(in srgb, var(--green) 30%, var(--bg-secondary)), color-mix(in srgb, var(--green) 14%, var(--bg-secondary)));
+  color: var(--green);
+  box-shadow:
+    0 14px 36px color-mix(in srgb, var(--green) 34%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--green) 22%, transparent);
+  animation: mobile-paired-pop 520ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.mobile-paired-title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-bold);
+}
+
+.mobile-paired-device {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  min-height: 28px;
+  gap: var(--space-6);
+  padding: var(--space-4) var(--space-10);
+  border: 1px solid color-mix(in srgb, var(--green) 30%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--green) 10%, transparent);
+  color: var(--text-primary);
+}
+
+.mobile-paired-device-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+}
+
+.mobile-paired-e2ee {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding-left: var(--space-8);
+  border-left: 1px solid color-mix(in srgb, var(--green) 28%, transparent);
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-bold);
+}
+
+.mobile-paired-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-8);
+  margin-top: var(--space-2);
+}
+
+.mobile-paired-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-6);
+}
+
+@keyframes mobile-paired-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes mobile-paired-pop {
+  0% { opacity: 0; transform: scale(0.4); }
+  60% { opacity: 1; transform: scale(1.08); }
+  100% { transform: scale(1); }
+}
+
+@keyframes mobile-paired-pulse {
+  0% { opacity: 0.7; transform: translate(-50%, -50%) scale(0.66); }
+  70% { opacity: 0; }
+  100% { opacity: 0; transform: translate(-50%, -50%) scale(1.16); }
+}
+
 .mobile-pair-disabled {
   padding: var(--space-14);
   border: 1px dashed color-mix(in srgb, var(--border) 88%, var(--accent));
@@ -1082,7 +1212,10 @@
   .mobile-cta-scan,
   .mobile-device-beam,
   .mobile-phone,
-  .mobile-phone-terminal-bars i {
+  .mobile-phone-terminal-bars i,
+  .mobile-paired,
+  .mobile-paired-badge,
+  .mobile-paired-ring {
     animation: none;
   }
 }

--- a/src/shared/mobile-protocol.ts
+++ b/src/shared/mobile-protocol.ts
@@ -37,6 +37,8 @@ export const MOBILE_CAPABILITIES = [
   'github.pr-status.v1', // github.prStatus RPC: per-worktree PR state (open/merged/closed) when gh CLI is available
   'jira.lookup.v1', // jira.isAvailable / jira.getIssueByKey RPCs: resolve a Jira ticket for worktree creation when the acli CLI is available
   'worktree.copy-files.v1', // worktrees.copyCandidates RPC + worktrees.create filesToCopy param: copy env/secret files from the main worktree into a new one
+  'terminal.bare.v1', // terminal.create with agentId 'shell': spawn a bare PTY (no agent launch command written), so a plain shell tab is possible
+  'notifications.push.v1', // notifications.registerPush / unregisterPush: desktop relays agent alerts to backgrounded devices via Expo push (content not E2EE - rides Expo/APNs/FCM)
 ] as const
 
 export type MobileCapability = (typeof MOBILE_CAPABILITIES)[number] | (string & {})


### PR DESCRIPTION
## Summary

Mobile companion improvements across terminals, notifications, and connection lifecycle.

### Terminals
- **Bare "shell" terminal tab.** New-tab picker can spawn a plain PTY with no agent, gated on the new `terminal.bare.v1` capability. `terminal.create` treats `agentId: 'shell'` as a bare shell (writes no launch command); the legacy no-agent path still defaults to Claude for older clients.

### Notifications - foreground (WS)
- **Fixed a notification leak (desktop side).** Removing a device now closes its live socket (`mobileServer.disconnectDevice`) so the subscription stops firing, instead of only deleting it from the trusted store.
- **Fixed the mirror leak (mobile side).** Removing a host from the home screen now drops the connection before forgetting it, tearing down the socket and listener. Removed dead `notifSubId` tracking.

### Notifications - background (Expo push), v1
- Relays agent alerts to backgrounded/disconnected devices via Expo push (`pushNotifier`). Connected devices keep getting alerts over the E2EE WS and are skipped by the push path, so there is **no duplicate per event**.
- Per-device token registration over the encrypted WS (`notifications.registerPush` / `unregisterPush`), gated by `notifications.push.v1`.
- Token teardown: explicit unregister on host removal (briefly waits for a connection), global unregister via `DeviceNotRegistered` when removing the **last** host, a desktop-side staleness window refreshed on every connect, and `DeviceNotRegistered` reaping. Tapping a remote push deep-links via the desktop instance id.
- **Independent "Background notifications" toggle** so users can keep encrypted in-app alerts while opting out of remote push.

### Usage
- Pull-to-refresh and the refresh button now force `rateLimits.refresh` (falling back to cached `rateLimits.get` on older desktops) so Claude/Codex usage actually updates.

## Privacy / external service
- Remote push content is **not** end-to-end encrypted (it rides Expo + APNs/FCM), unlike the in-app WS channel. The new toggle lets users opt out.
- The desktop now POSTs to `exp.host` (Expo) — a new third-party dependency that is subject to the internal **External Service Review** before enabling in a shipping build.

## Compatibility
- Everything is additive and capability-gated (`terminal.bare.v1`, `notifications.push.v1`); **no protocol version bump**. Older desktops simply don't expose the features and the mobile degrades gracefully.

## Still required for background push to actually deliver (infra, not code)
- APNs key (iOS) + FCM credentials (Android) in EAS.
- A dev/standalone build (not Expo Go).
- Until then, token registration returns null and the app stays foreground-only (no crash).

## Testing
- Desktop `yarn typecheck` clean; `yarn test src/main/services/mobileServer` 93 passing (incl. new bare-terminal cases).
- Mobile `tsc --noEmit` clean; `expo lint` clean (one pre-existing unrelated warning).

## Notes
- `mobile-app/app.json` had some pre-existing duplicated array entries (Bonjour services, iPad orientations, Android permissions) in the staged diff; committed as-is, worth a follow-up cleanup.
